### PR TITLE
feat: add workout exercises to Google Calendar event notes

### DIFF
--- a/src/wodplanner/app/main.py
+++ b/src/wodplanner/app/main.py
@@ -86,8 +86,10 @@ async def _periodic_sync_all(db_path: Path) -> None:
     from wodplanner.models.auth import AuthSession
     from wodplanner.services import calendar_sync, crypto
     from wodplanner.services.google_accounts import GoogleAccountsService
+    from wodplanner.services.schedule import ScheduleService
 
     db = GoogleAccountsService(db_path)
+    schedule_service = ScheduleService(db_path)
     enc_key = crypto.get_enc_key(settings.google_token_enc_key, settings.secret_key)
 
     user_ids = db.get_all_sync_enabled_user_ids()
@@ -117,6 +119,8 @@ async def _periodic_sync_all(db_path: Path) -> None:
                     enc_key=enc_key,
                     first_name=wodapp_session.firstname,
                     gym_name=wodapp_session.gym_name,
+                    schedule_service=schedule_service,
+                    gym_id=wodapp_session.gym_id,
                 )
             except Exception:
                 logger.exception("Periodic sync failed for user %d", user_id)

--- a/src/wodplanner/app/routers/google_sync.py
+++ b/src/wodplanner/app/routers/google_sync.py
@@ -15,8 +15,10 @@ from wodplanner.app.config import settings
 from wodplanner.app.dependencies import (
     get_client_from_session_for_view,
     get_google_accounts_service,
+    get_schedule_service,
     require_session_for_view,
 )
+from wodplanner.services.schedule import ScheduleService
 from wodplanner.models.auth import AuthSession
 from wodplanner.services import calendar_sync, crypto
 from wodplanner.services import google_calendar as gcal
@@ -230,6 +232,7 @@ def google_calendar_select(
     session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
     client: WodAppClient = Depends(get_client_from_session_for_view),
     db: GoogleAccountsService = Depends(get_google_accounts_service),
+    schedule_service: ScheduleService = Depends(get_schedule_service),
 ):
     """Save the chosen Google Calendar, then run an initial insert-only sync."""
     account = db.get_account(session.user_id)
@@ -287,6 +290,8 @@ def google_calendar_select(
         enc_key=key,
         first_name=session.firstname,
         gym_name=session.gym_name,
+        schedule_service=schedule_service,
+        gym_id=session.gym_id,
     )
     account = db.get_account(session.user_id)
 
@@ -308,6 +313,7 @@ def google_sync_now(
     session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
     client: WodAppClient = Depends(get_client_from_session_for_view),
     db: GoogleAccountsService = Depends(get_google_accounts_service),
+    schedule_service: ScheduleService = Depends(get_schedule_service),
 ):
     """Trigger a manual sync for the authenticated user."""
     account = db.get_account(session.user_id)
@@ -321,6 +327,8 @@ def google_sync_now(
         enc_key=_enc_key(),
         first_name=session.firstname,
         gym_name=session.gym_name,
+        schedule_service=schedule_service,
+        gym_id=session.gym_id,
     )
     account = db.get_account(session.user_id)
 

--- a/src/wodplanner/app/routers/google_sync.py
+++ b/src/wodplanner/app/routers/google_sync.py
@@ -18,7 +18,6 @@ from wodplanner.app.dependencies import (
     get_schedule_service,
     require_session_for_view,
 )
-from wodplanner.services.schedule import ScheduleService
 from wodplanner.models.auth import AuthSession
 from wodplanner.services import calendar_sync, crypto
 from wodplanner.services import google_calendar as gcal
@@ -29,6 +28,7 @@ from wodplanner.services.google_oauth import (
     get_user_email,
     revoke_token,
 )
+from wodplanner.services.schedule import ScheduleService
 
 logger = logging.getLogger(__name__)
 

