### PR TITLE
refactor: migrate all sync call sites to CalendarSyncService

### DIFF
--- a/src/wodplanner/app/routers/google_sync.py
+++ b/src/wodplanner/app/routers/google_sync.py
@@ -13,14 +13,15 @@ from itsdangerous import BadSignature, URLSafeTimedSerializer
 from wodplanner.api.client import WodAppClient
 from wodplanner.app.config import settings
 from wodplanner.app.dependencies import (
+    get_calendar_sync_service,
     get_client_from_session_for_view,
     get_google_accounts_service,
-    get_schedule_service,
     require_session_for_view,
 )
 from wodplanner.models.auth import AuthSession
-from wodplanner.services import calendar_sync, crypto
+from wodplanner.services import crypto
 from wodplanner.services import google_calendar as gcal
+from wodplanner.services.calendar_sync import CalendarSyncService
 from wodplanner.services.google_accounts import GoogleAccountsService
 from wodplanner.services.google_oauth import (
     build_auth_url,
@@ -28,7 +29,6 @@ from wodplanner.services.google_oauth import (
     get_user_email,
     revoke_token,
 )
-from wodplanner.services.schedule import ScheduleService
 
 logger = logging.getLogger(__name__)
 
@@ -205,6 +205,7 @@ def google_calendars(
     request: Request,
     session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
     db: GoogleAccountsService = Depends(get_google_accounts_service),
+    sync_service: CalendarSyncService = Depends(get_calendar_sync_service),
 ):
     """HTMX partial: list user's Google Calendars for calendar picker."""
     account = db.get_account(session.user_id)
@@ -212,7 +213,7 @@ def google_calendars(
         raise HTTPException(status_code=400, detail="Not connected to Google")
 
     try:
-        access_token = calendar_sync.get_valid_token(account, db, _enc_key())
+        access_token = sync_service.get_valid_token(account)
         calendars = gcal.list_calendars(access_token)
     except Exception:
         logger.exception("Failed to list calendars for user %d", session.user_id)
@@ -232,16 +233,15 @@ def google_calendar_select(
     session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
     client: WodAppClient = Depends(get_client_from_session_for_view),
     db: GoogleAccountsService = Depends(get_google_accounts_service),
-    schedule_service: ScheduleService = Depends(get_schedule_service),
+    sync_service: CalendarSyncService = Depends(get_calendar_sync_service),
 ):
     """Save the chosen Google Calendar, then run an initial insert-only sync."""
     account = db.get_account(session.user_id)
     if not account:
         raise HTTPException(status_code=400, detail="Not connected to Google")
 
-    key = _enc_key()
     try:
-        access_token = calendar_sync.get_valid_token(account, db, key)
+        access_token = sync_service.get_valid_token(account)
     except Exception:
         logger.exception("Token refresh failed for user %d", session.user_id)
         return _render(
@@ -283,14 +283,11 @@ def google_calendar_select(
     db.update_calendar(session.user_id, cal_id, cal_summary)
     account = db.get_account(session.user_id)
 
-    result = calendar_sync.sync_user(
+    result = sync_service.sync(
         account=account,  # type: ignore[arg-type]
-        db=db,
         client=client,
-        enc_key=key,
         first_name=session.firstname,
         gym_name=session.gym_name,
-        schedule_service=schedule_service,
         gym_id=session.gym_id,
     )
     account = db.get_account(session.user_id)
@@ -313,21 +310,18 @@ def google_sync_now(
     session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
     client: WodAppClient = Depends(get_client_from_session_for_view),
     db: GoogleAccountsService = Depends(get_google_accounts_service),
-    schedule_service: ScheduleService = Depends(get_schedule_service),
+    sync_service: CalendarSyncService = Depends(get_calendar_sync_service),
 ):
     """Trigger a manual sync for the authenticated user."""
     account = db.get_account(session.user_id)
     if not account or not account.calendar_id:
         raise HTTPException(status_code=400, detail="Not connected or no calendar selected")
 
-    result = calendar_sync.sync_user(
+    result = sync_service.sync(
         account=account,
-        db=db,
         client=client,
-        enc_key=_enc_key(),
         first_name=session.firstname,
         gym_name=session.gym_name,
-        schedule_service=schedule_service,
         gym_id=session.gym_id,
     )
     account = db.get_account(session.user_id)

--- a/src/wodplanner/app/routers/views.py
+++ b/src/wodplanner/app/routers/views.py
@@ -12,8 +12,8 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 
 from wodplanner.api.client import WodAppClient
-from wodplanner.app.config import settings
 from wodplanner.app.dependencies import (
+    get_calendar_sync_service,
     get_client_from_session_for_view,
     get_friends_service,
     get_google_accounts_service,
@@ -24,7 +24,7 @@ from wodplanner.app.dependencies import (
     require_session_for_view,
 )
 from wodplanner.models.auth import AuthSession
-from wodplanner.services import calendar_sync, crypto
+from wodplanner.services.calendar_sync import CalendarSyncService
 from wodplanner.services.calendar_view import build_calendar_view
 from wodplanner.services.friends import FriendsService
 from wodplanner.services.google_accounts import GoogleAccountsService
@@ -47,22 +47,18 @@ def _enqueue_google_sync(
     session: AuthSession,
     client: WodAppClient,
     db: GoogleAccountsService,
-    schedule_service: ScheduleService,
+    sync_service: CalendarSyncService,
 ) -> None:
     """Fire-and-forget Google Calendar sync after a signup or cancel."""
     account = db.get_account(session.user_id)
     if not account or not account.sync_enabled or not account.calendar_id:
         return
-    enc_key = crypto.get_enc_key(settings.google_token_enc_key, settings.secret_key)
     background_tasks.add_task(
-        calendar_sync.sync_user,
+        sync_service.sync,
         account=account,
-        db=db,
         client=client,
-        enc_key=enc_key,
         first_name=session.firstname,
         gym_name=session.gym_name,
-        schedule_service=schedule_service,
         gym_id=session.gym_id,
     )
 
@@ -431,13 +427,14 @@ def subscribe_view(
     prefs_service: PreferencesService = Depends(get_preferences_service),
     schedule_service: ScheduleService = Depends(get_schedule_service),
     google_db: GoogleAccountsService = Depends(get_google_accounts_service),
+    sync_service: CalendarSyncService = Depends(get_calendar_sync_service),
 ):
     """Subscribe to appointment from calendar (htmx)."""
     start = parse_api_datetime(date_start)
     end = parse_api_datetime(date_end)
 
     client.subscribe(appointment_id, start, end)
-    _enqueue_google_sync(background_tasks, session, client, google_db, schedule_service)
+    _enqueue_google_sync(background_tasks, session, client, google_db, sync_service)
 
     # Return updated calendar
     return calendar_day_partial(
@@ -464,13 +461,14 @@ def waitinglist_view(
     prefs_service: PreferencesService = Depends(get_preferences_service),
     schedule_service: ScheduleService = Depends(get_schedule_service),
     google_db: GoogleAccountsService = Depends(get_google_accounts_service),
+    sync_service: CalendarSyncService = Depends(get_calendar_sync_service),
 ):
     """Join waiting list from calendar (htmx)."""
     start = parse_api_datetime(date_start)
     end = parse_api_datetime(date_end)
 
     client.subscribe_waitinglist(appointment_id, start, end)
-    _enqueue_google_sync(background_tasks, session, client, google_db, schedule_service)
+    _enqueue_google_sync(background_tasks, session, client, google_db, sync_service)
 
     # Return updated calendar
     return calendar_day_partial(
@@ -498,6 +496,7 @@ def unsubscribe_view(
     prefs_service: PreferencesService = Depends(get_preferences_service),
     schedule_service: ScheduleService = Depends(get_schedule_service),
     google_db: GoogleAccountsService = Depends(get_google_accounts_service),
+    sync_service: CalendarSyncService = Depends(get_calendar_sync_service),
 ):
     """Unsubscribe from appointment (htmx)."""
     start = parse_api_datetime(date_start)
@@ -508,7 +507,7 @@ def unsubscribe_view(
     else:
         client.unsubscribe(appointment_id, start, end)
 
-    _enqueue_google_sync(background_tasks, session, client, google_db, schedule_service)
+    _enqueue_google_sync(background_tasks, session, client, google_db, sync_service)
 
     # Return updated calendar
     return calendar_day_partial(

--- a/tests/app/routers/test_google_sync.py
+++ b/tests/app/routers/test_google_sync.py
@@ -58,12 +58,21 @@ def mock_google_db():
 
 
 @pytest.fixture
-def google_app_client(monkeypatch, db_path, mock_google_db):
-    from wodplanner.app.dependencies import get_google_accounts_service
+def mock_sync_service():
+    svc = MagicMock()
+    svc.get_valid_token.return_value = "token"
+    svc.sync.return_value = MagicMock(ok=True, inserted=0, updated=0, deleted=0, errors=[])
+    return svc
+
+
+@pytest.fixture
+def google_app_client(monkeypatch, db_path, mock_google_db, mock_sync_service):
+    from wodplanner.app.dependencies import get_calendar_sync_service, get_google_accounts_service
 
     monkeypatch.setenv("DB_PATH", str(db_path))
     limiter._state.clear()
     app.dependency_overrides[get_google_accounts_service] = lambda: mock_google_db
+    app.dependency_overrides[get_calendar_sync_service] = lambda: mock_sync_service
 
     with TestClient(app) as client:
         yield client
@@ -265,19 +274,13 @@ class TestGoogleCalendars:
     def test_returns_calendar_list_html(self, google_app_client, session_cookie, mock_google_db):
         mock_google_db.get_account.return_value = _make_google_account()
         calendars = [{"id": "cal1", "summary": "My Calendar"}]
-        with (
-            patch("wodplanner.app.routers.google_sync.calendar_sync.get_valid_token", return_value="token"),
-            patch("wodplanner.app.routers.google_sync.gcal.list_calendars", return_value=calendars),
-        ):
+        with patch("wodplanner.app.routers.google_sync.gcal.list_calendars", return_value=calendars):
             r = google_app_client.get("/google/calendars", cookies={"session": session_cookie})
         assert r.status_code == 200
 
     def test_returns_empty_calendars_on_error(self, google_app_client, session_cookie, mock_google_db):
         mock_google_db.get_account.return_value = _make_google_account()
-        with (
-            patch("wodplanner.app.routers.google_sync.calendar_sync.get_valid_token", return_value="token"),
-            patch("wodplanner.app.routers.google_sync.gcal.list_calendars", side_effect=Exception("network")),
-        ):
+        with patch("wodplanner.app.routers.google_sync.gcal.list_calendars", side_effect=Exception("network")):
             r = google_app_client.get("/google/calendars", cookies={"session": session_cookie})
         assert r.status_code == 200
 
@@ -292,9 +295,10 @@ class TestGoogleCalendarSelect:
         r.errors = []
         return r
 
-    def test_select_existing_calendar(self, google_app_client, session_cookie, mock_google_db, monkeypatch):
+    def test_select_existing_calendar(self, google_app_client, session_cookie, mock_google_db, mock_sync_service, monkeypatch):
         account = _make_google_account()
         mock_google_db.get_account.return_value = account
+        mock_sync_service.sync.return_value = self._sync_result()
         mock_wodapp_client = MagicMock()
         mock_wodapp_client.get_upcoming_reservations.return_value = ([], {})
         monkeypatch.setattr(
@@ -302,23 +306,20 @@ class TestGoogleCalendarSelect:
             classmethod(lambda cls, s, cache=None: mock_wodapp_client),
         )
 
-        with (
-            patch("wodplanner.app.routers.google_sync.calendar_sync.get_valid_token", return_value="token"),
-            patch("wodplanner.app.routers.google_sync.calendar_sync.sync_user", return_value=self._sync_result()),
-        ):
-            r = google_app_client.post(
-                "/google/calendar/select",
-                data={"calendar_choice": "cal_id|My Calendar"},
-                cookies={"session": session_cookie},
-            )
+        r = google_app_client.post(
+            "/google/calendar/select",
+            data={"calendar_choice": "cal_id|My Calendar"},
+            cookies={"session": session_cookie},
+        )
         assert r.status_code == 200
         mock_google_db.update_calendar.assert_called_once_with(42, "cal_id", "My Calendar")
 
     def test_select_calendar_without_pipe_uses_id_as_summary(
-        self, google_app_client, session_cookie, mock_google_db, monkeypatch
+        self, google_app_client, session_cookie, mock_google_db, mock_sync_service, monkeypatch
     ):
         account = _make_google_account()
         mock_google_db.get_account.return_value = account
+        mock_sync_service.sync.return_value = self._sync_result()
         mock_wodapp_client = MagicMock()
         mock_wodapp_client.get_upcoming_reservations.return_value = ([], {})
         monkeypatch.setattr(
@@ -326,23 +327,20 @@ class TestGoogleCalendarSelect:
             classmethod(lambda cls, s, cache=None: mock_wodapp_client),
         )
 
-        with (
-            patch("wodplanner.app.routers.google_sync.calendar_sync.get_valid_token", return_value="token"),
-            patch("wodplanner.app.routers.google_sync.calendar_sync.sync_user", return_value=self._sync_result()),
-        ):
-            r = google_app_client.post(
-                "/google/calendar/select",
-                data={"calendar_choice": "only_id"},
-                cookies={"session": session_cookie},
-            )
+        r = google_app_client.post(
+            "/google/calendar/select",
+            data={"calendar_choice": "only_id"},
+            cookies={"session": session_cookie},
+        )
         assert r.status_code == 200
         mock_google_db.update_calendar.assert_called_once_with(42, "only_id", "only_id")
 
     def test_create_new_calendar(
-        self, google_app_client, session_cookie, mock_google_db, monkeypatch
+        self, google_app_client, session_cookie, mock_google_db, mock_sync_service, monkeypatch
     ):
         account = _make_google_account()
         mock_google_db.get_account.return_value = account
+        mock_sync_service.sync.return_value = self._sync_result()
         mock_wodapp_client = MagicMock()
         mock_wodapp_client.get_upcoming_reservations.return_value = ([], {})
         monkeypatch.setattr(
@@ -351,11 +349,7 @@ class TestGoogleCalendarSelect:
         )
 
         new_cal = {"id": "new_cal_id", "summary": "WodPlanner"}
-        with (
-            patch("wodplanner.app.routers.google_sync.calendar_sync.get_valid_token", return_value="token"),
-            patch("wodplanner.app.routers.google_sync.gcal.create_calendar", return_value=new_cal),
-            patch("wodplanner.app.routers.google_sync.calendar_sync.sync_user", return_value=self._sync_result()),
-        ):
+        with patch("wodplanner.app.routers.google_sync.gcal.create_calendar", return_value=new_cal):
             r = google_app_client.post(
                 "/google/calendar/select",
                 data={"calendar_choice": "__create__"},
@@ -375,10 +369,7 @@ class TestGoogleCalendarSelect:
             classmethod(lambda cls, s, cache=None: mock_wodapp_client),
         )
 
-        with (
-            patch("wodplanner.app.routers.google_sync.calendar_sync.get_valid_token", return_value="token"),
-            patch("wodplanner.app.routers.google_sync.gcal.create_calendar", side_effect=Exception("API error")),
-        ):
+        with patch("wodplanner.app.routers.google_sync.gcal.create_calendar", side_effect=Exception("API error")):
             r = google_app_client.post(
                 "/google/calendar/select",
                 data={"calendar_choice": "__create__"},
@@ -401,25 +392,22 @@ class TestGoogleCalendarSelect:
         assert r.status_code == 400
 
     def test_token_refresh_failure_returns_error_partial(
-        self, google_app_client, session_cookie, mock_google_db, monkeypatch
+        self, google_app_client, session_cookie, mock_google_db, mock_sync_service, monkeypatch
     ):
         account = _make_google_account()
         mock_google_db.get_account.return_value = account
+        mock_sync_service.get_valid_token.side_effect = Exception("refresh failed")
         mock_wodapp_client = MagicMock()
         monkeypatch.setattr(
             "wodplanner.app.dependencies.WodAppClient.from_session",
             classmethod(lambda cls, s, cache=None: mock_wodapp_client),
         )
 
-        with patch(
-            "wodplanner.app.routers.google_sync.calendar_sync.get_valid_token",
-            side_effect=Exception("refresh failed"),
-        ):
-            r = google_app_client.post(
-                "/google/calendar/select",
-                data={"calendar_choice": "cal_id"},
-                cookies={"session": session_cookie},
-            )
+        r = google_app_client.post(
+            "/google/calendar/select",
+            data={"calendar_choice": "cal_id"},
+            cookies={"session": session_cookie},
+        )
         assert r.status_code == 200
 
 
@@ -447,7 +435,7 @@ class TestGoogleSyncNow:
         assert r.status_code == 400
 
     def test_triggers_sync_and_returns_html(
-        self, google_app_client, session_cookie, mock_google_db, monkeypatch
+        self, google_app_client, session_cookie, mock_google_db, mock_sync_service, monkeypatch
     ):
         account = _make_google_account()
         mock_google_db.get_account.return_value = account
@@ -457,6 +445,7 @@ class TestGoogleSyncNow:
         sync_result.updated = 0
         sync_result.deleted = 0
         sync_result.errors = []
+        mock_sync_service.sync.return_value = sync_result
         mock_wodapp_client = MagicMock()
         mock_wodapp_client.get_upcoming_reservations.return_value = ([], {})
         monkeypatch.setattr(
@@ -464,8 +453,7 @@ class TestGoogleSyncNow:
             classmethod(lambda cls, s, cache=None: mock_wodapp_client),
         )
 
-        with patch("wodplanner.app.routers.google_sync.calendar_sync.sync_user", return_value=sync_result):
-            r = google_app_client.post("/google/sync", cookies={"session": session_cookie})
+        r = google_app_client.post("/google/sync", cookies={"session": session_cookie})
         assert r.status_code == 200
 
 


### PR DESCRIPTION
## Summary

- `_enqueue_google_sync()` now accepts `CalendarSyncService` instead of `schedule_service`; three call sites in views router updated
- Both `sync_user()` call sites in google_sync router replaced with `sync_service.sync()`
- Both `get_valid_token()` call sites in google_sync router replaced with `sync_service.get_valid_token()`
- No route handler assembles `enc_key` or references `calendar_sync.sync_user` / `calendar_sync.get_valid_token` directly
- Tests updated to override `get_calendar_sync_service` DI dependency instead of patching module-level functions

Closes #53

## Test plan

- [ ] `pytest` — 586 passed
- [ ] `ruff check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)