### PR TITLE
refactor: add get_valid_token to GoogleAccountsService

### DIFF
--- a/src/wodplanner/app/dependencies.py
+++ b/src/wodplanner/app/dependencies.py
@@ -52,7 +52,8 @@ def get_one_rep_max_service() -> OneRepMaxService:
 @lru_cache
 def get_google_accounts_service() -> GoogleAccountsService:
     """Get the singleton Google accounts service."""
-    return GoogleAccountsService(_get_db_path())
+    enc_key = crypto.get_enc_key(settings.google_token_enc_key, settings.secret_key)
+    return GoogleAccountsService(_get_db_path(), enc_key)
 
 
 @lru_cache

--- a/src/wodplanner/app/main.py
+++ b/src/wodplanner/app/main.py
@@ -89,9 +89,9 @@ async def _periodic_sync_all(db_path: Path) -> None:
     from wodplanner.services.google_accounts import GoogleAccountsService
     from wodplanner.services.schedule import ScheduleService
 
-    db = GoogleAccountsService(db_path)
-    schedule_service = ScheduleService(db_path)
     enc_key = crypto.get_enc_key(settings.google_token_enc_key, settings.secret_key)
+    db = GoogleAccountsService(db_path, enc_key)
+    schedule_service = ScheduleService(db_path)
     sync_service = CalendarSyncService(db, enc_key, schedule_service)
 
     user_ids = db.get_all_sync_enabled_user_ids()

