### PR TITLE
feat: introduce friend_presence module

### DIFF
--- a/src/wodplanner/services/friend_presence.py
+++ b/src/wodplanner/services/friend_presence.py
@@ -1,0 +1,58 @@
+"""Cross-reference live WodApp member lists against stored Friends."""
+
+import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from wodplanner.api.client import WodAppClient
+from wodplanner.models.calendar import Appointment
+from wodplanner.models.friends import Friend
+
+logger = logging.getLogger(__name__)
+
+_CONCURRENCY = 5
+
+
+def find_friends_in_appointments(
+    appointments: list[Appointment],
+    friends: list[Friend],
+    client: WodAppClient,
+) -> dict[int, list[Friend] | None]:
+    """Return Friends present in each Appointment, keyed by Appointment ID.
+
+    Value is a list of matching Friends (may be empty), or None if the member
+    fetch failed for that Appointment.
+    """
+    if not friends:
+        return {}
+
+    friend_map: dict[int, Friend] = {f.appuser_id: f for f in friends}
+
+    def fetch(appt: Appointment) -> tuple[int, list[Friend] | None]:
+        try:
+            members, _ = client.get_appointment_members(
+                appt.id_appointment,
+                appt.date_start,
+                appt.date_end,
+                expected_total=appt.total_subscriptions,
+            )
+            return appt.id_appointment, [
+                friend_map[m.id_appuser]
+                for m in members
+                if m.id_appuser in friend_map
+            ]
+        except Exception as exc:
+            logger.warning(
+                "Failed to fetch members for appointment %s: %s",
+                appt.id_appointment,
+                exc,
+            )
+            return appt.id_appointment, None
+
+    result: dict[int, list[Friend] | None] = {}
+    with ThreadPoolExecutor(max_workers=_CONCURRENCY) as pool:
+        futures = {pool.submit(fetch, appt): appt for appt in appointments}
+        for future in as_completed(futures):
+            appt_id, presence = future.result()
+            result[appt_id] = presence
+
+    return result

--- a/tests/services/test_friend_presence.py
+++ b/tests/services/test_friend_presence.py
@@ -1,0 +1,132 @@
+"""Tests for services/friend_presence.py"""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from wodplanner.models.calendar import Appointment, Member
+from wodplanner.models.friends import Friend
+from wodplanner.services.friend_presence import find_friends_in_appointments
+
+
+def make_appt(appt_id: int, total: int = 0) -> Appointment:
+    return Appointment(
+        id_appointment=appt_id,
+        id_appointment_type=1,
+        name="CrossFit",
+        date_start=datetime(2026, 5, 1, 9, 0),
+        date_end=datetime(2026, 5, 1, 10, 0),
+        max_subscriptions=20,
+        total_subscriptions=total,
+        status="open",
+    )
+
+
+def make_friend(appuser_id: int, name: str = "Alice") -> Friend:
+    return Friend(owner_user_id=1, appuser_id=appuser_id, name=name)
+
+
+def make_member(appuser_id: int, name: str = "Alice") -> Member:
+    return Member(name=name, id_appuser=appuser_id)
+
+
+class TestFindFriendsInAppointments:
+    def test_empty_friends_returns_empty_dict_no_api_calls(self):
+        client = MagicMock()
+        appts = [make_appt(1), make_appt(2)]
+
+        result = find_friends_in_appointments(appts, [], client)
+
+        assert result == {}
+        client.get_appointment_members.assert_not_called()
+
+    def test_friend_present_in_appointment_returns_friend_object(self):
+        client = MagicMock()
+        friend = make_friend(appuser_id=42, name="Bob")
+        appt = make_appt(1, total=1)
+        client.get_appointment_members.return_value = ([make_member(42, "Bob")], MagicMock())
+
+        result = find_friends_in_appointments([appt], [friend], client)
+
+        assert result[1] == [friend]
+
+    def test_member_not_in_friends_excluded(self):
+        client = MagicMock()
+        friend = make_friend(appuser_id=42)
+        appt = make_appt(1, total=2)
+        client.get_appointment_members.return_value = (
+            [make_member(42), make_member(99, "Stranger")],
+            MagicMock(),
+        )
+
+        result = find_friends_in_appointments([appt], [friend], client)
+
+        assert len(result[1]) == 1
+        assert result[1][0].appuser_id == 42
+
+    def test_fetch_failure_maps_to_none(self):
+        client = MagicMock()
+        friend = make_friend(appuser_id=42)
+        appt = make_appt(1)
+        client.get_appointment_members.side_effect = RuntimeError("network error")
+
+        result = find_friends_in_appointments([appt], [friend], client)
+
+        assert result[1] is None
+
+    def test_fetch_failure_does_not_affect_other_appointments(self):
+        client = MagicMock()
+        friend = make_friend(appuser_id=42, name="Alice")
+        appt_ok = make_appt(1, total=1)
+        appt_fail = make_appt(2)
+
+        def side_effect(appt_id, *args, **kwargs):
+            if appt_id == 2:
+                raise RuntimeError("fail")
+            return [make_member(42, "Alice")], MagicMock()
+
+        client.get_appointment_members.side_effect = side_effect
+
+        result = find_friends_in_appointments([appt_ok, appt_fail], [friend], client)
+
+        assert result[1] == [friend]
+        assert result[2] is None
+
+    def test_no_friends_in_appointment_returns_empty_list(self):
+        client = MagicMock()
+        friend = make_friend(appuser_id=42)
+        appt = make_appt(1, total=1)
+        client.get_appointment_members.return_value = ([make_member(99, "Other")], MagicMock())
+
+        result = find_friends_in_appointments([appt], [friend], client)
+
+        assert result[1] == []
+
+    def test_fetch_failure_logs_warning(self, caplog):
+        import logging
+
+        client = MagicMock()
+        friend = make_friend(appuser_id=42)
+        appt = make_appt(7)
+        client.get_appointment_members.side_effect = ValueError("boom")
+
+        with caplog.at_level(logging.WARNING, logger="wodplanner.services.friend_presence"):
+            find_friends_in_appointments([appt], [friend], client)
+
+        assert any("7" in r.message for r in caplog.records)
+
+    def test_multiple_friends_in_one_appointment(self):
+        client = MagicMock()
+        f1 = make_friend(appuser_id=1, name="Alice")
+        f2 = make_friend(appuser_id=2, name="Bob")
+        appt = make_appt(10, total=2)
+        client.get_appointment_members.return_value = (
+            [make_member(1, "Alice"), make_member(2, "Bob")],
+            MagicMock(),
+        )
+
+        result = find_friends_in_appointments([appt], [f1, f2], client)
+
+        assert len(result[10]) == 2
+        assert {fr.appuser_id for fr in result[10]} == {1, 2}

--- a/tests/services/test_friend_presence.py
+++ b/tests/services/test_friend_presence.py
@@ -3,8 +3,6 @@
 from datetime import datetime
 from unittest.mock import MagicMock
 
-import pytest
-
 from wodplanner.models.calendar import Appointment, Member
 from wodplanner.models.friends import Friend
 from wodplanner.services.friend_presence import find_friends_in_appointments


### PR DESCRIPTION
Closes #44

## Summary

- Adds `services/friend_presence.py` with `find_friends_in_appointments`
- Single seam for cross-referencing live WodApp member lists against stored Friends
- Concurrent fetch via `ThreadPoolExecutor` (max 5 workers); empty friends list short-circuits with no API calls; fetch failure maps to `None` with warning logged

## Test plan

- [x] `tests/services/test_friend_presence.py` — 8 cases covering all acceptance criteria
- [x] `ruff check` passes
- [x] `mypy src` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)