--- a/src/wodplanner/app/routers/views.py
+++ b/src/wodplanner/app/routers/views.py
@@ -47,6 +47,7 @@ def _enqueue_google_sync(
     session: AuthSession,
     client: WodAppClient,
     db: GoogleAccountsService,
+    schedule_service: ScheduleService,
 ) -> None:
     """Fire-and-forget Google Calendar sync after a signup or cancel."""
     account = db.get_account(session.user_id)
@@ -61,6 +62,8 @@ def _enqueue_google_sync(
         enc_key=enc_key,
         first_name=session.firstname,
         gym_name=session.gym_name,
+        schedule_service=schedule_service,
+        gym_id=session.gym_id,
     )
 
 
@@ -434,7 +437,7 @@ def subscribe_view(
     end = parse_api_datetime(date_end)
 
     client.subscribe(appointment_id, start, end)
-    _enqueue_google_sync(background_tasks, session, client, google_db)
+    _enqueue_google_sync(background_tasks, session, client, google_db, schedule_service)
 
     # Return updated calendar
     return calendar_day_partial(
@@ -467,7 +470,7 @@ def waitinglist_view(
     end = parse_api_datetime(date_end)
 
     client.subscribe_waitinglist(appointment_id, start, end)
-    _enqueue_google_sync(background_tasks, session, client, google_db)
+    _enqueue_google_sync(background_tasks, session, client, google_db, schedule_service)
 
     # Return updated calendar
     return calendar_day_partial(
@@ -505,7 +508,7 @@ def unsubscribe_view(
     else:
         client.unsubscribe(appointment_id, start, end)
 
-    _enqueue_google_sync(background_tasks, session, client, google_db)
+    _enqueue_google_sync(background_tasks, session, client, google_db, schedule_service)
 
     # Return updated calendar
     return calendar_day_partial(

--- a/src/wodplanner/services/calendar_sync.py
+++ b/src/wodplanner/services/calendar_sync.py
@@ -12,10 +12,12 @@ from datetime import datetime, timedelta
 from wodplanner.api.client import WodAppClient
 from wodplanner.app.config import settings
 from wodplanner.models.google import GoogleAccount, SyncedEvent
+from wodplanner.models.schedule import Schedule
 from wodplanner.services import crypto
 from wodplanner.services import google_calendar as gcal
 from wodplanner.services.google_accounts import GoogleAccountsService
 from wodplanner.services.google_oauth import refresh_access_token
+from wodplanner.services.schedule import ScheduleService
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +66,42 @@ def get_valid_token(
     return raw_token
 
 
-def _build_event(reservation: dict, gym_name: str, first_name: str) -> dict:
+def _build_description(class_name: str, schedule: Schedule | None) -> str:
+    parts = [f"Class: {class_name}"]
+    if schedule:
+        if schedule.warmup_mobility:
+            parts.append(f"Warmup/Mobility:\n{schedule.warmup_mobility}")
+        if schedule.strength_specialty:
+            parts.append(f"Strength/Specialty:\n{schedule.strength_specialty}")
+        if schedule.metcon:
+            parts.append(f"Metcon:\n{schedule.metcon}")
+    return "\n\n".join(parts)
+
+
+def _lookup_schedule(
+    schedule_service: ScheduleService | None,
+    reservation: dict,
+    gym_id: int | None,
+) -> Schedule | None:
+    if not schedule_service or gym_id is None:
+        return None
+    try:
+        return schedule_service.find_for_appointment(
+            reservation["name"],
+            reservation["date_start"].date(),
+            gym_id=gym_id,
+        )
+    except Exception:
+        logger.debug("Schedule lookup failed for appt %d", reservation["id_appointment"])
+        return None
+
+
+def _build_event(
+    reservation: dict,
+    gym_name: str,
+    first_name: str,
+    schedule: Schedule | None = None,
+) -> dict:
     start: datetime = reservation["date_start"]
     end: datetime = reservation.get("date_end") or start + _DEFAULT_CLASS_DURATION
     appt_id: int = reservation["id_appointment"]
@@ -73,7 +110,7 @@ def _build_event(reservation: dict, gym_name: str, first_name: str) -> dict:
         "location": gym_name,
         "start": {"dateTime": start.isoformat(), "timeZone": _TIMEZONE},
         "end": {"dateTime": end.isoformat(), "timeZone": _TIMEZONE},
-        "description": f"Class: {reservation['name']}",
+        "description": _build_description(reservation["name"], schedule),
         "extendedProperties": {"private": {_PROP_KEY: str(appt_id)}},
     }
 
@@ -150,6 +187,8 @@ def sync_user(
     enc_key: bytes,
     first_name: str,
     gym_name: str,
+    schedule_service: ScheduleService | None = None,
+    gym_id: int | None = None,
 ) -> SyncResult:
     """Full diff sync: insert new signups, update changed events, delete cancellations."""
     result = SyncResult()
@@ -190,7 +229,8 @@ def sync_user(
         if appt_id in existing:
             continue
         try:
-            event_body = _build_event(reservation, gym_name, first_name)
+            schedule = _lookup_schedule(schedule_service, reservation, gym_id)
+            event_body = _build_event(reservation, gym_name, first_name, schedule)
             created = gcal.insert_event(access_token, account.calendar_id, event_body)
             db.upsert_synced_event(
                 user_id=account.user_id,
@@ -220,7 +260,8 @@ def sync_user(
         if ev.date_start == new_start and ev.name == reservation["name"]:
             continue
         try:
-            event_body = _build_event(reservation, gym_name, first_name)
+            schedule = _lookup_schedule(schedule_service, reservation, gym_id)
+            event_body = _build_event(reservation, gym_name, first_name, schedule)
             gcal.update_event(
                 access_token, account.calendar_id, ev.google_event_id, event_body
             )

--- a/tests/services/test_calendar_sync.py
+++ b/tests/services/test_calendar_sync.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 from wodplanner.models.google import GoogleAccount, SyncedEvent
+from wodplanner.models.schedule import Schedule
 from wodplanner.services import calendar_sync
 from wodplanner.services.calendar_sync import SyncResult
 
@@ -116,6 +117,47 @@ class TestGetValidToken:
         db.update_tokens.assert_not_called()
 
 
+def _make_schedule(warmup=None, strength=None, metcon=None):
+    from datetime import date
+    return Schedule(
+        date=date(2026, 5, 1),
+        class_type="CrossFit",
+        warmup_mobility=warmup,
+        strength_specialty=strength,
+        metcon=metcon,
+    )
+
+
+class TestBuildDescription:
+    def test_no_schedule_returns_class_name_only(self):
+        desc = calendar_sync._build_description("CrossFit", None)
+        assert desc == "Class: CrossFit"
+
+    def test_includes_all_schedule_sections(self):
+        schedule = _make_schedule(
+            warmup="A. Row 500m",
+            strength="A. Back Squat 5x3",
+            metcon="AMRAP 12: 5 pull-ups",
+        )
+        desc = calendar_sync._build_description("CrossFit", schedule)
+        assert "Class: CrossFit" in desc
+        assert "Warmup/Mobility:\nA. Row 500m" in desc
+        assert "Strength/Specialty:\nA. Back Squat 5x3" in desc
+        assert "Metcon:\nAMRAP 12: 5 pull-ups" in desc
+
+    def test_skips_none_sections(self):
+        schedule = _make_schedule(metcon="AMRAP 10: 10 burpees")
+        desc = calendar_sync._build_description("CrossFit", schedule)
+        assert "Warmup" not in desc
+        assert "Strength" not in desc
+        assert "Metcon:\nAMRAP 10: 10 burpees" in desc
+
+    def test_sections_separated_by_blank_line(self):
+        schedule = _make_schedule(warmup="Warmup stuff", metcon="Metcon stuff")
+        desc = calendar_sync._build_description("CrossFit", schedule)
+        assert "\n\n" in desc
+
+
 class TestBuildEvent:
     def test_builds_event_with_explicit_date_end(self):
         start = datetime(2026, 5, 1, 10, 0)
@@ -139,6 +181,18 @@ class TestBuildEvent:
         event = calendar_sync._build_event(reservation, "Gym", "Alice")
         assert event["start"]["timeZone"] == "Europe/Amsterdam"
         assert event["end"]["timeZone"] == "Europe/Amsterdam"
+
+    def test_description_without_schedule(self):
+        reservation = _make_reservation(name="CrossFit")
+        event = calendar_sync._build_event(reservation, "Gym", "Alice")
+        assert event["description"] == "Class: CrossFit"
+
+    def test_description_with_schedule_includes_exercises(self):
+        reservation = _make_reservation(name="CrossFit")
+        schedule = _make_schedule(metcon="AMRAP 10: 5 pull-ups, 10 push-ups")
+        event = calendar_sync._build_event(reservation, "Gym", "Alice", schedule)
+        assert "Class: CrossFit" in event["description"]
+        assert "AMRAP 10: 5 pull-ups, 10 push-ups" in event["description"]
 
 
 class TestRebuildFromGoogle:
@@ -385,6 +439,53 @@ class TestSyncUser:
         call_args = db.update_sync_status.call_args[0]
         assert call_args[0] == 1  # user_id
         assert call_args[1] == "ok"
+
+    def test_inserts_with_schedule_exercises_in_description(self):
+        account = _make_account()
+        db = _make_db()
+        reservation = _make_reservation(appt_id=1, name="CrossFit", date_start=datetime(2026, 5, 1, 10, 0))
+        client = _make_client([reservation])
+        schedule = _make_schedule(metcon="AMRAP 10: 5 pull-ups")
+        schedule_service = MagicMock()
+        schedule_service.find_for_appointment.return_value = schedule
+        inserted_events = []
+
+        def capture_insert(token, cal_id, event_body):
+            inserted_events.append(event_body)
+            return {"id": "gev1"}
+
+        with (
+            patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"),
+            patch("wodplanner.services.calendar_sync.gcal.insert_event", side_effect=capture_insert),
+        ):
+            result = calendar_sync.sync_user(
+                account, db, client, ENC_KEY, "Alice", "Box",
+                schedule_service=schedule_service, gym_id=42,
+            )
+
+        assert result.inserted == 1
+        assert "AMRAP 10: 5 pull-ups" in inserted_events[0]["description"]
+        schedule_service.find_for_appointment.assert_called_once_with("CrossFit", datetime(2026, 5, 1, 10, 0).date(), gym_id=42)
+
+    def test_inserts_without_schedule_when_none_provided(self):
+        account = _make_account()
+        db = _make_db()
+        reservation = _make_reservation(appt_id=1, name="CrossFit", date_start=datetime(2026, 5, 1, 10, 0))
+        client = _make_client([reservation])
+        inserted_events = []
+
+        def capture_insert(token, cal_id, event_body):
+            inserted_events.append(event_body)
+            return {"id": "gev1"}
+
+        with (
+            patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"),
+            patch("wodplanner.services.calendar_sync.gcal.insert_event", side_effect=capture_insert),
+        ):
+            result = calendar_sync.sync_user(account, db, client, ENC_KEY, "Alice", "Box")
+
+        assert result.inserted == 1
+        assert inserted_events[0]["description"] == "Class: CrossFit"
 
     def test_delete_skips_event_with_invalid_date(self):
         account = _make_account()


### PR DESCRIPTION
When syncing class reservations to Google Calendar, look up the workout schedule (warmup/mobility, strength/specialty, metcon) for each class and include it in the calendar event description.

Closes #40

Generated with [Claude Code](https://claude.ai/code)