### PR TITLE
Add tests for Google Calendar integration, crypto, and calendar sync

### DIFF
--- a/tests/app/routers/test_google_sync.py
+++ b/tests/app/routers/test_google_sync.py
@@ -1,0 +1,523 @@
+"""Tests for app/routers/google_sync.py — Google Calendar OAuth and sync routes."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from wodplanner.app.config import settings
+from wodplanner.app.main import app
+from wodplanner.models.auth import AuthSession
+from wodplanner.models.google import GoogleAccount
+from wodplanner.services import session as cookie_session
+from wodplanner.services.login_limiter import limiter
+
+
+def _make_google_account(
+    user_id=42,
+    calendar_id="cal123",
+    sync_enabled=True,
+):
+    return GoogleAccount(
+        user_id=user_id,
+        google_email="user@gmail.com",
+        access_token="enc_access",
+        refresh_token="enc_refresh",
+        token_expiry=None,
+        scopes="calendar",
+        calendar_id=calendar_id,
+        sync_enabled=sync_enabled,
+        created_at="2026-01-01T00:00:00",
+    )
+
+
+@pytest.fixture
+def auth_session() -> AuthSession:
+    return AuthSession(
+        token="test_token",
+        user_id=42,
+        appuser_id=4242,
+        username="user@example.com",
+        firstname="User",
+        gym_id=100,
+        gym_name="Test Gym",
+        agenda_id=5,
+    )
+
+
+@pytest.fixture
+def session_cookie(auth_session: AuthSession) -> str:
+    return cookie_session.encode(auth_session, settings.secret_key)
+
+
+@pytest.fixture
+def mock_google_db():
+    db = MagicMock()
+    db.get_account.return_value = None
+    return db
+
+
+@pytest.fixture
+def google_app_client(monkeypatch, db_path, mock_google_db):
+    from wodplanner.app.dependencies import get_google_accounts_service
+
+    monkeypatch.setenv("DB_PATH", str(db_path))
+    limiter._state.clear()
+    app.dependency_overrides[get_google_accounts_service] = lambda: mock_google_db
+
+    with TestClient(app) as client:
+        yield client
+
+    app.dependency_overrides.clear()
+    limiter._state.clear()
+
+
+class TestSettingsPage:
+    def test_redirects_when_unauthenticated(self, google_app_client):
+        r = google_app_client.get("/settings", follow_redirects=False)
+        assert r.status_code in (302, 303)
+
+    def test_renders_when_authenticated(self, google_app_client, session_cookie):
+        r = google_app_client.get("/settings", cookies={"session": session_cookie})
+        assert r.status_code == 200
+
+    def test_renders_with_connected_account(self, google_app_client, session_cookie, mock_google_db):
+        mock_google_db.get_account.return_value = _make_google_account()
+        r = google_app_client.get("/settings", cookies={"session": session_cookie})
+        assert r.status_code == 200
+
+
+class TestGoogleConnect:
+    def test_returns_503_when_google_not_configured(self, google_app_client, session_cookie, monkeypatch):
+        monkeypatch.setattr(settings, "google_client_id", None)
+        monkeypatch.setattr(settings, "google_client_secret", None)
+        r = google_app_client.get(
+            "/google/connect", cookies={"session": session_cookie}, follow_redirects=False
+        )
+        assert r.status_code == 503
+
+    def test_redirects_to_google_when_configured(self, google_app_client, session_cookie, monkeypatch):
+        monkeypatch.setattr(settings, "google_client_id", "test_client_id")
+        monkeypatch.setattr(settings, "google_client_secret", "test_client_secret")
+        r = google_app_client.get(
+            "/google/connect", cookies={"session": session_cookie}, follow_redirects=False
+        )
+        assert r.status_code == 302
+        assert "accounts.google.com" in r.headers["location"]
+
+    def test_sets_g_state_cookie(self, google_app_client, session_cookie, monkeypatch):
+        monkeypatch.setattr(settings, "google_client_id", "cid")
+        monkeypatch.setattr(settings, "google_client_secret", "csecret")
+        r = google_app_client.get(
+            "/google/connect", cookies={"session": session_cookie}, follow_redirects=False
+        )
+        assert "g_state" in r.cookies or "g_state" in r.headers.get("set-cookie", "")
+
+
+class TestGoogleCallback:
+    def test_error_param_redirects_to_settings(self, google_app_client, session_cookie):
+        r = google_app_client.get(
+            "/google/callback?error=access_denied",
+            cookies={"session": session_cookie},
+            follow_redirects=False,
+        )
+        assert r.status_code == 303
+        assert "google_denied" in r.headers["location"]
+
+    def test_missing_code_redirects(self, google_app_client, session_cookie):
+        r = google_app_client.get(
+            "/google/callback?state=abc",
+            cookies={"session": session_cookie},
+            follow_redirects=False,
+        )
+        assert r.status_code == 303
+        assert "google_invalid" in r.headers["location"]
+
+    def test_missing_state_redirects(self, google_app_client, session_cookie):
+        r = google_app_client.get(
+            "/google/callback?code=abc",
+            cookies={"session": session_cookie},
+            follow_redirects=False,
+        )
+        assert r.status_code == 303
+        assert "google_invalid" in r.headers["location"]
+
+    def test_missing_g_state_cookie_redirects(self, google_app_client, session_cookie):
+        r = google_app_client.get(
+            "/google/callback?code=abc&state=xyz",
+            cookies={"session": session_cookie},
+            follow_redirects=False,
+        )
+        assert r.status_code == 303
+        assert "google_state_missing" in r.headers["location"]
+
+    def test_state_mismatch_redirects(self, google_app_client, session_cookie):
+        from itsdangerous import URLSafeTimedSerializer
+
+        signed_wrong = URLSafeTimedSerializer(settings.secret_key).dumps("wrong_state")
+        r = google_app_client.get(
+            "/google/callback?code=abc&state=xyz",
+            cookies={"session": session_cookie, "g_state": signed_wrong},
+            follow_redirects=False,
+        )
+        assert r.status_code == 303
+        assert "google_state_mismatch" in r.headers["location"]
+
+    def test_success_stores_account_and_redirects(
+        self, google_app_client, session_cookie, mock_google_db, monkeypatch
+    ):
+        from itsdangerous import URLSafeTimedSerializer
+
+        state = "valid_state_123"
+        signed = URLSafeTimedSerializer(settings.secret_key).dumps(state)
+        monkeypatch.setattr(settings, "google_client_id", "client_id")
+        monkeypatch.setattr(settings, "google_client_secret", "client_secret")
+        monkeypatch.setattr(settings, "google_redirect_uri", "https://example.com/cb")
+
+        token_data = {
+            "access_token": "raw_access",
+            "refresh_token": "raw_refresh",
+            "expires_in": 3600,
+            "scope": "calendar",
+        }
+        mock_google_db.upsert_account.return_value = _make_google_account()
+
+        with (
+            patch("wodplanner.app.routers.google_sync.exchange_code", return_value=token_data),
+            patch("wodplanner.app.routers.google_sync.get_user_email", return_value="user@gmail.com"),
+            patch("wodplanner.app.routers.google_sync.crypto.encrypt", return_value="enc"),
+        ):
+            r = google_app_client.get(
+                f"/google/callback?code=authcode&state={state}",
+                cookies={"session": session_cookie, "g_state": signed},
+                follow_redirects=False,
+            )
+        assert r.status_code == 303
+        assert "google_connected" in r.headers["location"]
+        mock_google_db.upsert_account.assert_called_once()
+
+    def test_exchange_failure_redirects_with_error(
+        self, google_app_client, session_cookie, monkeypatch
+    ):
+        from itsdangerous import URLSafeTimedSerializer
+
+        state = "state456"
+        signed = URLSafeTimedSerializer(settings.secret_key).dumps(state)
+        monkeypatch.setattr(settings, "google_client_id", "client_id")
+        monkeypatch.setattr(settings, "google_client_secret", "client_secret")
+        monkeypatch.setattr(settings, "google_redirect_uri", "https://example.com/cb")
+
+        with patch("wodplanner.app.routers.google_sync.exchange_code", side_effect=Exception("token exchange failed")):
+            r = google_app_client.get(
+                f"/google/callback?code=bad_code&state={state}",
+                cookies={"session": session_cookie, "g_state": signed},
+                follow_redirects=False,
+            )
+        assert r.status_code == 303
+        assert "google_exchange_failed" in r.headers["location"]
+
+
+class TestGoogleDisconnect:
+    def test_redirects_when_no_account(self, google_app_client, session_cookie, mock_google_db):
+        mock_google_db.get_account.return_value = None
+        r = google_app_client.post(
+            "/google/disconnect", cookies={"session": session_cookie}, follow_redirects=False
+        )
+        assert r.status_code == 303
+        assert "google_disconnected" in r.headers["location"]
+
+    def test_revokes_token_and_deletes_account(
+        self, google_app_client, session_cookie, mock_google_db
+    ):
+        mock_google_db.get_account.return_value = _make_google_account()
+        with (
+            patch("wodplanner.app.routers.google_sync.crypto.decrypt", return_value="raw_token"),
+            patch("wodplanner.app.routers.google_sync.revoke_token") as mock_revoke,
+        ):
+            r = google_app_client.post(
+                "/google/disconnect", cookies={"session": session_cookie}, follow_redirects=False
+            )
+        assert r.status_code == 303
+        mock_revoke.assert_called_once_with("raw_token")
+        mock_google_db.delete_account.assert_called_once_with(42)
+
+    def test_disconnect_continues_even_if_revoke_raises(
+        self, google_app_client, session_cookie, mock_google_db
+    ):
+        mock_google_db.get_account.return_value = _make_google_account()
+        with (
+            patch("wodplanner.app.routers.google_sync.crypto.decrypt", return_value="raw_token"),
+            patch("wodplanner.app.routers.google_sync.revoke_token", side_effect=Exception("revoke failed")),
+        ):
+            r = google_app_client.post(
+                "/google/disconnect", cookies={"session": session_cookie}, follow_redirects=False
+            )
+        assert r.status_code == 303
+        mock_google_db.delete_account.assert_called_once()
+
+
+class TestGoogleCalendars:
+    def test_returns_400_when_no_account(self, google_app_client, session_cookie, mock_google_db):
+        mock_google_db.get_account.return_value = None
+        r = google_app_client.get("/google/calendars", cookies={"session": session_cookie})
+        assert r.status_code == 400
+
+    def test_returns_calendar_list_html(self, google_app_client, session_cookie, mock_google_db):
+        mock_google_db.get_account.return_value = _make_google_account()
+        calendars = [{"id": "cal1", "summary": "My Calendar"}]
+        with (
+            patch("wodplanner.app.routers.google_sync.calendar_sync.get_valid_token", return_value="token"),
+            patch("wodplanner.app.routers.google_sync.gcal.list_calendars", return_value=calendars),
+        ):
+            r = google_app_client.get("/google/calendars", cookies={"session": session_cookie})
+        assert r.status_code == 200
+
+    def test_returns_empty_calendars_on_error(self, google_app_client, session_cookie, mock_google_db):
+        mock_google_db.get_account.return_value = _make_google_account()
+        with (
+            patch("wodplanner.app.routers.google_sync.calendar_sync.get_valid_token", return_value="token"),
+            patch("wodplanner.app.routers.google_sync.gcal.list_calendars", side_effect=Exception("network")),
+        ):
+            r = google_app_client.get("/google/calendars", cookies={"session": session_cookie})
+        assert r.status_code == 200
+
+
+class TestGoogleCalendarSelect:
+    def _sync_result(self):
+        r = MagicMock()
+        r.ok = True
+        r.inserted = 1
+        r.updated = 0
+        r.deleted = 0
+        r.errors = []
+        return r
+
+    def test_select_existing_calendar(self, google_app_client, session_cookie, mock_google_db, monkeypatch):
+        account = _make_google_account()
+        mock_google_db.get_account.return_value = account
+        mock_wodapp_client = MagicMock()
+        mock_wodapp_client.get_upcoming_reservations.return_value = ([], {})
+        monkeypatch.setattr(
+            "wodplanner.app.dependencies.WodAppClient.from_session",
+            classmethod(lambda cls, s, cache=None: mock_wodapp_client),
+        )
+
+        with (
+            patch("wodplanner.app.routers.google_sync.calendar_sync.get_valid_token", return_value="token"),
+            patch("wodplanner.app.routers.google_sync.calendar_sync.sync_user", return_value=self._sync_result()),
+        ):
+            r = google_app_client.post(
+                "/google/calendar/select",
+                data={"calendar_choice": "cal_id|My Calendar"},
+                cookies={"session": session_cookie},
+            )
+        assert r.status_code == 200
+        mock_google_db.update_calendar.assert_called_once_with(42, "cal_id", "My Calendar")
+
+    def test_select_calendar_without_pipe_uses_id_as_summary(
+        self, google_app_client, session_cookie, mock_google_db, monkeypatch
+    ):
+        account = _make_google_account()
+        mock_google_db.get_account.return_value = account
+        mock_wodapp_client = MagicMock()
+        mock_wodapp_client.get_upcoming_reservations.return_value = ([], {})
+        monkeypatch.setattr(
+            "wodplanner.app.dependencies.WodAppClient.from_session",
+            classmethod(lambda cls, s, cache=None: mock_wodapp_client),
+        )
+
+        with (
+            patch("wodplanner.app.routers.google_sync.calendar_sync.get_valid_token", return_value="token"),
+            patch("wodplanner.app.routers.google_sync.calendar_sync.sync_user", return_value=self._sync_result()),
+        ):
+            r = google_app_client.post(
+                "/google/calendar/select",
+                data={"calendar_choice": "only_id"},
+                cookies={"session": session_cookie},
+            )
+        assert r.status_code == 200
+        mock_google_db.update_calendar.assert_called_once_with(42, "only_id", "only_id")
+
+    def test_create_new_calendar(
+        self, google_app_client, session_cookie, mock_google_db, monkeypatch
+    ):
+        account = _make_google_account()
+        mock_google_db.get_account.return_value = account
+        mock_wodapp_client = MagicMock()
+        mock_wodapp_client.get_upcoming_reservations.return_value = ([], {})
+        monkeypatch.setattr(
+            "wodplanner.app.dependencies.WodAppClient.from_session",
+            classmethod(lambda cls, s, cache=None: mock_wodapp_client),
+        )
+
+        new_cal = {"id": "new_cal_id", "summary": "WodPlanner"}
+        with (
+            patch("wodplanner.app.routers.google_sync.calendar_sync.get_valid_token", return_value="token"),
+            patch("wodplanner.app.routers.google_sync.gcal.create_calendar", return_value=new_cal),
+            patch("wodplanner.app.routers.google_sync.calendar_sync.sync_user", return_value=self._sync_result()),
+        ):
+            r = google_app_client.post(
+                "/google/calendar/select",
+                data={"calendar_choice": "__create__"},
+                cookies={"session": session_cookie},
+            )
+        assert r.status_code == 200
+        mock_google_db.update_calendar.assert_called_once_with(42, "new_cal_id", "WodPlanner")
+
+    def test_create_calendar_failure_returns_error_partial(
+        self, google_app_client, session_cookie, mock_google_db, monkeypatch
+    ):
+        account = _make_google_account()
+        mock_google_db.get_account.return_value = account
+        mock_wodapp_client = MagicMock()
+        monkeypatch.setattr(
+            "wodplanner.app.dependencies.WodAppClient.from_session",
+            classmethod(lambda cls, s, cache=None: mock_wodapp_client),
+        )
+
+        with (
+            patch("wodplanner.app.routers.google_sync.calendar_sync.get_valid_token", return_value="token"),
+            patch("wodplanner.app.routers.google_sync.gcal.create_calendar", side_effect=Exception("API error")),
+        ):
+            r = google_app_client.post(
+                "/google/calendar/select",
+                data={"calendar_choice": "__create__"},
+                cookies={"session": session_cookie},
+            )
+        assert r.status_code == 200
+
+    def test_returns_400_when_no_account(self, google_app_client, session_cookie, mock_google_db, monkeypatch):
+        mock_google_db.get_account.return_value = None
+        mock_wodapp_client = MagicMock()
+        monkeypatch.setattr(
+            "wodplanner.app.dependencies.WodAppClient.from_session",
+            classmethod(lambda cls, s, cache=None: mock_wodapp_client),
+        )
+        r = google_app_client.post(
+            "/google/calendar/select",
+            data={"calendar_choice": "cal_id"},
+            cookies={"session": session_cookie},
+        )
+        assert r.status_code == 400
+
+    def test_token_refresh_failure_returns_error_partial(
+        self, google_app_client, session_cookie, mock_google_db, monkeypatch
+    ):
+        account = _make_google_account()
+        mock_google_db.get_account.return_value = account
+        mock_wodapp_client = MagicMock()
+        monkeypatch.setattr(
+            "wodplanner.app.dependencies.WodAppClient.from_session",
+            classmethod(lambda cls, s, cache=None: mock_wodapp_client),
+        )
+
+        with patch(
+            "wodplanner.app.routers.google_sync.calendar_sync.get_valid_token",
+            side_effect=Exception("refresh failed"),
+        ):
+            r = google_app_client.post(
+                "/google/calendar/select",
+                data={"calendar_choice": "cal_id"},
+                cookies={"session": session_cookie},
+            )
+        assert r.status_code == 200
+
+
+class TestGoogleSyncNow:
+    def test_returns_400_when_no_account(self, google_app_client, session_cookie, mock_google_db, monkeypatch):
+        mock_google_db.get_account.return_value = None
+        mock_wodapp_client = MagicMock()
+        monkeypatch.setattr(
+            "wodplanner.app.dependencies.WodAppClient.from_session",
+            classmethod(lambda cls, s, cache=None: mock_wodapp_client),
+        )
+        r = google_app_client.post("/google/sync", cookies={"session": session_cookie})
+        assert r.status_code == 400
+
+    def test_returns_400_when_no_calendar_selected(
+        self, google_app_client, session_cookie, mock_google_db, monkeypatch
+    ):
+        mock_google_db.get_account.return_value = _make_google_account(calendar_id=None)
+        mock_wodapp_client = MagicMock()
+        monkeypatch.setattr(
+            "wodplanner.app.dependencies.WodAppClient.from_session",
+            classmethod(lambda cls, s, cache=None: mock_wodapp_client),
+        )
+        r = google_app_client.post("/google/sync", cookies={"session": session_cookie})
+        assert r.status_code == 400
+
+    def test_triggers_sync_and_returns_html(
+        self, google_app_client, session_cookie, mock_google_db, monkeypatch
+    ):
+        account = _make_google_account()
+        mock_google_db.get_account.return_value = account
+        sync_result = MagicMock()
+        sync_result.ok = True
+        sync_result.inserted = 1
+        sync_result.updated = 0
+        sync_result.deleted = 0
+        sync_result.errors = []
+        mock_wodapp_client = MagicMock()
+        mock_wodapp_client.get_upcoming_reservations.return_value = ([], {})
+        monkeypatch.setattr(
+            "wodplanner.app.dependencies.WodAppClient.from_session",
+            classmethod(lambda cls, s, cache=None: mock_wodapp_client),
+        )
+
+        with patch("wodplanner.app.routers.google_sync.calendar_sync.sync_user", return_value=sync_result):
+            r = google_app_client.post("/google/sync", cookies={"session": session_cookie})
+        assert r.status_code == 200
+
+
+class TestGoogleSyncSection:
+    def test_returns_sync_section_html(self, google_app_client, session_cookie, mock_google_db):
+        mock_google_db.get_account.return_value = None
+        r = google_app_client.get("/google/sync-section", cookies={"session": session_cookie})
+        assert r.status_code == 200
+
+    def test_redirects_when_unauthenticated(self, google_app_client):
+        r = google_app_client.get("/google/sync-section", follow_redirects=False)
+        assert r.status_code in (302, 303)
+
+
+class TestHelperFunctions:
+    def test_token_expiry_iso_with_expires_in(self):
+        from wodplanner.app.routers.google_sync import _token_expiry_iso
+
+        result = _token_expiry_iso({"expires_in": 3600})
+        assert result is not None
+        assert "T" in result  # ISO 8601
+
+    def test_token_expiry_iso_without_expires_in(self):
+        from wodplanner.app.routers.google_sync import _token_expiry_iso
+
+        result = _token_expiry_iso({"access_token": "tok"})
+        assert result is None
+
+    def test_verify_state_valid(self):
+        from itsdangerous import URLSafeTimedSerializer
+
+        from wodplanner.app.routers.google_sync import _verify_state
+
+        signed = URLSafeTimedSerializer(settings.secret_key).dumps("mystate")
+        _verify_state(signed, "mystate")  # Must not raise
+
+    def test_verify_state_invalid_signature_raises(self):
+        from fastapi import HTTPException
+
+        from wodplanner.app.routers.google_sync import _verify_state
+
+        with pytest.raises(HTTPException) as exc_info:
+            _verify_state("not_a_valid_signature", "state")
+        assert exc_info.value.status_code == 400
+
+    def test_verify_state_mismatch_raises(self):
+        from fastapi import HTTPException
+        from itsdangerous import URLSafeTimedSerializer
+
+        from wodplanner.app.routers.google_sync import _verify_state
+
+        signed = URLSafeTimedSerializer(settings.secret_key).dumps("state_A")
+        with pytest.raises(HTTPException) as exc_info:
+            _verify_state(signed, "state_B")
+        assert exc_info.value.status_code == 400

--- a/tests/services/test_calendar_sync.py
+++ b/tests/services/test_calendar_sync.py
@@ -3,8 +3,6 @@
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from wodplanner.models.google import GoogleAccount, SyncedEvent
 from wodplanner.services import calendar_sync
 from wodplanner.services.calendar_sync import SyncResult

--- a/tests/services/test_calendar_sync.py
+++ b/tests/services/test_calendar_sync.py
@@ -1,0 +1,410 @@
+"""Tests for services/calendar_sync.py — full-diff sync engine."""
+
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from wodplanner.models.google import GoogleAccount, SyncedEvent
+from wodplanner.services import calendar_sync
+from wodplanner.services.calendar_sync import SyncResult
+
+
+def _make_account(
+    user_id=1,
+    calendar_id="cal_id",
+    token_expiry=None,
+    access_token="enc_access",
+    refresh_token="enc_refresh",
+):
+    return GoogleAccount(
+        user_id=user_id,
+        google_email="user@gmail.com",
+        access_token=access_token,
+        refresh_token=refresh_token,
+        token_expiry=token_expiry,
+        scopes="calendar",
+        calendar_id=calendar_id,
+        sync_enabled=True,
+        created_at=datetime.now().isoformat(),
+    )
+
+
+def _make_db(synced_events=None):
+    db = MagicMock()
+    db.get_synced_events.return_value = synced_events or []
+    return db
+
+
+def _make_client(reservations=None):
+    client = MagicMock()
+    client.get_upcoming_reservations.return_value = (reservations or [], {})
+    return client
+
+
+def _make_reservation(appt_id=1, name="CrossFit", date_start=None, date_end=None):
+    return {
+        "id_appointment": appt_id,
+        "name": name,
+        "date_start": date_start or datetime(2026, 5, 1, 10, 0),
+        "date_end": date_end,
+    }
+
+
+def _make_synced_event(appt_id=1, google_event_id="gev1", date_start=None, name="CrossFit"):
+    return SyncedEvent(
+        user_id=1,
+        id_appointment=appt_id,
+        google_event_id=google_event_id,
+        calendar_id="cal_id",
+        date_start=(date_start or datetime(2026, 5, 1, 10, 0)).isoformat(),
+        date_end=(date_start or datetime(2026, 5, 1, 11, 0)).isoformat(),
+        name=name,
+        etag=None,
+        synced_at=datetime.now().isoformat(),
+    )
+
+
+ENC_KEY = b"A" * 44  # Placeholder — crypto is mocked
+
+
+class TestSyncResult:
+    def test_ok_true_when_no_errors(self):
+        assert SyncResult().ok is True
+
+    def test_ok_false_when_errors_present(self):
+        assert SyncResult(errors=["something failed"]).ok is False
+
+    def test_default_counts_are_zero(self):
+        r = SyncResult()
+        assert r.inserted == 0
+        assert r.updated == 0
+        assert r.deleted == 0
+
+
+class TestGetValidToken:
+    def test_returns_decrypted_token_when_no_expiry(self):
+        account = _make_account(token_expiry=None)
+        with patch("wodplanner.services.calendar_sync.crypto.decrypt", return_value="raw_token"):
+            token = calendar_sync.get_valid_token(account, _make_db(), ENC_KEY)
+        assert token == "raw_token"
+
+    def test_returns_decrypted_token_when_expiry_is_far_future(self):
+        far_future = (datetime.now() + timedelta(hours=2)).isoformat()
+        account = _make_account(token_expiry=far_future)
+        with patch("wodplanner.services.calendar_sync.crypto.decrypt", return_value="raw_token"):
+            token = calendar_sync.get_valid_token(account, _make_db(), ENC_KEY)
+        assert token == "raw_token"
+
+    def test_refreshes_when_token_near_expiry(self):
+        near_expiry = (datetime.now() + timedelta(minutes=2)).isoformat()
+        account = _make_account(token_expiry=near_expiry)
+        db = _make_db()
+        with (
+            patch("wodplanner.services.calendar_sync.crypto.decrypt", side_effect=["enc_access", "enc_refresh"]),
+            patch("wodplanner.services.calendar_sync.refresh_access_token", return_value=("new_tok", "new_expiry")),
+            patch("wodplanner.services.calendar_sync.crypto.encrypt", return_value="enc_new_tok"),
+        ):
+            token = calendar_sync.get_valid_token(account, db, ENC_KEY)
+        assert token == "new_tok"
+        db.update_tokens.assert_called_once()
+
+    def test_no_refresh_when_not_near_expiry(self):
+        far_future = (datetime.now() + timedelta(hours=2)).isoformat()
+        account = _make_account(token_expiry=far_future)
+        db = _make_db()
+        with patch("wodplanner.services.calendar_sync.crypto.decrypt", return_value="raw_token"):
+            calendar_sync.get_valid_token(account, db, ENC_KEY)
+        db.update_tokens.assert_not_called()
+
+
+class TestBuildEvent:
+    def test_builds_event_with_explicit_date_end(self):
+        start = datetime(2026, 5, 1, 10, 0)
+        end = datetime(2026, 5, 1, 11, 0)
+        reservation = _make_reservation(appt_id=42, name="Gymnastics", date_start=start, date_end=end)
+        event = calendar_sync._build_event(reservation, "Box Gym", "Alice")
+        assert event["summary"] == "Alice - Gymnastics"
+        assert event["location"] == "Box Gym"
+        assert event["end"]["dateTime"] == end.isoformat()
+        assert event["extendedProperties"]["private"]["wodplanner_appointment_id"] == "42"
+
+    def test_uses_default_1h_duration_when_no_date_end(self):
+        start = datetime(2026, 5, 1, 10, 0)
+        reservation = _make_reservation(appt_id=1, date_start=start, date_end=None)
+        event = calendar_sync._build_event(reservation, "Gym", "Bob")
+        expected_end = start + timedelta(hours=1)
+        assert event["end"]["dateTime"] == expected_end.isoformat()
+
+    def test_timezone_is_amsterdam(self):
+        reservation = _make_reservation()
+        event = calendar_sync._build_event(reservation, "Gym", "Alice")
+        assert event["start"]["timeZone"] == "Europe/Amsterdam"
+        assert event["end"]["timeZone"] == "Europe/Amsterdam"
+
+
+class TestRebuildFromGoogle:
+    def test_returns_empty_when_no_calendar_id(self):
+        account = _make_account(calendar_id=None)
+        result = calendar_sync._rebuild_from_google("token", account, _make_db())
+        assert result == {}
+
+    def test_rebuilds_synced_events_from_google(self):
+        account = _make_account()
+        db = _make_db()
+        events = [
+            {
+                "id": "gev1",
+                "start": {"dateTime": "2026-05-01T10:00:00"},
+                "end": {"dateTime": "2026-05-01T11:00:00"},
+                "summary": "Alice - CrossFit",
+                "etag": "etag1",
+                "extendedProperties": {"private": {"wodplanner_appointment_id": "42"}},
+            }
+        ]
+        with patch("wodplanner.services.calendar_sync.gcal.list_events_in_range", return_value=events):
+            result = calendar_sync._rebuild_from_google("token", account, db)
+        assert 42 in result
+        assert result[42].google_event_id == "gev1"
+        db.upsert_synced_event.assert_called_once()
+
+    def test_skips_events_without_appointment_property(self):
+        account = _make_account()
+        events = [{"id": "ev1", "start": {}, "end": {}, "extendedProperties": {"private": {}}}]
+        with patch("wodplanner.services.calendar_sync.gcal.list_events_in_range", return_value=events):
+            result = calendar_sync._rebuild_from_google("token", account, _make_db())
+        assert result == {}
+
+    def test_skips_events_with_non_numeric_appointment_id(self):
+        account = _make_account()
+        events = [
+            {
+                "id": "ev1",
+                "extendedProperties": {"private": {"wodplanner_appointment_id": "not_a_number"}},
+            }
+        ]
+        with patch("wodplanner.services.calendar_sync.gcal.list_events_in_range", return_value=events):
+            result = calendar_sync._rebuild_from_google("token", account, _make_db())
+        assert result == {}
+
+    def test_returns_empty_on_list_events_exception(self):
+        account = _make_account()
+        with patch(
+            "wodplanner.services.calendar_sync.gcal.list_events_in_range",
+            side_effect=Exception("network error"),
+        ):
+            result = calendar_sync._rebuild_from_google("token", account, _make_db())
+        assert result == {}
+
+
+class TestSyncUser:
+    def test_error_when_no_calendar_id(self):
+        account = _make_account(calendar_id=None)
+        result = calendar_sync.sync_user(account, _make_db(), _make_client(), ENC_KEY, "Alice", "Box")
+        assert not result.ok
+        assert "no calendar selected" in result.errors[0]
+
+    def test_error_when_token_refresh_fails(self):
+        account = _make_account()
+        db = _make_db()
+        with patch("wodplanner.services.calendar_sync.get_valid_token", side_effect=Exception("token error")):
+            result = calendar_sync.sync_user(account, db, _make_client(), ENC_KEY, "Alice", "Box")
+        assert not result.ok
+        assert "token refresh failed" in result.errors[0]
+        db.disable_sync.assert_called_once_with(1, "token refresh failed: token error")
+
+    def test_error_when_wodapp_api_fails(self):
+        account = _make_account()
+        db = _make_db()
+        client = MagicMock()
+        client.get_upcoming_reservations.side_effect = Exception("API is down")
+        with patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"):
+            result = calendar_sync.sync_user(account, db, client, ENC_KEY, "Alice", "Box")
+        assert not result.ok
+        assert "WodApp fetch failed" in result.errors[0]
+
+    def test_inserts_new_reservation(self):
+        account = _make_account()
+        db = _make_db()
+        reservation = _make_reservation(appt_id=1, date_start=datetime(2026, 5, 1, 10, 0))
+        client = _make_client([reservation])
+
+        with (
+            patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"),
+            patch("wodplanner.services.calendar_sync.gcal.insert_event", return_value={"id": "gev1"}),
+        ):
+            result = calendar_sync.sync_user(account, db, client, ENC_KEY, "Alice", "Box")
+
+        assert result.inserted == 1
+        assert result.updated == 0
+        assert result.deleted == 0
+        assert result.ok
+
+    def test_inserts_reservation_with_date_end(self):
+        account = _make_account()
+        db = _make_db()
+        start = datetime(2026, 5, 1, 10, 0)
+        end = datetime(2026, 5, 1, 11, 30)
+        reservation = _make_reservation(appt_id=1, date_start=start, date_end=end)
+        client = _make_client([reservation])
+
+        with (
+            patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"),
+            patch("wodplanner.services.calendar_sync.gcal.insert_event", return_value={"id": "gev1"}),
+        ):
+            result = calendar_sync.sync_user(account, db, client, ENC_KEY, "Alice", "Box")
+
+        assert result.inserted == 1
+
+    def test_updates_event_when_name_changed(self):
+        account = _make_account()
+        existing_ev = _make_synced_event(appt_id=1, name="CrossFit")
+        db = _make_db(synced_events=[existing_ev])
+        # Same appt_id but different name
+        reservation = _make_reservation(appt_id=1, name="Gymnastics", date_start=datetime(2026, 5, 1, 10, 0))
+        client = _make_client([reservation])
+
+        with (
+            patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"),
+            patch("wodplanner.services.calendar_sync.gcal.update_event", return_value={}),
+        ):
+            result = calendar_sync.sync_user(account, db, client, ENC_KEY, "Alice", "Box")
+
+        assert result.updated == 1
+        assert result.inserted == 0
+
+    def test_updates_event_when_start_time_changed(self):
+        account = _make_account()
+        old_start = datetime(2026, 5, 1, 10, 0)
+        new_start = datetime(2026, 5, 1, 11, 0)
+        existing_ev = _make_synced_event(appt_id=1, date_start=old_start, name="CrossFit")
+        db = _make_db(synced_events=[existing_ev])
+        reservation = _make_reservation(appt_id=1, name="CrossFit", date_start=new_start)
+        client = _make_client([reservation])
+
+        with (
+            patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"),
+            patch("wodplanner.services.calendar_sync.gcal.update_event", return_value={}),
+        ):
+            result = calendar_sync.sync_user(account, db, client, ENC_KEY, "Alice", "Box")
+
+        assert result.updated == 1
+
+    def test_no_update_when_event_unchanged(self):
+        account = _make_account()
+        start = datetime(2026, 5, 1, 10, 0)
+        existing_ev = _make_synced_event(appt_id=1, date_start=start, name="CrossFit")
+        db = _make_db(synced_events=[existing_ev])
+        reservation = _make_reservation(appt_id=1, name="CrossFit", date_start=start)
+        client = _make_client([reservation])
+
+        with patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"):
+            result = calendar_sync.sync_user(account, db, client, ENC_KEY, "Alice", "Box")
+
+        assert result.updated == 0
+        assert result.inserted == 0
+
+    def test_deletes_cancelled_future_event(self):
+        account = _make_account()
+        future_start = datetime.now() + timedelta(days=3)
+        existing_ev = _make_synced_event(appt_id=99, date_start=future_start, name="CrossFit")
+        db = _make_db(synced_events=[existing_ev])
+        # No matching reservation — appt 99 was cancelled
+        client = _make_client([])
+
+        with (
+            patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"),
+            patch("wodplanner.services.calendar_sync.gcal.delete_event"),
+        ):
+            result = calendar_sync.sync_user(account, db, client, ENC_KEY, "Alice", "Box")
+
+        assert result.deleted == 1
+
+    def test_keeps_past_event_even_when_not_in_reservations(self):
+        account = _make_account()
+        past_start = datetime.now() - timedelta(days=1)
+        existing_ev = _make_synced_event(appt_id=99, date_start=past_start, name="CrossFit")
+        db = _make_db(synced_events=[existing_ev])
+        client = _make_client([])  # Empty — class already happened
+
+        with patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"):
+            result = calendar_sync.sync_user(account, db, client, ENC_KEY, "Alice", "Box")
+
+        assert result.deleted == 0
+
+    def test_triggers_recovery_when_db_empty_but_reservations_exist(self):
+        account = _make_account()
+        db = _make_db(synced_events=[])
+        reservation = _make_reservation(appt_id=1, date_start=datetime(2026, 5, 1, 10, 0))
+        client = _make_client([reservation])
+
+        with (
+            patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"),
+            patch("wodplanner.services.calendar_sync._rebuild_from_google", return_value={}) as mock_rebuild,
+            patch("wodplanner.services.calendar_sync.gcal.insert_event", return_value={"id": "gev1"}),
+        ):
+            calendar_sync.sync_user(account, db, client, ENC_KEY, "Alice", "Box")
+
+        mock_rebuild.assert_called_once()
+
+    def test_no_recovery_when_db_and_reservations_both_empty(self):
+        account = _make_account()
+        db = _make_db(synced_events=[])
+        client = _make_client([])
+
+        with (
+            patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"),
+            patch("wodplanner.services.calendar_sync._rebuild_from_google") as mock_rebuild,
+        ):
+            calendar_sync.sync_user(account, db, client, ENC_KEY, "Alice", "Box")
+
+        mock_rebuild.assert_not_called()
+
+    def test_insert_error_logged_in_result(self):
+        account = _make_account()
+        db = _make_db()
+        reservation = _make_reservation(appt_id=1, date_start=datetime(2026, 5, 1, 10, 0))
+        client = _make_client([reservation])
+
+        with (
+            patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"),
+            patch("wodplanner.services.calendar_sync.gcal.insert_event", side_effect=Exception("quota exceeded")),
+        ):
+            result = calendar_sync.sync_user(account, db, client, ENC_KEY, "Alice", "Box")
+
+        assert not result.ok
+        assert "insert appt 1" in result.errors[0]
+
+    def test_sync_status_written_at_end(self):
+        account = _make_account()
+        db = _make_db()
+        client = _make_client([])
+
+        with patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"):
+            calendar_sync.sync_user(account, db, client, ENC_KEY, "Alice", "Box")
+
+        db.update_sync_status.assert_called_once()
+        call_args = db.update_sync_status.call_args[0]
+        assert call_args[0] == 1  # user_id
+        assert call_args[1] == "ok"
+
+    def test_delete_skips_event_with_invalid_date(self):
+        account = _make_account()
+        ev = SyncedEvent(
+            user_id=1,
+            id_appointment=99,
+            google_event_id="gev99",
+            calendar_id="cal_id",
+            date_start="not-a-date",
+            date_end="not-a-date",
+            name="CrossFit",
+            etag=None,
+            synced_at=datetime.now().isoformat(),
+        )
+        db = _make_db(synced_events=[ev])
+        client = _make_client([])
+
+        with patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"):
+            result = calendar_sync.sync_user(account, db, client, ENC_KEY, "Alice", "Box")
+
+        assert result.deleted == 0

--- a/tests/services/test_crypto.py
+++ b/tests/services/test_crypto.py
@@ -1,0 +1,69 @@
+"""Tests for services/crypto.py — Fernet encryption helpers."""
+
+import base64
+
+import pytest
+
+from wodplanner.services.crypto import decrypt, derive_fernet_key, encrypt, get_enc_key
+
+
+class TestDeriveKey:
+    def test_returns_valid_fernet_key(self):
+        key = derive_fernet_key("mysecret")
+        # Fernet keys are 32 bytes encoded as base64url — 44 chars
+        assert len(key) == 44
+        raw = base64.urlsafe_b64decode(key)
+        assert len(raw) == 32
+
+    def test_deterministic(self):
+        assert derive_fernet_key("abc") == derive_fernet_key("abc")
+
+    def test_different_secrets_give_different_keys(self):
+        assert derive_fernet_key("secret1") != derive_fernet_key("secret2")
+
+
+class TestGetEncKey:
+    def test_derives_from_secret_when_no_explicit_key(self):
+        key = get_enc_key(None, "mysecret")
+        assert key == derive_fernet_key("mysecret")
+
+    def test_uses_explicit_key_when_provided(self):
+        raw = b"a" * 32
+        explicit = base64.urlsafe_b64encode(raw).decode()
+        key = get_enc_key(explicit, "ignored_secret")
+        assert len(key) == 44
+
+    def test_explicit_key_shorter_than_32_bytes_is_padded(self):
+        raw = b"short"
+        explicit = base64.urlsafe_b64encode(raw).decode()
+        key = get_enc_key(explicit, "ignored_secret")
+        assert len(key) == 44
+
+
+class TestEncryptDecrypt:
+    def test_round_trip(self):
+        key = derive_fernet_key("testkey")
+        plaintext = "hello world"
+        ciphertext = encrypt(plaintext, key)
+        assert ciphertext != plaintext
+        assert decrypt(ciphertext, key) == plaintext
+
+    def test_different_plaintext_gives_different_ciphertext(self):
+        key = derive_fernet_key("testkey")
+        assert encrypt("foo", key) != encrypt("bar", key)
+
+    def test_encrypt_produces_string(self):
+        key = derive_fernet_key("testkey")
+        result = encrypt("data", key)
+        assert isinstance(result, str)
+
+    def test_decrypt_with_wrong_key_raises(self):
+        key1 = derive_fernet_key("key1")
+        key2 = derive_fernet_key("key2")
+        ciphertext = encrypt("secret", key1)
+        with pytest.raises(Exception):
+            decrypt(ciphertext, key2)
+
+    def test_encrypt_empty_string(self):
+        key = derive_fernet_key("testkey")
+        assert decrypt(encrypt("", key), key) == ""

--- a/tests/services/test_google_accounts.py
+++ b/tests/services/test_google_accounts.py
@@ -1,0 +1,229 @@
+"""Tests for services/google_accounts.py — DB service for Google Calendar sync state."""
+
+import pytest
+
+from wodplanner.services.google_accounts import GoogleAccountsService
+
+
+@pytest.fixture
+def svc(db_path):
+    return GoogleAccountsService(db_path)
+
+
+def _insert_account(svc, user_id=1):
+    return svc.upsert_account(
+        user_id=user_id,
+        google_email="user@gmail.com",
+        access_token="enc_access",
+        refresh_token="enc_refresh",
+        token_expiry=None,
+        scopes="calendar",
+    )
+
+
+class TestGetAccount:
+    def test_returns_none_when_not_found(self, svc):
+        assert svc.get_account(999) is None
+
+    def test_returns_account_after_upsert(self, svc):
+        _insert_account(svc)
+        account = svc.get_account(1)
+        assert account is not None
+        assert account.google_email == "user@gmail.com"
+        assert account.user_id == 1
+
+
+class TestUpsertAccount:
+    def test_inserts_new_account(self, svc):
+        account = _insert_account(svc)
+        assert account.user_id == 1
+        assert account.sync_enabled is False
+
+    def test_updates_existing_account(self, svc):
+        _insert_account(svc)
+        svc.upsert_account(1, "new@gmail.com", "enc2", "enc_ref2", None, "calendar")
+        account = svc.get_account(1)
+        assert account.google_email == "new@gmail.com"
+
+    def test_multiple_users(self, svc):
+        _insert_account(svc, user_id=1)
+        _insert_account(svc, user_id=2)
+        assert svc.get_account(1) is not None
+        assert svc.get_account(2) is not None
+
+
+class TestUpdateCalendar:
+    def test_sets_calendar_id_and_enables_sync(self, svc):
+        _insert_account(svc)
+        result = svc.update_calendar(1, "cal_id_123", "My Calendar")
+        assert result is True
+        account = svc.get_account(1)
+        assert account.calendar_id == "cal_id_123"
+        assert account.calendar_summary == "My Calendar"
+        assert account.sync_enabled is True
+
+    def test_returns_false_for_unknown_user(self, svc):
+        result = svc.update_calendar(999, "cal_id", "name")
+        assert result is False
+
+
+class TestUpdateTokens:
+    def test_updates_access_token_and_expiry(self, svc):
+        _insert_account(svc)
+        svc.update_tokens(1, "new_enc_token", "2026-12-31T00:00:00")
+        account = svc.get_account(1)
+        assert account.access_token == "new_enc_token"
+        assert account.token_expiry == "2026-12-31T00:00:00"
+
+    def test_clears_expiry_when_none(self, svc):
+        _insert_account(svc)
+        svc.update_tokens(1, "tok", None)
+        account = svc.get_account(1)
+        assert account.token_expiry is None
+
+
+class TestUpdateSyncStatus:
+    def test_sets_status_and_timestamp(self, svc):
+        _insert_account(svc)
+        svc.update_sync_status(1, "ok")
+        account = svc.get_account(1)
+        assert account.last_sync_status == "ok"
+        assert account.last_sync_at is not None
+
+    def test_updates_status_multiple_times(self, svc):
+        _insert_account(svc)
+        svc.update_sync_status(1, "ok")
+        svc.update_sync_status(1, "error: something failed")
+        account = svc.get_account(1)
+        assert account.last_sync_status == "error: something failed"
+
+
+class TestDisableSync:
+    def test_disables_sync_and_sets_reason(self, svc):
+        _insert_account(svc)
+        svc.update_calendar(1, "cal_id", "cal")
+        assert svc.get_account(1).sync_enabled is True
+        svc.disable_sync(1, "token expired")
+        account = svc.get_account(1)
+        assert account.sync_enabled is False
+        assert account.last_sync_status == "token expired"
+
+
+class TestDeleteAccount:
+    def test_removes_account(self, svc):
+        _insert_account(svc)
+        svc.delete_account(1)
+        assert svc.get_account(1) is None
+
+    def test_also_removes_synced_events(self, svc):
+        _insert_account(svc)
+        svc.upsert_synced_event(
+            1, 101, "gev1", "cal_id",
+            "2026-04-27T10:00:00", "2026-04-27T11:00:00", "CrossFit"
+        )
+        svc.delete_account(1)
+        assert svc.get_synced_events(1) == []
+
+    def test_no_error_when_account_does_not_exist(self, svc):
+        svc.delete_account(999)  # Must not raise
+
+
+class TestGetAllSyncEnabledUserIds:
+    def test_returns_users_with_sync_calendar_and_session(self, svc):
+        _insert_account(svc, user_id=1)
+        svc.update_calendar(1, "cal_id", "cal")
+        svc.store_wodapp_session_enc(1, "enc_session")
+        ids = svc.get_all_sync_enabled_user_ids()
+        assert 1 in ids
+
+    def test_excludes_users_without_sync_enabled(self, svc):
+        _insert_account(svc, user_id=2)
+        # Not calling update_calendar — sync_enabled stays False
+        ids = svc.get_all_sync_enabled_user_ids()
+        assert 2 not in ids
+
+    def test_excludes_users_without_wodapp_session(self, svc):
+        _insert_account(svc, user_id=3)
+        svc.update_calendar(3, "cal_id", "cal")
+        # sync_enabled=True but no session stored
+        ids = svc.get_all_sync_enabled_user_ids()
+        assert 3 not in ids
+
+    def test_returns_empty_when_none_qualify(self, svc):
+        assert svc.get_all_sync_enabled_user_ids() == []
+
+
+class TestWodappSessionEnc:
+    def test_store_and_retrieve(self, svc):
+        _insert_account(svc)
+        svc.store_wodapp_session_enc(1, "enc_session_data")
+        result = svc.get_wodapp_session_enc(1)
+        assert result == "enc_session_data"
+
+    def test_returns_none_when_not_stored(self, svc):
+        _insert_account(svc)
+        assert svc.get_wodapp_session_enc(1) is None
+
+    def test_returns_none_for_unknown_user(self, svc):
+        assert svc.get_wodapp_session_enc(999) is None
+
+    def test_overwrites_existing_session(self, svc):
+        _insert_account(svc)
+        svc.store_wodapp_session_enc(1, "old_session")
+        svc.store_wodapp_session_enc(1, "new_session")
+        assert svc.get_wodapp_session_enc(1) == "new_session"
+
+
+class TestSyncedEvents:
+    def test_upsert_and_get(self, svc):
+        _insert_account(svc)
+        svc.upsert_synced_event(
+            1, 101, "gev1", "cal_id",
+            "2026-04-27T10:00:00", "2026-04-27T11:00:00", "CrossFit", etag="etag1"
+        )
+        events = svc.get_synced_events(1)
+        assert len(events) == 1
+        assert events[0].id_appointment == 101
+        assert events[0].google_event_id == "gev1"
+        assert events[0].etag == "etag1"
+
+    def test_upsert_updates_existing_event(self, svc):
+        _insert_account(svc)
+        svc.upsert_synced_event(
+            1, 101, "gev1", "cal_id",
+            "2026-04-27T10:00:00", "2026-04-27T11:00:00", "CrossFit"
+        )
+        svc.upsert_synced_event(
+            1, 101, "gev1_updated", "cal_id",
+            "2026-04-28T10:00:00", "2026-04-28T11:00:00", "Gymnastics"
+        )
+        events = svc.get_synced_events(1)
+        assert len(events) == 1
+        assert events[0].google_event_id == "gev1_updated"
+        assert events[0].name == "Gymnastics"
+
+    def test_delete_synced_event(self, svc):
+        _insert_account(svc)
+        svc.upsert_synced_event(
+            1, 101, "gev1", "cal_id",
+            "2026-04-27T10:00:00", "2026-04-27T11:00:00", "CrossFit"
+        )
+        svc.delete_synced_event(1, 101)
+        assert svc.get_synced_events(1) == []
+
+    def test_get_synced_events_empty_for_new_user(self, svc):
+        _insert_account(svc)
+        assert svc.get_synced_events(1) == []
+
+    def test_multiple_events_for_same_user(self, svc):
+        _insert_account(svc)
+        svc.upsert_synced_event(
+            1, 101, "gev1", "cal_id",
+            "2026-04-27T10:00:00", "2026-04-27T11:00:00", "CrossFit"
+        )
+        svc.upsert_synced_event(
+            1, 102, "gev2", "cal_id",
+            "2026-04-28T10:00:00", "2026-04-28T11:00:00", "Gymnastics"
+        )
+        events = svc.get_synced_events(1)
+        assert len(events) == 2

--- a/tests/services/test_google_calendar.py
+++ b/tests/services/test_google_calendar.py
@@ -1,0 +1,110 @@
+"""Tests for services/google_calendar.py — Google Calendar API v3 wrapper."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from wodplanner.services import google_calendar as gcal
+
+
+def _mock_resp(json_data, status_code=200):
+    mock = MagicMock()
+    mock.json.return_value = json_data
+    mock.status_code = status_code
+    mock.raise_for_status = MagicMock()
+    return mock
+
+
+class TestListCalendars:
+    def test_returns_items(self):
+        with patch("httpx.get", return_value=_mock_resp({"items": [{"id": "cal1"}]})):
+            result = gcal.list_calendars("token")
+        assert result == [{"id": "cal1"}]
+
+    def test_returns_empty_list_when_no_items_key(self):
+        with patch("httpx.get", return_value=_mock_resp({})):
+            result = gcal.list_calendars("token")
+        assert result == []
+
+    def test_raises_on_http_error(self):
+        mock_resp = _mock_resp({})
+        mock_resp.raise_for_status.side_effect = Exception("403")
+        with patch("httpx.get", return_value=mock_resp):
+            with pytest.raises(Exception, match="403"):
+                gcal.list_calendars("bad_token")
+
+
+class TestCreateCalendar:
+    def test_returns_calendar_resource(self):
+        cal = {"id": "new_cal_id", "summary": "WodPlanner"}
+        with patch("httpx.post", return_value=_mock_resp(cal)):
+            result = gcal.create_calendar("token", "WodPlanner")
+        assert result["id"] == "new_cal_id"
+        assert result["summary"] == "WodPlanner"
+
+
+class TestInsertEvent:
+    def test_returns_created_event(self):
+        event = {"id": "ev1", "summary": "CrossFit"}
+        with patch("httpx.post", return_value=_mock_resp(event)):
+            result = gcal.insert_event("token", "cal_id", {"summary": "CrossFit"})
+        assert result["id"] == "ev1"
+
+
+class TestUpdateEvent:
+    def test_returns_updated_event(self):
+        event = {"id": "ev1", "summary": "Updated CrossFit"}
+        with patch("httpx.put", return_value=_mock_resp(event)):
+            result = gcal.update_event("token", "cal_id", "ev1", {"summary": "Updated CrossFit"})
+        assert result["summary"] == "Updated CrossFit"
+
+
+class TestDeleteEvent:
+    def test_delete_success_calls_raise_for_status(self):
+        mock_resp = _mock_resp({}, status_code=204)
+        with patch("httpx.delete", return_value=mock_resp):
+            gcal.delete_event("token", "cal_id", "ev1")
+        mock_resp.raise_for_status.assert_called_once()
+
+    def test_delete_404_is_silently_ignored(self):
+        mock_resp = _mock_resp({}, status_code=404)
+        with patch("httpx.delete", return_value=mock_resp):
+            gcal.delete_event("token", "cal_id", "ev1")  # Must not raise
+        mock_resp.raise_for_status.assert_not_called()
+
+    def test_delete_500_raises(self):
+        mock_resp = _mock_resp({}, status_code=500)
+        mock_resp.raise_for_status.side_effect = Exception("500 Internal Server Error")
+        with patch("httpx.delete", return_value=mock_resp):
+            with pytest.raises(Exception, match="500"):
+                gcal.delete_event("token", "cal_id", "ev1")
+
+
+class TestListEventsWithPrivateProperty:
+    def test_returns_matching_events(self):
+        events = [{"id": "ev1"}, {"id": "ev2"}]
+        with patch("httpx.get", return_value=_mock_resp({"items": events})):
+            result = gcal.list_events_with_private_property("token", "cal_id", "my_key", "my_value")
+        assert result == events
+
+    def test_returns_empty_when_no_items(self):
+        with patch("httpx.get", return_value=_mock_resp({})):
+            result = gcal.list_events_with_private_property("token", "cal_id", "k", "v")
+        assert result == []
+
+
+class TestListEventsInRange:
+    def test_returns_events_in_range(self):
+        events = [{"id": "ev1"}, {"id": "ev2"}]
+        with patch("httpx.get", return_value=_mock_resp({"items": events})):
+            result = gcal.list_events_in_range(
+                "token", "cal_id", "2026-01-01T00:00:00Z", "2026-12-31T00:00:00Z"
+            )
+        assert len(result) == 2
+
+    def test_returns_empty_list_when_no_items(self):
+        with patch("httpx.get", return_value=_mock_resp({})):
+            result = gcal.list_events_in_range(
+                "token", "cal_id", "2026-01-01T00:00:00Z", "2026-12-31T00:00:00Z"
+            )
+        assert result == []

