### PR TITLE
refactor: remove module-level sync_user() and get_valid_token()

### DIFF
--- a/src/wodplanner/app/main.py
+++ b/src/wodplanner/app/main.py
@@ -84,13 +84,15 @@ async def _periodic_sync_all(db_path: Path) -> None:
     """Background task: sync all users with sync_enabled every 30 minutes."""
     from wodplanner.api.client import WodAppClient
     from wodplanner.models.auth import AuthSession
-    from wodplanner.services import calendar_sync, crypto
+    from wodplanner.services import crypto
+    from wodplanner.services.calendar_sync import CalendarSyncService
     from wodplanner.services.google_accounts import GoogleAccountsService
     from wodplanner.services.schedule import ScheduleService
 
     db = GoogleAccountsService(db_path)
     schedule_service = ScheduleService(db_path)
     enc_key = crypto.get_enc_key(settings.google_token_enc_key, settings.secret_key)
+    sync_service = CalendarSyncService(db, enc_key, schedule_service)
 
     user_ids = db.get_all_sync_enabled_user_ids()
     logger.info("Periodic sync: %d user(s) with sync enabled", len(user_ids))
@@ -112,14 +114,11 @@ async def _periodic_sync_all(db_path: Path) -> None:
                 wodapp_session = AuthSession.model_validate_json(session_json)
                 client = WodAppClient.from_session(wodapp_session)
                 await asyncio.to_thread(
-                    calendar_sync.sync_user,
+                    sync_service.sync,
                     account=account,
-                    db=db,
                     client=client,
-                    enc_key=enc_key,
                     first_name=wodapp_session.firstname,
                     gym_name=wodapp_session.gym_name,
-                    schedule_service=schedule_service,
                     gym_id=wodapp_session.gym_id,
                 )
             except Exception:

--- a/src/wodplanner/services/calendar_sync.py
+++ b/src/wodplanner/services/calendar_sync.py
@@ -39,33 +39,6 @@ class SyncResult:
         return not self.errors
 
 
-def get_valid_token(
-    account: GoogleAccount,
-    db: GoogleAccountsService,
-    enc_key: bytes,
-) -> str:
-    """Return a valid access token, refreshing via refresh_token when near expiry."""
-    raw_token = crypto.decrypt(account.access_token, enc_key)
-
-    if account.token_expiry:
-        expiry = datetime.fromisoformat(account.token_expiry)
-        if datetime.now() + timedelta(minutes=5) >= expiry:
-            raw_refresh = crypto.decrypt(account.refresh_token, enc_key)
-            new_token, new_expiry = refresh_access_token(
-                raw_refresh,
-                settings.google_client_id,  # type: ignore[arg-type]
-                settings.google_client_secret,  # type: ignore[arg-type]
-            )
-            db.update_tokens(
-                account.user_id,
-                crypto.encrypt(new_token, enc_key),
-                new_expiry,
-            )
-            return new_token
-
-    return raw_token
-
-
 def _build_description(class_name: str, schedule: Schedule | None) -> str:
     parts = [f"Class: {class_name}"]
     if schedule:
@@ -192,7 +165,26 @@ class CalendarSyncService:
         self._schedule_service = schedule_service
 
     def get_valid_token(self, account: GoogleAccount) -> str:
-        return get_valid_token(account, self._db, self._enc_key)
+        """Return a valid access token, refreshing via refresh_token when near expiry."""
+        raw_token = crypto.decrypt(account.access_token, self._enc_key)
+
+        if account.token_expiry:
+            expiry = datetime.fromisoformat(account.token_expiry)
+            if datetime.now() + timedelta(minutes=5) >= expiry:
+                raw_refresh = crypto.decrypt(account.refresh_token, self._enc_key)
+                new_token, new_expiry = refresh_access_token(
+                    raw_refresh,
+                    settings.google_client_id,  # type: ignore[arg-type]
+                    settings.google_client_secret,  # type: ignore[arg-type]
+                )
+                self._db.update_tokens(
+                    account.user_id,
+                    crypto.encrypt(new_token, self._enc_key),
+                    new_expiry,
+                )
+                return new_token
+
+        return raw_token
 
     def sync(
         self,
@@ -202,149 +194,127 @@ class CalendarSyncService:
         gym_name: str,
         gym_id: int | None = None,
     ) -> SyncResult:
-        return sync_user(
-            account=account,
-            db=self._db,
-            client=client,
-            enc_key=self._enc_key,
-            first_name=first_name,
-            gym_name=gym_name,
-            schedule_service=self._schedule_service,
-            gym_id=gym_id,
+        """Full diff sync: insert new signups, update changed events, delete cancellations."""
+        result = SyncResult()
+
+        if not account.calendar_id:
+            result.errors.append("no calendar selected")
+            return result
+
+        try:
+            access_token = self.get_valid_token(account)
+        except Exception as exc:
+            logger.exception("Token refresh failed for user %d", account.user_id)
+            self._db.disable_sync(account.user_id, f"token refresh failed: {exc}")
+            result.errors.append(f"token refresh failed: {exc}")
+            return result
+
+        # Never delete events when WodApp call fails — abort and leave existing events.
+        try:
+            reservations, _ = client.get_upcoming_reservations()
+        except Exception as exc:
+            logger.exception("WodApp fetch failed for user %d", account.user_id)
+            status = f"error: WodApp fetch failed: {exc}"
+            self._db.update_sync_status(account.user_id, status)
+            result.errors.append(status)
+            return result
+
+        existing = {ev.id_appointment: ev for ev in self._db.get_synced_events(account.user_id)}
+        desired = {r["id_appointment"]: r for r in reservations}
+
+        # Recovery: rebuild mapping from Google Calendar if DB is empty but user has signups.
+        if not existing and desired:
+            existing = _rebuild_from_google(access_token, account, self._db)
+
+        now = datetime.now()
+
+        # ── Insert ────────────────────────────────────────────────────────────────
+        for appt_id, reservation in desired.items():
+            if appt_id in existing:
+                continue
+            try:
+                schedule = _lookup_schedule(self._schedule_service, reservation, gym_id)
+                event_body = _build_event(reservation, gym_name, first_name, schedule)
+                created = gcal.insert_event(access_token, account.calendar_id, event_body)
+                self._db.upsert_synced_event(
+                    user_id=account.user_id,
+                    id_appointment=appt_id,
+                    google_event_id=created["id"],
+                    calendar_id=account.calendar_id,
+                    date_start=reservation["date_start"].isoformat(),
+                    date_end=(
+                        reservation.get("date_end") or reservation["date_start"] + _DEFAULT_CLASS_DURATION
+                    ).isoformat(),
+                    name=reservation["name"],
+                    etag=created.get("etag"),
+                )
+                result.inserted += 1
+            except Exception as exc:
+                logger.warning(
+                    "Insert failed appt %d user %d: %s", appt_id, account.user_id, exc
+                )
+                result.errors.append(f"insert appt {appt_id}: {exc}")
+
+        # ── Update ────────────────────────────────────────────────────────────────
+        for appt_id, reservation in desired.items():
+            if appt_id not in existing:
+                continue
+            ev = existing[appt_id]
+            new_start = reservation["date_start"].isoformat()
+            if ev.date_start == new_start and ev.name == reservation["name"]:
+                continue
+            try:
+                schedule = _lookup_schedule(self._schedule_service, reservation, gym_id)
+                event_body = _build_event(reservation, gym_name, first_name, schedule)
+                gcal.update_event(
+                    access_token, account.calendar_id, ev.google_event_id, event_body
+                )
+                self._db.upsert_synced_event(
+                    user_id=account.user_id,
+                    id_appointment=appt_id,
+                    google_event_id=ev.google_event_id,
+                    calendar_id=account.calendar_id,
+                    date_start=new_start,
+                    date_end=(
+                        reservation.get("date_end") or reservation["date_start"] + _DEFAULT_CLASS_DURATION
+                    ).isoformat(),
+                    name=reservation["name"],
+                    etag=ev.etag,
+                )
+                result.updated += 1
+            except Exception as exc:
+                logger.warning(
+                    "Update failed appt %d user %d: %s", appt_id, account.user_id, exc
+                )
+                result.errors.append(f"update appt {appt_id}: {exc}")
+
+        # ── Delete ────────────────────────────────────────────────────────────────
+        # Only delete future events — leave past events as calendar history.
+        for appt_id, ev in existing.items():
+            if appt_id in desired:
+                continue
+            try:
+                event_start = datetime.fromisoformat(ev.date_start)
+            except ValueError:
+                continue
+            if event_start <= now:
+                # Class already started/finished — keep event for history.
+                continue
+            try:
+                gcal.delete_event(access_token, account.calendar_id, ev.google_event_id)
+                self._db.delete_synced_event(account.user_id, appt_id)
+                result.deleted += 1
+            except Exception as exc:
+                logger.warning(
+                    "Delete failed appt %d user %d: %s", appt_id, account.user_id, exc
+                )
+                result.errors.append(f"delete appt {appt_id}: {exc}")
+
+        status = "ok" if result.ok else f"partial errors: {'; '.join(result.errors[:3])}"
+        self._db.update_sync_status(account.user_id, status)
+        logger.info(
+            "Sync user %d: +%d ~%d -%d errors=%s (desired=%d existing=%d)",
+            account.user_id, result.inserted, result.updated, result.deleted,
+            result.errors or "none", len(desired), len(existing),
         )
-
-
-def sync_user(
-    account: GoogleAccount,
-    db: GoogleAccountsService,
-    client: WodAppClient,
-    enc_key: bytes,
-    first_name: str,
-    gym_name: str,
-    schedule_service: ScheduleService | None = None,
-    gym_id: int | None = None,
-) -> SyncResult:
-    """Full diff sync: insert new signups, update changed events, delete cancellations."""
-    result = SyncResult()
-
-    if not account.calendar_id:
-        result.errors.append("no calendar selected")
         return result
-
-    try:
-        access_token = get_valid_token(account, db, enc_key)
-    except Exception as exc:
-        logger.exception("Token refresh failed for user %d", account.user_id)
-        db.disable_sync(account.user_id, f"token refresh failed: {exc}")
-        result.errors.append(f"token refresh failed: {exc}")
-        return result
-
-    # Never delete events when WodApp call fails — abort and leave existing events.
-    try:
-        reservations, _ = client.get_upcoming_reservations()
-    except Exception as exc:
-        logger.exception("WodApp fetch failed for user %d", account.user_id)
-        status = f"error: WodApp fetch failed: {exc}"
-        db.update_sync_status(account.user_id, status)
-        result.errors.append(status)
-        return result
-
-    existing = {ev.id_appointment: ev for ev in db.get_synced_events(account.user_id)}
-    desired = {r["id_appointment"]: r for r in reservations}
-
-    # Recovery: rebuild mapping from Google Calendar if DB is empty but user has signups.
-    if not existing and desired:
-        existing = _rebuild_from_google(access_token, account, db)
-
-    now = datetime.now()
-
-    # ── Insert ────────────────────────────────────────────────────────────────
-    for appt_id, reservation in desired.items():
-        if appt_id in existing:
-            continue
-        try:
-            schedule = _lookup_schedule(schedule_service, reservation, gym_id)
-            event_body = _build_event(reservation, gym_name, first_name, schedule)
-            created = gcal.insert_event(access_token, account.calendar_id, event_body)
-            db.upsert_synced_event(
-                user_id=account.user_id,
-                id_appointment=appt_id,
-                google_event_id=created["id"],
-                calendar_id=account.calendar_id,
-                date_start=reservation["date_start"].isoformat(),
-                date_end=(
-                    reservation.get("date_end") or reservation["date_start"] + _DEFAULT_CLASS_DURATION
-                ).isoformat(),
-                name=reservation["name"],
-                etag=created.get("etag"),
-            )
-            result.inserted += 1
-        except Exception as exc:
-            logger.warning(
-                "Insert failed appt %d user %d: %s", appt_id, account.user_id, exc
-            )
-            result.errors.append(f"insert appt {appt_id}: {exc}")
-
-    # ── Update ────────────────────────────────────────────────────────────────
-    for appt_id, reservation in desired.items():
-        if appt_id not in existing:
-            continue
-        ev = existing[appt_id]
-        new_start = reservation["date_start"].isoformat()
-        if ev.date_start == new_start and ev.name == reservation["name"]:
-            continue
-        try:
-            schedule = _lookup_schedule(schedule_service, reservation, gym_id)
-            event_body = _build_event(reservation, gym_name, first_name, schedule)
-            gcal.update_event(
-                access_token, account.calendar_id, ev.google_event_id, event_body
-            )
-            db.upsert_synced_event(
-                user_id=account.user_id,
-                id_appointment=appt_id,
-                google_event_id=ev.google_event_id,
-                calendar_id=account.calendar_id,
-                date_start=new_start,
-                date_end=(
-                    reservation.get("date_end") or reservation["date_start"] + _DEFAULT_CLASS_DURATION
-                ).isoformat(),
-                name=reservation["name"],
-                etag=ev.etag,
-            )
-            result.updated += 1
-        except Exception as exc:
-            logger.warning(
-                "Update failed appt %d user %d: %s", appt_id, account.user_id, exc
-            )
-            result.errors.append(f"update appt {appt_id}: {exc}")
-
-    # ── Delete ────────────────────────────────────────────────────────────────
-    # Only delete future events — leave past events as calendar history.
-    for appt_id, ev in existing.items():
-        if appt_id in desired:
-            continue
-        try:
-            event_start = datetime.fromisoformat(ev.date_start)
-        except ValueError:
-            continue
-        if event_start <= now:
-            # Class already started/finished — keep event for history.
-            continue
-        try:
-            gcal.delete_event(access_token, account.calendar_id, ev.google_event_id)
-            db.delete_synced_event(account.user_id, appt_id)
-            result.deleted += 1
-        except Exception as exc:
-            logger.warning(
-                "Delete failed appt %d user %d: %s", appt_id, account.user_id, exc
-            )
-            result.errors.append(f"delete appt {appt_id}: {exc}")
-
-    status = "ok" if result.ok else f"partial errors: {'; '.join(result.errors[:3])}"
-    db.update_sync_status(account.user_id, status)
-    logger.info(
-        "Sync user %d: +%d ~%d -%d errors=%s (desired=%d existing=%d)",
-        account.user_id, result.inserted, result.updated, result.deleted,
-        result.errors or "none", len(desired), len(existing),
-    )
-    return result

--- a/tests/services/test_calendar_sync.py
+++ b/tests/services/test_calendar_sync.py
@@ -267,7 +267,7 @@ class TestSyncUser:
     def test_error_when_token_refresh_fails(self):
         account = _make_account()
         db = _make_db()
-        with patch("wodplanner.services.calendar_sync.get_valid_token", side_effect=Exception("token error")):
+        with patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", side_effect=Exception("token error")):
             result = _make_service(db).sync(account, _make_client(), "Alice", "Box")
         assert not result.ok
         assert "token refresh failed" in result.errors[0]
@@ -278,7 +278,7 @@ class TestSyncUser:
         db = _make_db()
         client = MagicMock()
         client.get_upcoming_reservations.side_effect = Exception("API is down")
-        with patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"):
+        with patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"):
             result = _make_service(db).sync(account, client, "Alice", "Box")
         assert not result.ok
         assert "WodApp fetch failed" in result.errors[0]
@@ -290,7 +290,7 @@ class TestSyncUser:
         client = _make_client([reservation])
 
         with (
-            patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"),
+            patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"),
             patch("wodplanner.services.calendar_sync.gcal.insert_event", return_value={"id": "gev1"}),
         ):
             result = _make_service(db).sync(account, client, "Alice", "Box")
@@ -309,7 +309,7 @@ class TestSyncUser:
         client = _make_client([reservation])
 
         with (
-            patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"),
+            patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"),
             patch("wodplanner.services.calendar_sync.gcal.insert_event", return_value={"id": "gev1"}),
         ):
             result = _make_service(db).sync(account, client, "Alice", "Box")
@@ -324,7 +324,7 @@ class TestSyncUser:
         client = _make_client([reservation])
 
         with (
-            patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"),
+            patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"),
             patch("wodplanner.services.calendar_sync.gcal.update_event", return_value={}),
         ):
             result = _make_service(db).sync(account, client, "Alice", "Box")
@@ -342,7 +342,7 @@ class TestSyncUser:
         client = _make_client([reservation])
 
         with (
-            patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"),
+            patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"),
             patch("wodplanner.services.calendar_sync.gcal.update_event", return_value={}),
         ):
             result = _make_service(db).sync(account, client, "Alice", "Box")
@@ -357,7 +357,7 @@ class TestSyncUser:
         reservation = _make_reservation(appt_id=1, name="CrossFit", date_start=start)
         client = _make_client([reservation])
 
-        with patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"):
+        with patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"):
             result = _make_service(db).sync(account, client, "Alice", "Box")
 
         assert result.updated == 0
@@ -371,7 +371,7 @@ class TestSyncUser:
         client = _make_client([])
 
         with (
-            patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"),
+            patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"),
             patch("wodplanner.services.calendar_sync.gcal.delete_event"),
         ):
             result = _make_service(db).sync(account, client, "Alice", "Box")
@@ -385,7 +385,7 @@ class TestSyncUser:
         db = _make_db(synced_events=[existing_ev])
         client = _make_client([])
 
-        with patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"):
+        with patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"):
             result = _make_service(db).sync(account, client, "Alice", "Box")
 
         assert result.deleted == 0
@@ -397,7 +397,7 @@ class TestSyncUser:
         client = _make_client([reservation])
 
         with (
-            patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"),
+            patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"),
             patch("wodplanner.services.calendar_sync._rebuild_from_google", return_value={}) as mock_rebuild,
             patch("wodplanner.services.calendar_sync.gcal.insert_event", return_value={"id": "gev1"}),
         ):
@@ -411,7 +411,7 @@ class TestSyncUser:
         client = _make_client([])
 
         with (
-            patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"),
+            patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"),
             patch("wodplanner.services.calendar_sync._rebuild_from_google") as mock_rebuild,
         ):
             _make_service(db).sync(account, client, "Alice", "Box")
@@ -425,7 +425,7 @@ class TestSyncUser:
         client = _make_client([reservation])
 
         with (
-            patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"),
+            patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"),
             patch("wodplanner.services.calendar_sync.gcal.insert_event", side_effect=Exception("quota exceeded")),
         ):
             result = _make_service(db).sync(account, client, "Alice", "Box")
@@ -438,7 +438,7 @@ class TestSyncUser:
         db = _make_db()
         client = _make_client([])
 
-        with patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"):
+        with patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"):
             _make_service(db).sync(account, client, "Alice", "Box")
 
         db.update_sync_status.assert_called_once()
@@ -461,7 +461,7 @@ class TestSyncUser:
             return {"id": "gev1"}
 
         with (
-            patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"),
+            patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"),
             patch("wodplanner.services.calendar_sync.gcal.insert_event", side_effect=capture_insert),
         ):
             result = _make_service(db, schedule_service).sync(account, client, "Alice", "Box", gym_id=42)
@@ -482,7 +482,7 @@ class TestSyncUser:
             return {"id": "gev1"}
 
         with (
-            patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"),
+            patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"),
             patch("wodplanner.services.calendar_sync.gcal.insert_event", side_effect=capture_insert),
         ):
             result = _make_service(db).sync(account, client, "Alice", "Box")
@@ -506,7 +506,7 @@ class TestSyncUser:
         db = _make_db(synced_events=[ev])
         client = _make_client([])
 
-        with patch("wodplanner.services.calendar_sync.get_valid_token", return_value="token"):
+        with patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"):
             result = _make_service(db).sync(account, client, "Alice", "Box")
 
         assert result.deleted == 0


### PR DESCRIPTION
## Summary

- Inline `get_valid_token()` and `sync_user()` logic into `CalendarSyncService` methods
- Delete unused module-level functions
- Update `main.py` periodic sync to use `CalendarSyncService` directly
- Update 17 test mocks to target `CalendarSyncService.get_valid_token`

Closes #54