### PR TITLE
refactor: migrate CalendarSyncService off get_valid_token

### DIFF
--- a/src/wodplanner/app/dependencies.py
+++ b/src/wodplanner/app/dependencies.py
@@ -59,10 +59,8 @@ def get_google_accounts_service() -> GoogleAccountsService:
 @lru_cache
 def get_calendar_sync_service() -> CalendarSyncService:
     """Get the singleton calendar sync service."""
-    enc_key = crypto.get_enc_key(settings.google_token_enc_key, settings.secret_key)
     return CalendarSyncService(
         db=get_google_accounts_service(),
-        enc_key=enc_key,
         schedule_service=get_schedule_service(),
     )
 

--- a/src/wodplanner/app/main.py
+++ b/src/wodplanner/app/main.py
@@ -92,7 +92,7 @@ async def _periodic_sync_all(db_path: Path) -> None:
     enc_key = crypto.get_enc_key(settings.google_token_enc_key, settings.secret_key)
     db = GoogleAccountsService(db_path, enc_key)
     schedule_service = ScheduleService(db_path)
-    sync_service = CalendarSyncService(db, enc_key, schedule_service)
+    sync_service = CalendarSyncService(db, schedule_service)
 
     user_ids = db.get_all_sync_enabled_user_ids()
     logger.info("Periodic sync: %d user(s) with sync enabled", len(user_ids))

--- a/src/wodplanner/app/routers/google_sync.py
+++ b/src/wodplanner/app/routers/google_sync.py
@@ -205,7 +205,6 @@ def google_calendars(
     request: Request,
     session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
     db: GoogleAccountsService = Depends(get_google_accounts_service),
-    sync_service: CalendarSyncService = Depends(get_calendar_sync_service),
 ):
     """HTMX partial: list user's Google Calendars for calendar picker."""
     account = db.get_account(session.user_id)