--- a/tests/services/test_google_oauth.py
+++ b/tests/services/test_google_oauth.py
@@ -1,0 +1,104 @@
+"""Tests for services/google_oauth.py — Google OAuth2 helpers."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from wodplanner.services.google_oauth import (
+    build_auth_url,
+    exchange_code,
+    get_user_email,
+    refresh_access_token,
+    revoke_token,
+)
+
+
+class TestBuildAuthUrl:
+    def test_starts_with_auth_endpoint(self):
+        url = build_auth_url("state123", "my-client-id", "https://example.com/cb")
+        assert url.startswith("https://accounts.google.com/o/oauth2/v2/auth")
+
+    def test_contains_client_id(self):
+        url = build_auth_url("state123", "my-client-id", "https://example.com/cb")
+        assert "my-client-id" in url
+
+    def test_contains_redirect_uri(self):
+        url = build_auth_url("state123", "client_id", "https://example.com/callback")
+        assert "example.com" in url
+
+    def test_contains_state(self):
+        url = build_auth_url("mystate", "client_id", "https://example.com/cb")
+        assert "mystate" in url
+
+    def test_includes_offline_access(self):
+        url = build_auth_url("s", "c", "r")
+        assert "offline" in url
+
+    def test_includes_calendar_scope(self):
+        url = build_auth_url("s", "c", "r")
+        assert "calendar" in url
+
+
+class TestExchangeCode:
+    def test_returns_token_dict(self):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"access_token": "tok", "refresh_token": "ref"}
+        with patch("httpx.post", return_value=mock_resp):
+            result = exchange_code("code", "client_id", "client_secret", "redirect")
+        assert result["access_token"] == "tok"
+        mock_resp.raise_for_status.assert_called_once()
+
+    def test_raises_on_http_error(self):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = Exception("401 Unauthorized")
+        with patch("httpx.post", return_value=mock_resp):
+            with pytest.raises(Exception, match="401"):
+                exchange_code("bad_code", "c", "s", "r")
+
+
+class TestGetUserEmail:
+    def test_returns_email(self):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"email": "user@example.com"}
+        with patch("httpx.get", return_value=mock_resp):
+            result = get_user_email("access_token")
+        assert result == "user@example.com"
+
+    def test_returns_unknown_when_email_missing(self):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {}
+        with patch("httpx.get", return_value=mock_resp):
+            result = get_user_email("access_token")
+        assert result == "unknown"
+
+
+class TestRefreshAccessToken:
+    def test_returns_new_token_and_expiry_iso(self):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"access_token": "new_tok", "expires_in": 3600}
+        with patch("httpx.post", return_value=mock_resp):
+            token, expiry = refresh_access_token("refresh_tok", "client_id", "client_secret")
+        assert token == "new_tok"
+        assert expiry is not None
+        assert "T" in expiry  # ISO 8601 datetime
+
+    def test_expiry_is_none_when_no_expires_in(self):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"access_token": "new_tok"}
+        with patch("httpx.post", return_value=mock_resp):
+            token, expiry = refresh_access_token("refresh_tok", "c", "s")
+        assert token == "new_tok"
+        assert expiry is None
+
+
+class TestRevokeToken:
+    def test_calls_revoke_endpoint(self):
+        with patch("httpx.post") as mock_post:
+            revoke_token("some_token")
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args
+        assert "revoke" in str(call_kwargs)
+
+    def test_swallows_network_exceptions(self):
+        with patch("httpx.post", side_effect=Exception("network error")):
+            revoke_token("token")  # Must not raise


### PR DESCRIPTION
Adds 6 new test files targeting the lowest-coverage modules: crypto, google_oauth, google_calendar, google_accounts, calendar_sync, and the google_sync router. Expected to bring overall coverage from 83% to ~92%+.

Closes #37

Generated with [Claude Code](https://claude.ai/code)