### PR TITLE
feat: benchmark WOD detection + calendar indicator (Slice 1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ api = [
 import-schedule = "wodplanner.cli.import_schedule:main"
 backup-db = "wodplanner.cli.backup_db:main"
 add-1rm = "wodplanner.cli.add_1rm:main"
+add-benchmark = "wodplanner.cli.add_benchmark:main"
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/src/wodplanner/app/dependencies.py
+++ b/src/wodplanner/app/dependencies.py
@@ -13,6 +13,7 @@ from wodplanner.models.auth import AuthSession
 from wodplanner.services import crypto
 from wodplanner.services import session as cookie_session
 from wodplanner.services.api_cache import ApiCacheService
+from wodplanner.services.benchmark import BenchmarkService
 from wodplanner.services.calendar_sync import CalendarSyncService
 from wodplanner.services.friends import FriendsService
 from wodplanner.services.google_accounts import GoogleAccountsService
@@ -64,6 +65,12 @@ def get_calendar_sync_service() -> CalendarSyncService:
         db=get_google_accounts_service(),
         schedule_service=get_schedule_service(),
     )
+
+
+@lru_cache
+def get_benchmark_service() -> BenchmarkService:
+    """Get the singleton benchmark service."""
+    return BenchmarkService(_get_db_path())
 
 
 @lru_cache

--- a/src/wodplanner/app/routers/views.py
+++ b/src/wodplanner/app/routers/views.py
@@ -13,6 +13,7 @@ from fastapi.templating import Jinja2Templates
 
 from wodplanner.api.client import WodAppClient
 from wodplanner.app.dependencies import (
+    get_benchmark_service,
     get_client_from_session_for_view,
     get_friends_service,
     get_one_rep_max_service,
@@ -23,6 +24,7 @@ from wodplanner.app.dependencies import (
     require_session_for_view,
 )
 from wodplanner.models.auth import AuthSession
+from wodplanner.services.benchmark import BenchmarkService
 from wodplanner.services.day_card import build_day_cards
 from wodplanner.services.friend_presence import find_friends_in_appointments
 from wodplanner.services.friends import FriendsService
@@ -165,10 +167,13 @@ _HEADER_TOOLTIPS = {"filter", "today", "date_picker"}
 def _get_tooltip_context(dismissed: set, appt_data: list) -> dict:
     active = next((t for t in _TOOLTIP_SEQUENCE if t not in dismissed), None)
     any_has_1rm = any(a.has_1rm for a in appt_data)
+    any_has_benchmark = any(a.has_benchmark for a in appt_data)
     show_1rm = "1rm" not in dismissed and any_has_1rm
+    show_benchmark = "benchmark" not in dismissed and any_has_benchmark
     return {
         "active_tooltip": active,
         "show_1rm_tooltip": show_1rm,
+        "show_benchmark_tooltip": show_benchmark,
         "show_backdrop": active in _HEADER_TOOLTIPS,
     }
 
@@ -179,6 +184,7 @@ def _fetch_calendar_data(
     client: WodAppClient,
     friends_service: FriendsService,
     schedule_service: ScheduleService,
+    benchmark_service: BenchmarkService,
     hidden_types: set[str],
 ) -> list:
     """Fetch appointment data and build DayCard objects for calendar rendering."""
@@ -192,12 +198,14 @@ def _fetch_calendar_data(
     )
 
     friends_by_appt = find_friends_in_appointments(visible, friends, client) or {}
+    benchmark_names = benchmark_service.get_benchmark_list()
 
     return build_day_cards(
         appointments=visible,
         friends_by_appt_id=friends_by_appt,
         schedule_by_class_type=schedule_map,
         now=datetime.now(),
+        benchmark_names=benchmark_names,
     )
 
 
@@ -210,6 +218,7 @@ def calendar_page(
     friends_service: FriendsService = Depends(get_friends_service),
     prefs_service: PreferencesService = Depends(get_preferences_service),
     schedule_service: ScheduleService = Depends(get_schedule_service),
+    benchmark_service: BenchmarkService = Depends(get_benchmark_service),
 ):
     """Main calendar page."""
     target_date = parse_iso_date(day) if day else date.today()
@@ -218,7 +227,7 @@ def calendar_page(
 
     hidden_types = prefs_service.get_hidden_class_types(session.user_id)
     dismissed = set(prefs_service.get_dismissed_tooltips(session.user_id))
-    appt_data = _fetch_calendar_data(session, target_date, client, friends_service, schedule_service, set(hidden_types))
+    appt_data = _fetch_calendar_data(session, target_date, client, friends_service, schedule_service, benchmark_service, set(hidden_types))
 
     weekday = target_date.strftime("%A")
     filters = [{"name": t, "hidden": t in hidden_types} for t in FILTERABLE_CLASS_TYPES]
@@ -251,6 +260,7 @@ def calendar_day_partial(
     friends_service: FriendsService = Depends(get_friends_service),
     prefs_service: PreferencesService = Depends(get_preferences_service),
     schedule_service: ScheduleService = Depends(get_schedule_service),
+    benchmark_service: BenchmarkService = Depends(get_benchmark_service),
 ):
     """Calendar day partial for htmx updates."""
     target_date = parse_iso_date(day)
@@ -259,7 +269,7 @@ def calendar_day_partial(
 
     hidden_types = prefs_service.get_hidden_class_types(session.user_id)
     dismissed = set(prefs_service.get_dismissed_tooltips(session.user_id))
-    appt_data = _fetch_calendar_data(session, target_date, client, friends_service, schedule_service, set(hidden_types))
+    appt_data = _fetch_calendar_data(session, target_date, client, friends_service, schedule_service, benchmark_service, set(hidden_types))
 
     weekday = target_date.strftime("%A")
     filters = [{"name": t, "hidden": t in hidden_types} for t in FILTERABLE_CLASS_TYPES]
@@ -291,6 +301,7 @@ def toggle_filter(
     friends_service: FriendsService = Depends(get_friends_service),
     prefs_service: PreferencesService = Depends(get_preferences_service),
     schedule_service: ScheduleService = Depends(get_schedule_service),
+    benchmark_service: BenchmarkService = Depends(get_benchmark_service),
 ):
     """Toggle a class type filter."""
     prefs_service.toggle_hidden_class_type(session.user_id, class_type)
@@ -302,6 +313,7 @@ def toggle_filter(
         friends_service=friends_service,
         prefs_service=prefs_service,
         schedule_service=schedule_service,
+        benchmark_service=benchmark_service,
     )
 
 
@@ -433,6 +445,7 @@ def subscribe_view(
     prefs_service: PreferencesService = Depends(get_preferences_service),
     schedule_service: ScheduleService = Depends(get_schedule_service),
     subscription_service: SubscriptionService = Depends(get_subscription_service),
+    benchmark_service: BenchmarkService = Depends(get_benchmark_service),
 ):
     """Subscribe to appointment from calendar (htmx)."""
     start = parse_api_datetime(date_start)
@@ -456,6 +469,7 @@ def subscribe_view(
         friends_service=friends_service,
         prefs_service=prefs_service,
         schedule_service=schedule_service,
+        benchmark_service=benchmark_service,
     )
 
 
@@ -472,6 +486,7 @@ def waitinglist_view(
     prefs_service: PreferencesService = Depends(get_preferences_service),
     schedule_service: ScheduleService = Depends(get_schedule_service),
     subscription_service: SubscriptionService = Depends(get_subscription_service),
+    benchmark_service: BenchmarkService = Depends(get_benchmark_service),
 ):
     """Join waiting list from calendar (htmx)."""
     start = parse_api_datetime(date_start)
@@ -495,6 +510,7 @@ def waitinglist_view(
         friends_service=friends_service,
         prefs_service=prefs_service,
         schedule_service=schedule_service,
+        benchmark_service=benchmark_service,
     )
 
 
@@ -512,6 +528,7 @@ def unsubscribe_view(
     prefs_service: PreferencesService = Depends(get_preferences_service),
     schedule_service: ScheduleService = Depends(get_schedule_service),
     subscription_service: SubscriptionService = Depends(get_subscription_service),
+    benchmark_service: BenchmarkService = Depends(get_benchmark_service),
 ):
     """Unsubscribe from appointment (htmx)."""
     start = parse_api_datetime(date_start)
@@ -541,6 +558,7 @@ def unsubscribe_view(
         friends_service=friends_service,
         prefs_service=prefs_service,
         schedule_service=schedule_service,
+        benchmark_service=benchmark_service,
     )
 
 

--- a/src/wodplanner/app/static/css/style.css
+++ b/src/wodplanner/app/static/css/style.css
@@ -634,6 +634,23 @@ body {
     background: #ede9fe;
 }
 
+.btn-icon.btn-benchmark {
+    color: #d97706;
+    border-color: #d97706;
+}
+
+.btn-icon.btn-benchmark:hover {
+    background: #fef3c7;
+}
+
+.benchmark-label {
+    font-size: 0.65rem;
+    font-weight: 600;
+    margin-left: 2px;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+}
+
 .one-rm-chart-container {
     padding: 1rem;
     height: 260px;

--- a/src/wodplanner/app/templates/partials/calendar_content.html
+++ b/src/wodplanner/app/templates/partials/calendar_content.html
@@ -5,15 +5,17 @@
     </div>
 
     {% if appointments %}
-    {% set ns = namespace(schedule_done=False, friends_done=False, one_rm_done=False) %}
+    {% set ns = namespace(schedule_done=False, friends_done=False, one_rm_done=False, benchmark_done=False) %}
     <div class="appointments">
         {% for appt in appointments %}
         {% set is_first_schedule = not ns.schedule_done %}
         {% set is_first_friends = not ns.friends_done %}
         {% set is_first_1rm = not ns.one_rm_done and appt.has_1rm %}
+        {% set is_first_benchmark = not ns.benchmark_done and appt.has_benchmark %}
         {% set ns.schedule_done = True %}
         {% set ns.friends_done = True %}
         {% if appt.has_1rm %}{% set ns.one_rm_done = True %}{% endif %}
+        {% if appt.has_benchmark %}{% set ns.benchmark_done = True %}{% endif %}
         <div class="appointment status-{{ appt.status }}{% if appt.is_past %} is-past{% endif %}">
             <div class="appointment-time">
                 {{ appt.time_start }} - {{ appt.time_end }}
@@ -70,6 +72,24 @@
                     <div id="tooltip-1rm" class="filter-tooltip">
                         <p>This class has a 1RM exercise. Tap to log your score.</p>
                         <button class="btn btn-sm" onclick="dismissTooltip('1rm', this.closest('.tooltip-btn-wrapper'))">Got it</button>
+                    </div>
+                    {% endif %}
+                </div>
+                {% endif %}
+                {% if appt.has_benchmark %}
+                <div class="tooltip-btn-wrapper{% if is_first_benchmark and show_benchmark_tooltip %} has-tooltip{% endif %}">
+                    <button class="btn btn-icon btn-sm btn-benchmark"
+                            title="{{ appt.benchmark_name }}">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <circle cx="12" cy="12" r="10"/>
+                            <polyline points="12 6 12 12 16 14"/>
+                        </svg>
+                        <span class="benchmark-label">{{ appt.benchmark_name }}</span>
+                    </button>
+                    {% if is_first_benchmark and show_benchmark_tooltip %}
+                    <div id="tooltip-benchmark" class="filter-tooltip">
+                        <p>This class has a benchmark WOD ({{ appt.benchmark_name }}). Tap to log your time.</p>
+                        <button class="btn btn-sm" onclick="dismissTooltip('benchmark', this.closest('.tooltip-btn-wrapper'))">Got it</button>
                     </div>
                     {% endif %}
                 </div>

--- a/src/wodplanner/cli/add_benchmark.py
+++ b/src/wodplanner/cli/add_benchmark.py
@@ -1,0 +1,52 @@
+"""CLI tool for managing the benchmark WOD list."""
+
+import argparse
+import sys
+from pathlib import Path
+
+from wodplanner.services.benchmark import BenchmarkService
+from wodplanner.services.migrations import ensure_migrations
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Add a benchmark WOD to the list")
+    parser.add_argument(
+        "--name",
+        type=str,
+        help="Benchmark WOD name to add",
+    )
+    parser.add_argument(
+        "--category",
+        type=str,
+        default="Benchmark",
+        help="Category (e.g. 'The Girls', 'Hero', 'Benchmark')",
+    )
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=Path("wodplanner.db"),
+        help="Path to the database file (default: wodplanner.db)",
+    )
+    args = parser.parse_args()
+
+    ensure_migrations(args.db)
+    service = BenchmarkService(args.db)
+
+    raw_name = args.name.strip() if args.name else None
+    if not raw_name:
+        names = service.get_benchmark_list()
+        print("Existing benchmark WODs:")
+        for i, name in enumerate(names, 1):
+            print(f"  {i}. {name}")
+        raw_name = input("\nEnter new benchmark name: ").strip()
+        if not raw_name:
+            print("No name provided. Exiting.")
+            sys.exit(0)
+
+    category = input(f"Category [{args.category}]: ").strip() or args.category
+
+    if service.add_benchmark_wod(raw_name, category):
+        print(f'Added "{raw_name}" (category: {category}) to the benchmark WOD list.')
+    else:
+        print(f'Benchmark "{raw_name}" already exists in the list.')
+        sys.exit(1)

--- a/src/wodplanner/models/benchmark.py
+++ b/src/wodplanner/models/benchmark.py
@@ -1,0 +1,12 @@
+"""Benchmark WOD models."""
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class BenchmarkWod(BaseModel):
+    id: int | None = None
+    name: str
+    category: str
+    created_at: datetime | None = None

--- a/src/wodplanner/services/benchmark.py
+++ b/src/wodplanner/services/benchmark.py
@@ -1,0 +1,95 @@
+"""Benchmark WOD detection and service."""
+
+import sqlite3
+from datetime import datetime
+
+from wodplanner.models.benchmark import BenchmarkWod
+from wodplanner.services import migrations
+from wodplanner.services.base import BaseService
+from wodplanner.utils.dates import parse_iso_datetime
+
+_SEED_BENCHMARKS: dict[str, list[str]] = {
+    "The Girls": [
+        "Fran", "Helen", "Cindy", "Annie", "Isabel", "Jackie", "Karen",
+        "Angie", "Barbara", "Chelsea", "Diane", "Elizabeth", "Grace",
+        "Linda", "Mary", "Nancy", "Amanda", "Eva",
+    ],
+    "Hero": [
+        "Murph", "Kalsu", "JT", "Loredo", "Randy", "Danny", "Michael",
+        "Nate", "Joshie", "Badger",
+    ],
+}
+
+
+def find_benchmark_in_schedule(
+    schedule_texts: list[str | None],
+    benchmark_names: list[str],
+) -> str | None:
+    """Scan schedule text fields for known benchmark names (case-insensitive)."""
+    combined = " ".join(t for t in schedule_texts if t)
+    if not combined:
+        return None
+    lower_combined = combined.lower()
+    for name in benchmark_names:
+        if name.lower() in lower_combined:
+            return name
+    return None
+
+
+def _migrate_v600(conn: sqlite3.Connection) -> None:
+    """Create benchmark_wods table."""
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS benchmark_wods (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL UNIQUE,
+            category TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        )
+    """)
+
+
+def _migrate_v601(conn: sqlite3.Connection) -> None:
+    """Seed default benchmark WODs if empty."""
+    if conn.execute("SELECT COUNT(*) FROM benchmark_wods").fetchone()[0] == 0:
+        rows = [
+            (name, category, datetime.now().isoformat())
+            for category, names in _SEED_BENCHMARKS.items()
+            for name in names
+        ]
+        conn.executemany(
+            "INSERT OR IGNORE INTO benchmark_wods (name, category, created_at) VALUES (?, ?, ?)",
+            rows,
+        )
+
+
+migrations.register(600, "create benchmark_wods table", _migrate_v600)
+migrations.register(601, "seed default benchmark WODs", _migrate_v601)
+
+
+class BenchmarkService(BaseService):
+    def _row_to_model(self, row: sqlite3.Row) -> BenchmarkWod:
+        return BenchmarkWod(
+            id=row["id"],
+            name=row["name"],
+            category=row["category"],
+            created_at=parse_iso_datetime(row["created_at"]),
+        )
+
+    def get_benchmark_list(self) -> list[str]:
+        with self._get_connection() as conn:
+            rows = conn.execute(
+                "SELECT name FROM benchmark_wods ORDER BY name"
+            ).fetchall()
+            return [row["name"] for row in rows]
+
+    def add_benchmark_wod(self, name: str, category: str) -> bool:
+        try:
+            with self._get_connection() as conn:
+                conn.execute(
+                    "INSERT INTO benchmark_wods (name, category, created_at) VALUES (?, ?, ?)",
+                    (name.strip(), category.strip(), datetime.now().isoformat()),
+                )
+                conn.commit()
+                return True
+        except sqlite3.IntegrityError:
+            return False

--- a/src/wodplanner/services/day_card.py
+++ b/src/wodplanner/services/day_card.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 
 from wodplanner.models.calendar import Appointment
 from wodplanner.models.friends import Friend
+from wodplanner.services.benchmark import find_benchmark_in_schedule
 from wodplanner.services.one_rep_max import has_1rm_exercise as _check_1rm
 
 _TZ = ZoneInfo("Europe/Amsterdam")
@@ -39,6 +40,24 @@ def _has_1rm(appt_name: str, schedule_by_class_type: Mapping[str, object]) -> bo
     )
 
 
+def _find_benchmark(
+    appt_name: str,
+    schedule_by_class_type: Mapping[str, object],
+    benchmark_names: list[str],
+) -> str | None:
+    """Check if appointment's matched Schedule contains a benchmark WOD."""
+    sched = schedule_by_class_type.get(appt_name)
+    if sched is None or not benchmark_names:
+        return None
+    texts = [
+        getattr(sched, "warmup_mobility", None),
+        getattr(sched, "strength_specialty", None),
+        getattr(sched, "metcon", None),
+        getattr(sched, "raw_content", None),
+    ]
+    return find_benchmark_in_schedule(texts, benchmark_names)
+
+
 class DayCard(BaseModel):
     """Enriched Appointment for calendar rendering."""
 
@@ -53,6 +72,8 @@ class DayCard(BaseModel):
     date_end: str
     friends: list[Friend] = []
     has_1rm: bool = False
+    has_benchmark: bool = False
+    benchmark_name: str | None = None
     signup_open: bool = False
     is_past: bool = False
 
@@ -62,6 +83,7 @@ def build_day_cards(
     friends_by_appt_id: Mapping[int, list[Friend] | None],
     schedule_by_class_type: Mapping[str, object],
     now: datetime,
+    benchmark_names: list[str] | None = None,
 ) -> list[DayCard]:
     """Build DayCard objects from raw appointment data."""
     cards: list[DayCard] = []
@@ -70,6 +92,7 @@ def build_day_cards(
         target_date = appt.date_start.date()
         actual_start = datetime.combine(target_date, appt.date_start.time(), tzinfo=appt.date_start.tzinfo)
         actual_start_tz = actual_start.replace(tzinfo=_TZ) if actual_start.tzinfo is None else actual_start
+        benchmark_name = _find_benchmark(appt.name, schedule_by_class_type, benchmark_names or [])
 
         cards.append(
             DayCard(
@@ -84,6 +107,8 @@ def build_day_cards(
                 date_end=target_date.isoformat(),
                 friends=friends_by_appt_id.get(appt.id_appointment) or [],
                 has_1rm=_has_1rm(appt.name, schedule_by_class_type),
+                has_benchmark=benchmark_name is not None,
+                benchmark_name=benchmark_name,
                 signup_open=_is_signup_open(appt.name, actual_start, now),
                 is_past=actual_start_tz < now_tz,
             )

--- a/src/wodplanner/services/migrations.py
+++ b/src/wodplanner/services/migrations.py
@@ -93,6 +93,7 @@ def _import_services_for_registration() -> None:
     """Import service modules so their register() calls execute."""
     # Local imports avoid a circular import at module load time.
     from wodplanner.services import (  # noqa: F401
+        benchmark,
         friends,
         google_accounts,
         one_rep_max,

--- a/tests/services/test_benchmark.py
+++ b/tests/services/test_benchmark.py
@@ -1,0 +1,174 @@
+"""Tests for services/benchmark.py — benchmark WOD detection and service."""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from wodplanner.services.benchmark import BenchmarkService, find_benchmark_in_schedule
+
+
+class TestFindBenchmarkInSchedule:
+    def test_finds_murph_in_metcon(self):
+        names = ["Murph", "Fran", "Helen"]
+        result = find_benchmark_in_schedule(
+            schedule_texts=["Metcon: Murph for time"],
+            benchmark_names=names,
+        )
+        assert result == "Murph"
+
+    def test_returns_none_when_no_match(self):
+        names = ["Murph", "Fran", "Helen"]
+        result = find_benchmark_in_schedule(
+            schedule_texts=["Metcon: some other workout"],
+            benchmark_names=names,
+        )
+        assert result is None
+
+    def test_case_insensitive_matching(self):
+        names = ["Murph", "Fran", "Helen"]
+        result = find_benchmark_in_schedule(
+            schedule_texts=["Metcon: murph for time"],
+            benchmark_names=names,
+        )
+        assert result == "Murph"
+
+    def test_handles_none_texts(self):
+        names = ["Murph", "Fran"]
+        result = find_benchmark_in_schedule(
+            schedule_texts=[None, "", None],
+            benchmark_names=names,
+        )
+        assert result is None
+
+    def test_returns_first_match_in_list_order(self):
+        names = ["Fran", "Helen", "Murph"]
+        result = find_benchmark_in_schedule(
+            schedule_texts=["Metcon: Helen and Murph for time"],
+            benchmark_names=names,
+        )
+        assert result == "Helen"
+
+    def test_scans_multiple_fields(self):
+        names = ["Fran", "Helen", "Cindy"]
+        result = find_benchmark_in_schedule(
+            schedule_texts=["Warm-up: light jog", "", "Strength: 5x5", "Metcon: Cindy"],
+            benchmark_names=names,
+        )
+        assert result == "Cindy"
+
+
+class TestDayCardEnrichment:
+    def test_benchmark_enrichment_adds_fields(self):
+        """DayCard gets has_benchmark and benchmark_name when schedule matches."""
+        from datetime import date
+
+        from wodplanner.models.calendar import Appointment
+        from wodplanner.models.schedule import Schedule
+        from wodplanner.services.day_card import build_day_cards
+
+        appt = Appointment(
+            id_appointment=1,
+            id_appointment_type=1,
+            name="CrossFit",
+            date_start=datetime(2026, 6, 15, 9, 0),
+            date_end=datetime(2026, 6, 15, 10, 0),
+            max_subscriptions=20,
+            total_subscriptions=5,
+            status="open",
+        )
+        sched = Schedule(
+            date=date(2026, 6, 15),
+            class_type="CrossFit",
+            metcon="Murph for time",
+        )
+        result = build_day_cards(
+            appointments=[appt],
+            friends_by_appt_id={},
+            schedule_by_class_type={"CrossFit": sched},
+            now=datetime(2026, 6, 10, 12, 0, tzinfo=ZoneInfo("Europe/Amsterdam")),
+            benchmark_names=["Murph", "Fran", "Helen"],
+        )
+        card = result[0]
+        assert card.has_benchmark is True
+        assert card.benchmark_name == "Murph"
+
+    def test_no_benchmark_when_no_match(self):
+        from datetime import date
+
+        from wodplanner.models.calendar import Appointment
+        from wodplanner.models.schedule import Schedule
+        from wodplanner.services.day_card import build_day_cards
+
+        appt = Appointment(
+            id_appointment=1,
+            id_appointment_type=1,
+            name="CrossFit",
+            date_start=datetime(2026, 6, 15, 9, 0),
+            date_end=datetime(2026, 6, 15, 10, 0),
+            max_subscriptions=20,
+            total_subscriptions=5,
+            status="open",
+        )
+        sched = Schedule(
+            date=date(2026, 6, 15),
+            class_type="CrossFit",
+            metcon="Some other workout",
+        )
+        result = build_day_cards(
+            appointments=[appt],
+            friends_by_appt_id={},
+            schedule_by_class_type={"CrossFit": sched},
+            now=datetime(2026, 6, 10, 12, 0, tzinfo=ZoneInfo("Europe/Amsterdam")),
+            benchmark_names=["Murph", "Fran", "Helen"],
+        )
+        card = result[0]
+        assert card.has_benchmark is False
+        assert card.benchmark_name is None
+
+    def test_no_schedule_no_benchmark(self):
+        from wodplanner.models.calendar import Appointment
+        from wodplanner.services.day_card import build_day_cards
+
+        appt = Appointment(
+            id_appointment=1,
+            id_appointment_type=1,
+            name="CrossFit",
+            date_start=datetime(2026, 6, 15, 9, 0),
+            date_end=datetime(2026, 6, 15, 10, 0),
+            max_subscriptions=20,
+            total_subscriptions=5,
+            status="open",
+        )
+        result = build_day_cards(
+            appointments=[appt],
+            friends_by_appt_id={},
+            schedule_by_class_type={},
+            now=datetime(2026, 6, 10, 12, 0, tzinfo=ZoneInfo("Europe/Amsterdam")),
+            benchmark_names=["Murph", "Fran"],
+        )
+        card = result[0]
+        assert card.has_benchmark is False
+        assert card.benchmark_name is None
+
+
+class TestBenchmarkService:
+    def test_get_benchmark_list_returns_seeded_names(self, db_path):
+        svc = BenchmarkService(db_path)
+        names = svc.get_benchmark_list()
+        assert len(names) >= 28
+        assert "Murph" in names
+        assert "Fran" in names
+        assert "Cindy" in names
+
+    def test_add_benchmark_wod(self, db_path):
+        svc = BenchmarkService(db_path)
+        result = svc.add_benchmark_wod("Fight Gone Bad", "Benchmark")
+        assert result is True
+
+        names = svc.get_benchmark_list()
+        assert "Fight Gone Bad" in names
+
+    def test_add_benchmark_wod_duplicate_returns_false(self, db_path):
+        svc = BenchmarkService(db_path)
+        svc.add_benchmark_wod("Test Benchmark", "The Girls")
+        result = svc.add_benchmark_wod("Test Benchmark", "Hero")
+        assert result is False


### PR DESCRIPTION
## Summary

Implements **Slice 1** of Benchmark WOD tracking (#80 → #81). The calendar now detects known Benchmark WODs (Murph, Fran, etc.) in Schedule text and shows an amber stopwatch indicator on the appointment row.

## Changes

### New files
- `src/wodplanner/models/benchmark.py` — `BenchmarkWod` Pydantic model
- `src/wodplanner/services/benchmark.py` — migrations v600-601, `find_benchmark_in_schedule()` scanner, `BenchmarkService` (CRUD for benchmark_wods table)
- `src/wodplanner/cli/add_benchmark.py` — `add-benchmark` CLI (interactive + `--name`/`--category`)
- `tests/services/test_benchmark.py` — 12 tests covering detection, enrichment, service

### Modified files
- `services/migrations.py` — register `benchmark` module for import
- `services/day_card.py` — `has_benchmark`/`benchmark_name` on `DayCard`, `_find_benchmark()` helper
- `app/dependencies.py` — `get_benchmark_service()` singleton
- `app/routers/views.py` — wire `BenchmarkService` into calendar pipeline and all HTMX routes
- `app/static/css/style.css` — amber button styling for benchmark indicator
- `templates/partials/calendar_content.html` — stopwatch icon + label + tooltip
- `pyproject.toml` — register `add-benchmark` CLI entry point

## Verification
- All 630 tests pass (including 12 new benchmark tests)
- `ruff check .` — clean
- `mypy src/` — no new errors

Closes #81