@@ -213,7 +212,7 @@ def google_calendars(
         raise HTTPException(status_code=400, detail="Not connected to Google")
 
     try:
-        access_token = sync_service.get_valid_token(account)
+        access_token = db.get_valid_token(account)
         calendars = gcal.list_calendars(access_token)
     except Exception:
         logger.exception("Failed to list calendars for user %d", session.user_id)
@@ -241,7 +240,7 @@ def google_calendar_select(
         raise HTTPException(status_code=400, detail="Not connected to Google")
 
     try:
-        access_token = sync_service.get_valid_token(account)
+        access_token = db.get_valid_token(account)
     except Exception:
         logger.exception("Token refresh failed for user %d", session.user_id)
         return _render(

--- a/src/wodplanner/services/calendar_sync.py
+++ b/src/wodplanner/services/calendar_sync.py
@@ -10,13 +10,10 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 
 from wodplanner.api.client import WodAppClient
-from wodplanner.app.config import settings
 from wodplanner.models.google import GoogleAccount, SyncedEvent
 from wodplanner.models.schedule import Schedule
-from wodplanner.services import crypto
 from wodplanner.services import google_calendar as gcal
 from wodplanner.services.google_accounts import GoogleAccountsService
-from wodplanner.services.google_oauth import refresh_access_token
 from wodplanner.services.schedule import ScheduleService
 
 logger = logging.getLogger(__name__)
@@ -157,34 +154,10 @@ class CalendarSyncService:
     def __init__(
         self,
         db: GoogleAccountsService,
-        enc_key: bytes,
         schedule_service: ScheduleService | None = None,
     ) -> None:
         self._db = db
-        self._enc_key = enc_key
         self._schedule_service = schedule_service
-
-    def get_valid_token(self, account: GoogleAccount) -> str:
-        """Return a valid access token, refreshing via refresh_token when near expiry."""
-        raw_token = crypto.decrypt(account.access_token, self._enc_key)
-
-        if account.token_expiry:
-            expiry = datetime.fromisoformat(account.token_expiry)
-            if datetime.now() + timedelta(minutes=5) >= expiry:
-                raw_refresh = crypto.decrypt(account.refresh_token, self._enc_key)
-                new_token, new_expiry = refresh_access_token(
-                    raw_refresh,
-                    settings.google_client_id,  # type: ignore[arg-type]
-                    settings.google_client_secret,  # type: ignore[arg-type]
-                )
-                self._db.update_tokens(
-                    account.user_id,
-                    crypto.encrypt(new_token, self._enc_key),
-                    new_expiry,
-                )
-                return new_token
-
-        return raw_token
 
     def sync(
         self,
@@ -202,7 +175,7 @@ class CalendarSyncService:
             return result
 
         try:
-            access_token = self.get_valid_token(account)
+            access_token = self._db.get_valid_token(account)
         except Exception as exc:
             logger.exception("Token refresh failed for user %d", account.user_id)
             self._db.disable_sync(account.user_id, f"token refresh failed: {exc}")

--- a/tests/services/test_calendar_sync.py
+++ b/tests/services/test_calendar_sync.py
@@ -64,11 +64,8 @@ def _make_synced_event(appt_id=1, google_event_id="gev1", date_start=None, name=
     )
 
 
-ENC_KEY = b"A" * 44  # Placeholder — crypto is mocked
-
-
 def _make_service(db=None, schedule_service=None):
-    return CalendarSyncService(db or _make_db(), ENC_KEY, schedule_service)
+    return CalendarSyncService(db or _make_db(), schedule_service)
 
 
 class TestSyncResult:
@@ -83,46 +80,6 @@ class TestSyncResult:
         assert r.inserted == 0
         assert r.updated == 0
         assert r.deleted == 0
-
-
-class TestGetValidToken:
-    def test_returns_decrypted_token_when_no_expiry(self):
-        account = _make_account(token_expiry=None)
-        service = CalendarSyncService(_make_db(), ENC_KEY)
-        with patch("wodplanner.services.calendar_sync.crypto.decrypt", return_value="raw_token"):
-            token = service.get_valid_token(account)
-        assert token == "raw_token"
-
-    def test_returns_decrypted_token_when_expiry_is_far_future(self):
-        far_future = (datetime.now() + timedelta(hours=2)).isoformat()
-        account = _make_account(token_expiry=far_future)
-        service = CalendarSyncService(_make_db(), ENC_KEY)
-        with patch("wodplanner.services.calendar_sync.crypto.decrypt", return_value="raw_token"):
-            token = service.get_valid_token(account)
-        assert token == "raw_token"
-
-    def test_refreshes_when_token_near_expiry(self):
-        near_expiry = (datetime.now() + timedelta(minutes=2)).isoformat()
-        account = _make_account(token_expiry=near_expiry)
-        db = _make_db()
-        service = CalendarSyncService(db, ENC_KEY)
-        with (
-            patch("wodplanner.services.calendar_sync.crypto.decrypt", side_effect=["enc_access", "enc_refresh"]),
-            patch("wodplanner.services.calendar_sync.refresh_access_token", return_value=("new_tok", "new_expiry")),
-            patch("wodplanner.services.calendar_sync.crypto.encrypt", return_value="enc_new_tok"),
-        ):
-            token = service.get_valid_token(account)
-        assert token == "new_tok"
-        db.update_tokens.assert_called_once()
-
-    def test_no_refresh_when_not_near_expiry(self):
-        far_future = (datetime.now() + timedelta(hours=2)).isoformat()
-        account = _make_account(token_expiry=far_future)
-        db = _make_db()
-        service = CalendarSyncService(db, ENC_KEY)
-        with patch("wodplanner.services.calendar_sync.crypto.decrypt", return_value="raw_token"):
-            service.get_valid_token(account)
-        db.update_tokens.assert_not_called()
 
 
 def _make_schedule(warmup=None, strength=None, metcon=None):
@@ -267,8 +224,8 @@ class TestSyncUser:
     def test_error_when_token_refresh_fails(self):
         account = _make_account()
         db = _make_db()
-        with patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", side_effect=Exception("token error")):
-            result = _make_service(db).sync(account, _make_client(), "Alice", "Box")
+        db.get_valid_token.side_effect = Exception("token error")
+        result = _make_service(db).sync(account, _make_client(), "Alice", "Box")
         assert not result.ok
         assert "token refresh failed" in result.errors[0]
         db.disable_sync.assert_called_once_with(1, "token refresh failed: token error")
@@ -276,23 +233,21 @@ class TestSyncUser:
     def test_error_when_wodapp_api_fails(self):
         account = _make_account()
         db = _make_db()
+        db.get_valid_token.return_value = "token"
         client = MagicMock()
         client.get_upcoming_reservations.side_effect = Exception("API is down")
-        with patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"):
-            result = _make_service(db).sync(account, client, "Alice", "Box")
+        result = _make_service(db).sync(account, client, "Alice", "Box")
         assert not result.ok
         assert "WodApp fetch failed" in result.errors[0]
 
     def test_inserts_new_reservation(self):
         account = _make_account()
         db = _make_db()
+        db.get_valid_token.return_value = "token"
         reservation = _make_reservation(appt_id=1, date_start=datetime(2026, 5, 1, 10, 0))
         client = _make_client([reservation])
 
-        with (
-            patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"),
-            patch("wodplanner.services.calendar_sync.gcal.insert_event", return_value={"id": "gev1"}),
-        ):
+        with patch("wodplanner.services.calendar_sync.gcal.insert_event", return_value={"id": "gev1"}):
             result = _make_service(db).sync(account, client, "Alice", "Box")
 
         assert result.inserted == 1
@@ -303,15 +258,13 @@ class TestSyncUser:
     def test_inserts_reservation_with_date_end(self):
         account = _make_account()
         db = _make_db()
+        db.get_valid_token.return_value = "token"
         start = datetime(2026, 5, 1, 10, 0)
         end = datetime(2026, 5, 1, 11, 30)
         reservation = _make_reservation(appt_id=1, date_start=start, date_end=end)
         client = _make_client([reservation])
 
-        with (
-            patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"),
-            patch("wodplanner.services.calendar_sync.gcal.insert_event", return_value={"id": "gev1"}),
-        ):
+        with patch("wodplanner.services.calendar_sync.gcal.insert_event", return_value={"id": "gev1"}):
             result = _make_service(db).sync(account, client, "Alice", "Box")
 
         assert result.inserted == 1
@@ -320,13 +273,11 @@ class TestSyncUser:
         account = _make_account()
         existing_ev = _make_synced_event(appt_id=1, name="CrossFit")
         db = _make_db(synced_events=[existing_ev])
+        db.get_valid_token.return_value = "token"
         reservation = _make_reservation(appt_id=1, name="Gymnastics", date_start=datetime(2026, 5, 1, 10, 0))
         client = _make_client([reservation])
 
-        with (
-            patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"),
-            patch("wodplanner.services.calendar_sync.gcal.update_event", return_value={}),
-        ):
+        with patch("wodplanner.services.calendar_sync.gcal.update_event", return_value={}):
             result = _make_service(db).sync(account, client, "Alice", "Box")
 
         assert result.updated == 1
@@ -338,13 +289,11 @@ class TestSyncUser:
         new_start = datetime(2026, 5, 1, 11, 0)
         existing_ev = _make_synced_event(appt_id=1, date_start=old_start, name="CrossFit")
         db = _make_db(synced_events=[existing_ev])
+        db.get_valid_token.return_value = "token"
         reservation = _make_reservation(appt_id=1, name="CrossFit", date_start=new_start)
         client = _make_client([reservation])
 
-        with (
-            patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"),
-            patch("wodplanner.services.calendar_sync.gcal.update_event", return_value={}),
-        ):
+        with patch("wodplanner.services.calendar_sync.gcal.update_event", return_value={}):
             result = _make_service(db).sync(account, client, "Alice", "Box")
 
         assert result.updated == 1
@@ -354,11 +303,11 @@ class TestSyncUser:
         start = datetime(2026, 5, 1, 10, 0)
         existing_ev = _make_synced_event(appt_id=1, date_start=start, name="CrossFit")
         db = _make_db(synced_events=[existing_ev])
+        db.get_valid_token.return_value = "token"
         reservation = _make_reservation(appt_id=1, name="CrossFit", date_start=start)
         client = _make_client([reservation])
 
-        with patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"):
-            result = _make_service(db).sync(account, client, "Alice", "Box")
+        result = _make_service(db).sync(account, client, "Alice", "Box")
 
         assert result.updated == 0
         assert result.inserted == 0
@@ -368,12 +317,10 @@ class TestSyncUser:
         future_start = datetime.now() + timedelta(days=3)
         existing_ev = _make_synced_event(appt_id=99, date_start=future_start, name="CrossFit")
         db = _make_db(synced_events=[existing_ev])
+        db.get_valid_token.return_value = "token"
         client = _make_client([])
 
-        with (
-            patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"),
-            patch("wodplanner.services.calendar_sync.gcal.delete_event"),
-        ):
+        with patch("wodplanner.services.calendar_sync.gcal.delete_event"):
             result = _make_service(db).sync(account, client, "Alice", "Box")
 
         assert result.deleted == 1
@@ -383,21 +330,21 @@ class TestSyncUser:
         past_start = datetime.now() - timedelta(days=1)
         existing_ev = _make_synced_event(appt_id=99, date_start=past_start, name="CrossFit")
         db = _make_db(synced_events=[existing_ev])
+        db.get_valid_token.return_value = "token"
         client = _make_client([])
 
-        with patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"):
-            result = _make_service(db).sync(account, client, "Alice", "Box")
+        result = _make_service(db).sync(account, client, "Alice", "Box")
 
         assert result.deleted == 0
 
     def test_triggers_recovery_when_db_empty_but_reservations_exist(self):
         account = _make_account()
         db = _make_db(synced_events=[])
+        db.get_valid_token.return_value = "token"
         reservation = _make_reservation(appt_id=1, date_start=datetime(2026, 5, 1, 10, 0))
         client = _make_client([reservation])
 
         with (
-            patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"),
             patch("wodplanner.services.calendar_sync._rebuild_from_google", return_value={}) as mock_rebuild,
             patch("wodplanner.services.calendar_sync.gcal.insert_event", return_value={"id": "gev1"}),
         ):
@@ -408,12 +355,10 @@ class TestSyncUser:
     def test_no_recovery_when_db_and_reservations_both_empty(self):
         account = _make_account()
         db = _make_db(synced_events=[])
+        db.get_valid_token.return_value = "token"
         client = _make_client([])
 
-        with (
-            patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"),
-            patch("wodplanner.services.calendar_sync._rebuild_from_google") as mock_rebuild,
-        ):
+        with patch("wodplanner.services.calendar_sync._rebuild_from_google") as mock_rebuild:
             _make_service(db).sync(account, client, "Alice", "Box")
 
         mock_rebuild.assert_not_called()
@@ -421,13 +366,11 @@ class TestSyncUser:
     def test_insert_error_logged_in_result(self):
         account = _make_account()
         db = _make_db()
+        db.get_valid_token.return_value = "token"
         reservation = _make_reservation(appt_id=1, date_start=datetime(2026, 5, 1, 10, 0))
         client = _make_client([reservation])
 
-        with (
-            patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"),
-            patch("wodplanner.services.calendar_sync.gcal.insert_event", side_effect=Exception("quota exceeded")),
-        ):
+        with patch("wodplanner.services.calendar_sync.gcal.insert_event", side_effect=Exception("quota exceeded")):
             result = _make_service(db).sync(account, client, "Alice", "Box")
 
         assert not result.ok
@@ -436,10 +379,10 @@ class TestSyncUser:
     def test_sync_status_written_at_end(self):
         account = _make_account()
         db = _make_db()
+        db.get_valid_token.return_value = "token"
         client = _make_client([])
 
-        with patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"):
-            _make_service(db).sync(account, client, "Alice", "Box")
+        _make_service(db).sync(account, client, "Alice", "Box")
 
         db.update_sync_status.assert_called_once()
         call_args = db.update_sync_status.call_args[0]
@@ -449,6 +392,7 @@ class TestSyncUser:
     def test_inserts_with_schedule_exercises_in_description(self):
         account = _make_account()
         db = _make_db()
+        db.get_valid_token.return_value = "token"
         reservation = _make_reservation(appt_id=1, name="CrossFit", date_start=datetime(2026, 5, 1, 10, 0))
         client = _make_client([reservation])
         schedule = _make_schedule(metcon="AMRAP 10: 5 pull-ups")
@@ -460,10 +404,7 @@ class TestSyncUser:
             inserted_events.append(event_body)
             return {"id": "gev1"}
 
-        with (
-            patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"),
-            patch("wodplanner.services.calendar_sync.gcal.insert_event", side_effect=capture_insert),
-        ):
+        with patch("wodplanner.services.calendar_sync.gcal.insert_event", side_effect=capture_insert):
             result = _make_service(db, schedule_service).sync(account, client, "Alice", "Box", gym_id=42)
 
         assert result.inserted == 1
@@ -473,6 +414,7 @@ class TestSyncUser:
     def test_inserts_without_schedule_when_none_provided(self):
         account = _make_account()
         db = _make_db()
+        db.get_valid_token.return_value = "token"
         reservation = _make_reservation(appt_id=1, name="CrossFit", date_start=datetime(2026, 5, 1, 10, 0))
         client = _make_client([reservation])
         inserted_events = []
@@ -481,10 +423,7 @@ class TestSyncUser:
             inserted_events.append(event_body)
             return {"id": "gev1"}
 
-        with (
-            patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"),
-            patch("wodplanner.services.calendar_sync.gcal.insert_event", side_effect=capture_insert),
-        ):
+        with patch("wodplanner.services.calendar_sync.gcal.insert_event", side_effect=capture_insert):
             result = _make_service(db).sync(account, client, "Alice", "Box")
 
         assert result.inserted == 1
@@ -504,9 +443,9 @@ class TestSyncUser:
             synced_at=datetime.now().isoformat(),
         )
         db = _make_db(synced_events=[ev])
+        db.get_valid_token.return_value = "token"
         client = _make_client([])
 
-        with patch("wodplanner.services.calendar_sync.CalendarSyncService.get_valid_token", return_value="token"):
-            result = _make_service(db).sync(account, client, "Alice", "Box")
+        result = _make_service(db).sync(account, client, "Alice", "Box")
 
         assert result.deleted == 0


### PR DESCRIPTION
## Summary

- Remove `enc_key` parameter and `get_valid_token()` method from `CalendarSyncService` — token lifecycle now owned entirely by `GoogleAccountsService`
- Update all call sites: dependency factory, periodic sync task, router routes
- Clean up unused imports (`crypto`, `refresh_access_token`, `settings`) from `calendar_sync.py`

## Changes

| File | Change |
|------|--------|
| `services/calendar_sync.py` | Drop `enc_key` from `__init__`, remove `get_valid_token()`, delegate to `self._db.get_valid_token()` in `sync()`, remove 3 unused imports |
| `app/dependencies.py` | Stop deriving/passing `enc_key` in `get_calendar_sync_service()` |
| `app/main.py` | Construct `CalendarSyncService` without `enc_key` in periodic sync |
| `app/routers/google_sync.py` | Calendar-listing route calls `db.get_valid_token()` directly and drops `CalendarSyncService` dependency; calendar-select route also uses `db.get_valid_token()` |
| `tests/services/test_calendar_sync.py` | Remove `TestGetValidToken` class, `ENC_KEY` constant, update `_make_service()`, replace method patches with mock db configuration |

## Verification

- 553 tests pass (full suite)
- Lint clean (`ruff check`)

Closes #61