### PR TITLE
refactor: make session required in SubscriptionService.act()

### DIFF
--- a/src/wodplanner/services/subscription.py
+++ b/src/wodplanner/services/subscription.py
@@ -1,0 +1,87 @@
+"""SubscriptionService — compose WodApp Sign Up + Google Calendar Sync."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from fastapi import BackgroundTasks
+
+from wodplanner.api.client import WodAppClient
+
+if TYPE_CHECKING:
+    from wodplanner.models.auth import AuthSession
+    from wodplanner.services.calendar_sync import CalendarSyncService
+    from wodplanner.services.google_accounts import GoogleAccountsService
+
+
+logger = logging.getLogger(__name__)
+
+
+class SubscribeAction(str, Enum):
+    SUBSCRIBE = "subscribe"
+    WAITLIST = "waitinglist"
+    UNSUBSCRIBE = "unsubscribe"
+    UNSUBSCRIBE_WAITLIST = "unsubscribe_waitinglist"
+
+
+class SubscriptionService:
+    """Composes WodApp subscription API call + Google Calendar sync enqueue."""
+
+    def __init__(
+        self,
+        client: WodAppClient,
+        google_db: GoogleAccountsService,
+        sync_service: CalendarSyncService,
+    ) -> None:
+        self._client = client
+        self._google_db = google_db
+        self._sync_service = sync_service
+
+    def act(
+        self,
+        appointment_id: int,
+        start: datetime,
+        end: datetime,
+        action: SubscribeAction,
+        background_tasks: BackgroundTasks,
+        session: AuthSession,
+    ) -> None:
+        """Execute subscription action and enqueue calendar sync if applicable."""
+        self._dispatch(appointment_id, start, end, action)
+        self._enqueue_sync(background_tasks, session)
+
+    def _dispatch(
+        self,
+        appointment_id: int,
+        start: datetime,
+        end: datetime,
+        action: SubscribeAction,
+    ) -> None:
+        dispatch_map = {
+            SubscribeAction.SUBSCRIBE: self._client.subscribe,
+            SubscribeAction.WAITLIST: self._client.subscribe_waitinglist,
+            SubscribeAction.UNSUBSCRIBE: self._client.unsubscribe,
+            SubscribeAction.UNSUBSCRIBE_WAITLIST: self._client.unsubscribe_waitinglist,
+        }
+        handler = dispatch_map[action]
+        handler(appointment_id, start, end)
+
+    def _enqueue_sync(
+        self,
+        background_tasks: BackgroundTasks,
+        session: AuthSession,
+    ) -> None:
+        account = self._google_db.get_account(session.user_id)
+        if not account or not account.sync_enabled or not account.calendar_id:
+            return
+        background_tasks.add_task(
+            self._sync_service.sync,
+            account=account,
+            client=self._client,
+            first_name=session.firstname,
+            gym_name=session.gym_name,
+            gym_id=session.gym_id,
+        )

--- a/tests/services/test_subscription.py
+++ b/tests/services/test_subscription.py
@@ -1,0 +1,208 @@
+"""Tests for SubscriptionService — compose Sign Up + Google Calendar Sync."""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from wodplanner.api.client import WodAppClient
+from wodplanner.models.auth import AuthSession
+
+
+class TestSubscribeActionDispatch:
+    """Each SubscribeAction dispatches the correct WodAppClient method."""
+
+    @pytest.fixture
+    def client(self):
+        return MagicMock(spec=WodAppClient)
+
+    @pytest.fixture
+    def background_tasks(self):
+        bt = MagicMock()
+        # Prevent real task scheduling side effects
+        bt.add_task = MagicMock()
+        return bt
+
+    @pytest.fixture
+    def google_db(self):
+        db = MagicMock()
+        db.get_account.return_value = None  # no sync account
+        return db
+
+    @pytest.fixture
+    def sync_service(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def auth_session(self) -> AuthSession:
+        return AuthSession(
+            token="test_token",
+            user_id=42,
+            appuser_id=4242,
+            username="user@example.com",
+            firstname="User",
+            gym_id=100,
+            gym_name="Test Gym",
+            agenda_id=5,
+        )
+
+    def test_subscribe_action(self, client, background_tasks, google_db, sync_service, auth_session):
+        from wodplanner.services.subscription import SubscribeAction, SubscriptionService
+
+        service = SubscriptionService(
+            client=client,
+            google_db=google_db,
+            sync_service=sync_service,
+        )
+        start = datetime(2026, 4, 25, 10, 0)
+        end = datetime(2026, 4, 25, 11, 0)
+
+        service.act(appointment_id=1, start=start, end=end, action=SubscribeAction.SUBSCRIBE, background_tasks=background_tasks, session=auth_session)
+
+        client.subscribe.assert_called_once_with(1, start, end)
+        # sync skipped: google_db.get_account returns None
+        background_tasks.add_task.assert_not_called()
+
+    def test_waitinglist_action(self, client, background_tasks, google_db, sync_service, auth_session):
+        from wodplanner.services.subscription import SubscribeAction, SubscriptionService
+
+        service = SubscriptionService(
+            client=client,
+            google_db=google_db,
+            sync_service=sync_service,
+        )
+        start = datetime(2026, 4, 25, 10, 0)
+        end = datetime(2026, 4, 25, 11, 0)
+
+        service.act(appointment_id=1, start=start, end=end, action=SubscribeAction.WAITLIST, background_tasks=background_tasks, session=auth_session)
+
+        client.subscribe_waitinglist.assert_called_once_with(1, start, end)
+        # sync skipped: google_db.get_account returns None
+        background_tasks.add_task.assert_not_called()
+
+    def test_unsubscribe_action(self, client, background_tasks, google_db, sync_service, auth_session):
+        from wodplanner.services.subscription import SubscribeAction, SubscriptionService
+
+        service = SubscriptionService(
+            client=client,
+            google_db=google_db,
+            sync_service=sync_service,
+        )
+        start = datetime(2026, 4, 25, 10, 0)
+        end = datetime(2026, 4, 25, 11, 0)
+
+        service.act(appointment_id=1, start=start, end=end, action=SubscribeAction.UNSUBSCRIBE, background_tasks=background_tasks, session=auth_session)
+
+        client.unsubscribe.assert_called_once_with(1, start, end)
+        # sync skipped: google_db.get_account returns None
+        background_tasks.add_task.assert_not_called()
+
+    def test_unsubscribe_waitinglist_action(self, client, background_tasks, google_db, sync_service, auth_session):
+        from wodplanner.services.subscription import SubscribeAction, SubscriptionService
+
+        service = SubscriptionService(
+            client=client,
+            google_db=google_db,
+            sync_service=sync_service,
+        )
+        start = datetime(2026, 4, 25, 10, 0)
+        end = datetime(2026, 4, 25, 11, 0)
+
+        service.act(appointment_id=1, start=start, end=end, action=SubscribeAction.UNSUBSCRIBE_WAITLIST, background_tasks=background_tasks, session=auth_session)
+
+        client.unsubscribe_waitinglist.assert_called_once_with(1, start, end)
+        # sync skipped: google_db.get_account returns None
+        background_tasks.add_task.assert_not_called()
+
+
+class TestSyncEnqueue:
+    """Calendar sync is enqueued exactly once when account exists and enabled."""
+
+    @pytest.fixture
+    def client(self):
+        return MagicMock(spec=WodAppClient)
+
+    @pytest.fixture
+    def background_tasks(self):
+        bt = MagicMock()
+        bt.add_task = MagicMock()
+        return bt
+
+    @pytest.fixture
+    def sync_account(self, auth_session):
+        """Mock GoogleAccount with sync enabled."""
+        account = MagicMock()
+        account.sync_enabled = True
+        account.calendar_id = "primary"
+        return account
+
+    @pytest.fixture
+    def google_db(self, sync_account):
+        db = MagicMock()
+        db.get_account.return_value = sync_account
+        return db
+
+    @pytest.fixture
+    def auth_session(self) -> AuthSession:
+        return AuthSession(
+            token="test_token",
+            user_id=42,
+            appuser_id=4242,
+            username="user@example.com",
+            firstname="User",
+            gym_id=100,
+            gym_name="Test Gym",
+            agenda_id=5,
+        )
+
+    def test_sync_enqueued_when_account_enabled(self, client, background_tasks, google_db, auth_session):
+        from wodplanner.services.subscription import SubscribeAction, SubscriptionService
+
+        service = SubscriptionService(
+            client=client,
+            google_db=google_db,
+            sync_service=MagicMock(),
+        )
+        start = datetime(2026, 4, 25, 10, 0)
+        end = datetime(2026, 4, 25, 11, 0)
+
+        service.act(appointment_id=1, start=start, end=end, action=SubscribeAction.SUBSCRIBE, background_tasks=background_tasks, session=auth_session)
+
+        # Verify sync was enqueued exactly once
+        background_tasks.add_task.assert_called_once()
+
+    def test_sync_not_enqueued_when_account_disabled(self, client, background_tasks, google_db, auth_session):
+        from wodplanner.services.subscription import SubscribeAction, SubscriptionService
+
+        google_db.get_account.return_value.sync_enabled = False
+
+        service = SubscriptionService(
+            client=client,
+            google_db=google_db,
+            sync_service=MagicMock(),
+        )
+        start = datetime(2026, 4, 25, 10, 0)
+        end = datetime(2026, 4, 25, 11, 0)
+
+        service.act(appointment_id=1, start=start, end=end, action=SubscribeAction.SUBSCRIBE, background_tasks=background_tasks, session=auth_session)
+
+        client.subscribe.assert_called_once()
+        background_tasks.add_task.assert_not_called()
+
+    def test_sync_not_enqueued_when_no_account(self, client, background_tasks, google_db, auth_session):
+        from wodplanner.services.subscription import SubscribeAction, SubscriptionService
+
+        google_db.get_account.return_value = None
+
+        service = SubscriptionService(
+            client=client,
+            google_db=google_db,
+            sync_service=MagicMock(),
+        )
+        start = datetime(2026, 4, 25, 10, 0)
+        end = datetime(2026, 4, 25, 11, 0)
+
+        service.act(appointment_id=1, start=start, end=end, action=SubscribeAction.SUBSCRIBE, background_tasks=background_tasks, session=auth_session)
+
+        client.subscribe.assert_called_once()
+        background_tasks.add_task.assert_not_called()


### PR DESCRIPTION
Remove the `= None` default from the `session` parameter so callers must always supply an AuthSession. Drop the `if session:` guard in `act()` — `_enqueue_sync` already short-circuits when `google_db.get_account` returns None.

Update TestSubscribeActionDispatch tests to pass a real AuthSession and fix the "No sync account" comments to accurately describe that sync is skipped because google_db.get_account returns None.

https://claude.ai/code/session_01SW9SnbH3UDVrBEzRRE91Ua