--- a/src/wodplanner/services/google_accounts.py
+++ b/src/wodplanner/services/google_accounts.py
@@ -4,11 +4,13 @@ Version range 500-599.
 """
 
 import sqlite3
-from datetime import datetime
+from datetime import datetime, timedelta
+from pathlib import Path
 
 from wodplanner.models.google import GoogleAccount, SyncedEvent
-from wodplanner.services import migrations
+from wodplanner.services import crypto, migrations
 from wodplanner.services.base import BaseService
+from wodplanner.services.google_oauth import refresh_access_token
 
 
 def _migrate_v500(conn: sqlite3.Connection) -> None:
@@ -71,6 +73,34 @@ migrations.register(502, "add wodapp_session_enc to google_accounts", _migrate_v
 
 class GoogleAccountsService(BaseService):
     """DB service for google_accounts and synced_events tables."""
+
+    def __init__(self, db_path: str | Path = "wodplanner.db", enc_key: bytes | None = None) -> None:
+        super().__init__(db_path)
+        self._enc_key = enc_key
+
+    def get_valid_token(self, account: GoogleAccount) -> str:
+        """Return a valid access token, refreshing via refresh_token when near expiry."""
+        raw_token = crypto.decrypt(account.access_token, self._enc_key)  # type: ignore[arg-type]
+
+        if account.token_expiry:
+            expiry = datetime.fromisoformat(account.token_expiry)
+            if datetime.now() + timedelta(minutes=5) >= expiry:
+                raw_refresh = crypto.decrypt(account.refresh_token, self._enc_key)  # type: ignore[arg-type]
+                from wodplanner.app.config import settings
+
+                new_token, new_expiry = refresh_access_token(
+                    raw_refresh,
+                    settings.google_client_id,  # type: ignore[arg-type]
+                    settings.google_client_secret,  # type: ignore[arg-type]
+                )
+                self.update_tokens(
+                    account.user_id,
+                    crypto.encrypt(new_token, self._enc_key),  # type: ignore[arg-type]
+                    new_expiry,
+                )
+                return new_token
+
+        return raw_token
 
     def _row_to_account(self, row: sqlite3.Row) -> GoogleAccount:
         return GoogleAccount(

--- a/tests/services/test_google_accounts.py
+++ b/tests/services/test_google_accounts.py
@@ -1,13 +1,39 @@
 """Tests for services/google_accounts.py — DB service for Google Calendar sync state."""
 
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
 import pytest
 
+from wodplanner.models.google import GoogleAccount
 from wodplanner.services.google_accounts import GoogleAccountsService
+
+ENC_KEY = b"A" * 44  # Placeholder — crypto is mocked
+
+
+def _make_account(
+    user_id=1,
+    calendar_id="cal_id",
+    token_expiry=None,
+    access_token="enc_access",
+    refresh_token="enc_refresh",
+):
+    return GoogleAccount(
+        user_id=user_id,
+        google_email="user@gmail.com",
+        access_token=access_token,
+        refresh_token=refresh_token,
+        token_expiry=token_expiry,
+        scopes="calendar",
+        calendar_id=calendar_id,
+        sync_enabled=True,
+        created_at=datetime.now().isoformat(),
+    )
 
 
 @pytest.fixture
 def svc(db_path):
-    return GoogleAccountsService(db_path)
+    return GoogleAccountsService(db_path, ENC_KEY)
 
 
 def _insert_account(svc, user_id=1):
@@ -227,3 +253,46 @@ class TestSyncedEvents:
         )
         events = svc.get_synced_events(1)
         assert len(events) == 2
+
+
+class TestGetValidToken:
+    def test_returns_decrypted_token_when_no_expiry(self, svc):
+        _insert_account(svc)
+        account = svc.get_account(1)
+        with patch("wodplanner.services.google_accounts.crypto.decrypt", return_value="raw_token"):
+            token = svc.get_valid_token(account)
+        assert token == "raw_token"
+
+    def test_returns_decrypted_token_when_expiry_is_far_future(self, svc):
+        _insert_account(svc)
+        far_future = (datetime.now() + timedelta(hours=2)).isoformat()
+        svc.update_tokens(1, "enc_access", far_future)
+        account = svc.get_account(1)
+        with patch("wodplanner.services.google_accounts.crypto.decrypt", return_value="raw_token"):
+            token = svc.get_valid_token(account)
+        assert token == "raw_token"
+
+    def test_refreshes_when_token_near_expiry(self, svc):
+        _insert_account(svc)
+        near_expiry = (datetime.now() + timedelta(minutes=2)).isoformat()
+        svc.update_tokens(1, "enc_access", near_expiry)
+        account = svc.get_account(1)
+        with (
+            patch("wodplanner.services.google_accounts.crypto.decrypt", side_effect=["enc_access", "enc_refresh"]),
+            patch("wodplanner.services.google_accounts.refresh_access_token", return_value=("new_tok", "new_expiry")),
+            patch("wodplanner.services.google_accounts.crypto.encrypt", return_value="enc_new_tok"),
+        ):
+            token = svc.get_valid_token(account)
+        assert token == "new_tok"
+
+    def test_no_refresh_when_not_near_expiry(self, svc):
+        _insert_account(svc)
+        far_future = (datetime.now() + timedelta(hours=2)).isoformat()
+        svc.update_tokens(1, "enc_access", far_future)
+        account = svc.get_account(1)
+        call_count = [0]
+        original = svc.update_tokens
+        svc.update_tokens = lambda *a, **kw: (call_count.__setitem__(0, call_count[0] + 1), original(*a, **kw))
+        with patch("wodplanner.services.google_accounts.crypto.decrypt", return_value="raw_token"):
+            svc.get_valid_token(account)
+        assert call_count[0] == 0


### PR DESCRIPTION
## Summary

- Adds token lifecycle management to `GoogleAccountsService` — it now accepts `enc_key: bytes` and provides `get_valid_token(account) -> str`
- `get_valid_token` decrypts the stored access token, checks expiry with a 5-minute buffer, refreshes via OAuth when near expiry, persists the new encrypted token, and returns a plaintext token
- All construction sites updated to pass `enc_key` (dependency factory in `dependencies.py`, periodic sync task in `main.py`)
- `TestGetValidToken` class added to `test_google_accounts.py` covering: no expiry, far-future expiry, near-expiry refresh, no refresh when not near expiry

## Changes

- **`src/wodplanner/services/google_accounts.py`** — `enc_key` constructor param, `get_valid_token()` method
- **`src/wodplanner/app/dependencies.py`** — derive and pass `enc_key` at construction
- **`src/wodplanner/app/main.py`** — pass `enc_key` to `GoogleAccountsService` in periodic sync
- **`tests/services/test_google_accounts.py`** — fixture updated, `TestGetValidToken` with 4 tests

## Notes

`CalendarSyncService` is unchanged by this slice — it still has its own `get_valid_token`. Full delegation and removal of duplication from `CalendarSyncService` is the next slice.