### PR TITLE
feat: benchmark WOD result logging via modal (Slice 2)

### DIFF
--- a/src/wodplanner/app/routers/views.py
+++ b/src/wodplanner/app/routers/views.py
@@ -24,7 +24,7 @@ from wodplanner.app.dependencies import (
     require_session_for_view,
 )
 from wodplanner.models.auth import AuthSession
-from wodplanner.services.benchmark import BenchmarkService
+from wodplanner.services.benchmark import BenchmarkService, find_benchmark_in_schedule
 from wodplanner.services.day_card import build_day_cards
 from wodplanner.services.friend_presence import find_friends_in_appointments
 from wodplanner.services.friends import FriendsService
@@ -52,6 +52,20 @@ def _format_1rm_entries(entries):
             "weight_kg": e.weight_kg,
             "recorded_at": e.recorded_at.strftime("%b %d, %Y"),
             "recorded_at_iso": e.recorded_at.isoformat(),
+        }
+        for e in entries
+    ]
+
+
+def _format_benchmark_entries(entries):
+    return [
+        {
+            "id": e.id,
+            "benchmark_name": e.benchmark_name,
+            "time_seconds": e.time_seconds,
+            "formatted_time": f"{e.time_seconds // 60}:{e.time_seconds % 60:02d}",
+            "is_rx": e.is_rx,
+            "recorded_at": e.recorded_at,
         }
         for e in entries
     ]
@@ -786,4 +800,101 @@ def delete_one_rep_max_view(
             "entries": entries,
             "exercises_data_json": _build_exercises_chart_data(entries),
         },
+    )
+
+
+@router.get("/appointments/{appointment_id}/benchmark", response_class=HTMLResponse)
+def benchmark_modal_view(
+    request: Request,
+    appointment_id: int,
+    date_start: str,
+    class_name: str,
+    session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
+    schedule_service: ScheduleService = Depends(get_schedule_service),
+    benchmark_service: BenchmarkService = Depends(get_benchmark_service),
+):
+    """Get benchmark result modal for an appointment (htmx modal)."""
+    schedule_date = parse_iso_date(date_start.split(" ")[0])
+    schedule = match_schedule(class_name, schedule_date, gym_id=session.gym_id, schedule_service=schedule_service)
+
+    benchmark_name = None
+    if schedule:
+        texts = [
+            getattr(schedule, "warmup_mobility", None),
+            getattr(schedule, "strength_specialty", None),
+            getattr(schedule, "metcon", None),
+            getattr(schedule, "raw_content", None),
+        ]
+        benchmark_names = benchmark_service.get_benchmark_list()
+        benchmark_name = find_benchmark_in_schedule(texts, benchmark_names)
+
+    if not benchmark_name:
+        raise HTTPException(status_code=404, detail="No benchmark WOD detected for this appointment")
+
+    raw = benchmark_service.get_results_for_benchmark(session.user_id, benchmark_name)
+    entries = _format_benchmark_entries(raw)
+
+    return render(
+        request,
+        "partials/benchmark_modal.html",
+        {
+            "benchmark_name": benchmark_name,
+            "entries": entries,
+            "preset_date": schedule_date.isoformat(),
+        },
+    )
+
+
+@router.post("/benchmark-results/add", response_class=HTMLResponse)
+def add_benchmark_result_view(
+    request: Request,
+    benchmark_name: str = Form(...),
+    minutes: int = Form(...),
+    seconds: int = Form(...),
+    is_rx: str = Form("true"),
+    recorded_at: str = Form(...),
+    session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
+    benchmark_service: BenchmarkService = Depends(get_benchmark_service),
+):
+    """Add a benchmark result (htmx)."""
+    total_seconds = minutes * 60 + seconds
+    if total_seconds <= 0:
+        raise HTTPException(status_code=400, detail="Time must be greater than 0.")
+
+    benchmark_service.add_result(
+        user_id=session.user_id,
+        benchmark_name=benchmark_name.strip(),
+        time_seconds=total_seconds,
+        is_rx=is_rx == "true",
+        recorded_at=recorded_at,
+    )
+
+    raw = benchmark_service.get_results_for_benchmark(session.user_id, benchmark_name)
+    entries = _format_benchmark_entries(raw)
+    return render(
+        request,
+        "partials/benchmark_history.html",
+        {"entries": entries},
+    )
+
+
+@router.delete("/benchmark-results/{result_id}/delete", response_class=HTMLResponse)
+def delete_benchmark_result_view(
+    request: Request,
+    result_id: int,
+    session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
+    benchmark_service: BenchmarkService = Depends(get_benchmark_service),
+):
+    """Delete a benchmark result (htmx)."""
+    result = benchmark_service.get_result(session.user_id, result_id)
+    benchmark_name = result.benchmark_name if result else None
+
+    benchmark_service.delete_result(session.user_id, result_id)
+
+    raw = benchmark_service.get_results_for_benchmark(session.user_id, benchmark_name) if benchmark_name else []
+    entries = _format_benchmark_entries(raw)
+    return render(
+        request,
+        "partials/benchmark_history.html",
+        {"entries": entries},
     )

--- a/src/wodplanner/app/static/css/style.css
+++ b/src/wodplanner/app/static/css/style.css
@@ -651,6 +651,135 @@ body {
     letter-spacing: 0.02em;
 }
 
+.benchmark-form {
+    margin-bottom: 1rem;
+}
+
+.benchmark-form .form-row {
+    display: flex;
+    gap: 0.5rem;
+    align-items: flex-end;
+    flex-wrap: wrap;
+}
+
+.benchmark-form .form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    flex: 1;
+    min-width: 140px;
+}
+
+.benchmark-form .form-group-narrow {
+    flex: 0 0 110px;
+    min-width: 90px;
+}
+
+.benchmark-form .form-group-submit {
+    flex: 0 0 auto;
+}
+
+.benchmark-form--modal .form-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    align-items: end;
+    gap: 0.5rem;
+}
+
+.benchmark-form--modal .form-row > :nth-child(1) {
+    grid-column: 1 / -1;
+}
+
+.benchmark-form--modal .form-group-submit .btn {
+    width: 100%;
+    justify-content: center;
+}
+
+.benchmark-form label {
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--gray-600);
+}
+
+.benchmark-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.875rem;
+}
+
+.benchmark-table th {
+    text-align: left;
+    padding: 0.375rem 0.5rem;
+    font-size: 0.75rem;
+    color: var(--gray-500);
+    border-bottom: 1px solid var(--gray-200);
+}
+
+.benchmark-table td {
+    padding: 0.375rem 0.5rem;
+    border-bottom: 1px solid var(--gray-100);
+}
+
+.benchmark-time {
+    font-weight: 600;
+}
+
+.benchmark-date {
+    font-size: 0.75rem;
+}
+
+.benchmark-empty {
+    font-size: 0.875rem;
+    text-align: center;
+    padding: 1rem 0;
+}
+
+.radio-group {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+    padding-top: 0.25rem;
+}
+
+.radio-inline {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.875rem;
+    cursor: pointer;
+}
+
+.badge {
+    display: inline-block;
+    padding: 0.125rem 0.5rem;
+    border-radius: 999px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+}
+
+.badge-rx {
+    background: #dbeafe;
+    color: #1d4ed8;
+}
+
+.badge-scaled {
+    background: #fef3c7;
+    color: #d97706;
+}
+
+@media (max-width: 640px) {
+    .benchmark-form .form-row {
+        flex-direction: column;
+    }
+    .benchmark-form .form-group,
+    .benchmark-form .form-group-narrow {
+        flex: 1;
+        min-width: 0;
+        width: 100%;
+    }
+}
+
 .one-rm-chart-container {
     padding: 1rem;
     height: 260px;

--- a/src/wodplanner/app/templates/base.html
+++ b/src/wodplanner/app/templates/base.html
@@ -58,6 +58,11 @@
         <div id="one-rep-max-modal-container"></div>
     </div>
 
+    <!-- Benchmark Modal -->
+    <div id="benchmark-modal" class="modal">
+        <div id="benchmark-modal-container"></div>
+    </div>
+
     <script>
         function openPeopleModal() {
             document.getElementById('people-modal').classList.add('active');
@@ -100,12 +105,26 @@
             }
         });
 
+        function openBenchmarkModal() {
+            document.getElementById('benchmark-modal').classList.add('active');
+        }
+        function closeBenchmarkModal() {
+            document.getElementById('benchmark-modal').classList.remove('active');
+            document.getElementById('benchmark-modal-container').innerHTML = '';
+        }
+        document.getElementById('benchmark-modal').addEventListener('click', function(e) {
+            if (e.target === this) {
+                closeBenchmarkModal();
+            }
+        });
+
         // Close modals on Escape key
         document.addEventListener('keydown', function(e) {
             if (e.key === 'Escape') {
                 closePeopleModal();
                 closeScheduleModal();
                 close1rmModal();
+                closeBenchmarkModal();
             }
         });
 

--- a/src/wodplanner/app/templates/partials/benchmark_history.html
+++ b/src/wodplanner/app/templates/partials/benchmark_history.html
@@ -1,0 +1,41 @@
+<div id="benchmark-history" class="benchmark-history">
+    {% if entries %}
+    <table class="benchmark-table">
+        <thead>
+            <tr>
+                <th>Date</th>
+                <th>Time</th>
+                <th>RX / Scaled</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for entry in entries %}
+            <tr>
+                <td class="benchmark-date text-muted">{{ entry.recorded_at }}</td>
+                <td class="benchmark-time">{{ entry.formatted_time }}</td>
+                <td>
+                    {% if entry.is_rx %}
+                    <span class="badge badge-rx">RX</span>
+                    {% else %}
+                    <span class="badge badge-scaled">Scaled</span>
+                    {% endif %}
+                </td>
+                <td>
+                    <button class="btn-delete"
+                            hx-delete="/benchmark-results/{{ entry.id }}/delete"
+                            hx-target="#benchmark-history"
+                            hx-swap="outerHTML"
+                            hx-confirm="Delete this benchmark result?"
+                            title="Delete">
+                        &times;
+                    </button>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    <p class="text-muted benchmark-empty">No entries yet.</p>
+    {% endif %}
+</div>

--- a/src/wodplanner/app/templates/partials/benchmark_modal.html
+++ b/src/wodplanner/app/templates/partials/benchmark_modal.html
@@ -1,0 +1,56 @@
+<div class="modal-content">
+    <div class="modal-header">
+        <h3 class="modal-title">Benchmark WOD: {{ benchmark_name }}</h3>
+        <button class="modal-close" onclick="closeBenchmarkModal()" aria-label="Close">&times;</button>
+    </div>
+    <div class="modal-body">
+        <form hx-post="/benchmark-results/add"
+              hx-target="#benchmark-history"
+              hx-swap="outerHTML"
+              class="benchmark-form benchmark-form--modal">
+            <input type="hidden" name="benchmark_name" value="{{ benchmark_name }}">
+            <input type="hidden" name="recorded_at" value="{{ preset_date }}">
+            <div class="form-row">
+                <div class="form-group form-group-narrow">
+                    <label for="benchmark-minutes">Minutes</label>
+                    <input type="number"
+                           id="benchmark-minutes"
+                           name="minutes"
+                           min="0"
+                           max="999"
+                           placeholder="0"
+                           required
+                           class="form-control">
+                </div>
+                <div class="form-group form-group-narrow">
+                    <label for="benchmark-seconds">Seconds</label>
+                    <input type="number"
+                           id="benchmark-seconds"
+                           name="seconds"
+                           min="0"
+                           max="59"
+                           placeholder="00"
+                           required
+                           class="form-control">
+                </div>
+                <div class="form-group form-group-narrow">
+                    <label>RX / Scaled</label>
+                    <div class="radio-group">
+                        <label class="radio-inline">
+                            <input type="radio" name="is_rx" value="true" checked> RX
+                        </label>
+                        <label class="radio-inline">
+                            <input type="radio" name="is_rx" value="false"> Scaled
+                        </label>
+                    </div>
+                </div>
+                <div class="form-group form-group-submit">
+                    <label>&nbsp;</label>
+                    <button type="submit" class="btn btn-primary btn-sm">Save</button>
+                </div>
+            </div>
+        </form>
+
+        {% include "partials/benchmark_history.html" %}
+    </div>
+</div>

--- a/src/wodplanner/app/templates/partials/calendar_content.html
+++ b/src/wodplanner/app/templates/partials/calendar_content.html
@@ -79,7 +79,11 @@
                 {% if appt.has_benchmark %}
                 <div class="tooltip-btn-wrapper{% if is_first_benchmark and show_benchmark_tooltip %} has-tooltip{% endif %}">
                     <button class="btn btn-icon btn-sm btn-benchmark"
-                            title="{{ appt.benchmark_name }}">
+                            hx-get="/appointments/{{ appt.id }}/benchmark?date_start={{ appt.date_start }}%20{{ appt.time_start }}&class_name={{ appt.name | urlencode }}"
+                            hx-target="#benchmark-modal-container"
+                            hx-swap="innerHTML"
+                            onclick="openBenchmarkModal(); dismissTooltip('benchmark', this.closest('.tooltip-btn-wrapper'));"
+                            title="Log benchmark result for {{ appt.benchmark_name }}">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                             <circle cx="12" cy="12" r="10"/>
                             <polyline points="12 6 12 12 16 14"/>

--- a/src/wodplanner/models/benchmark.py
+++ b/src/wodplanner/models/benchmark.py
@@ -10,3 +10,13 @@ class BenchmarkWod(BaseModel):
     name: str
     category: str
     created_at: datetime | None = None
+
+
+class BenchmarkResult(BaseModel):
+    id: int | None = None
+    user_id: int
+    benchmark_name: str
+    time_seconds: int
+    is_rx: bool = True
+    recorded_at: str
+    created_at: datetime | None = None

--- a/src/wodplanner/services/benchmark.py
+++ b/src/wodplanner/services/benchmark.py
@@ -3,7 +3,7 @@
 import sqlite3
 from datetime import datetime
 
-from wodplanner.models.benchmark import BenchmarkWod
+from wodplanner.models.benchmark import BenchmarkResult, BenchmarkWod
 from wodplanner.services import migrations
 from wodplanner.services.base import BaseService
 from wodplanner.utils.dates import parse_iso_datetime
@@ -62,8 +62,24 @@ def _migrate_v601(conn: sqlite3.Connection) -> None:
         )
 
 
+def _migrate_v602(conn: sqlite3.Connection) -> None:
+    """Create benchmark_results table."""
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS benchmark_results (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            benchmark_name TEXT NOT NULL,
+            time_seconds INTEGER NOT NULL,
+            is_rx INTEGER NOT NULL DEFAULT 1,
+            recorded_at TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        )
+    """)
+
+
 migrations.register(600, "create benchmark_wods table", _migrate_v600)
 migrations.register(601, "seed default benchmark WODs", _migrate_v601)
+migrations.register(602, "create benchmark_results table", _migrate_v602)
 
 
 class BenchmarkService(BaseService):
@@ -93,3 +109,50 @@ class BenchmarkService(BaseService):
                 return True
         except sqlite3.IntegrityError:
             return False
+
+    def _row_to_result(self, row: sqlite3.Row) -> BenchmarkResult:
+        return BenchmarkResult(
+            id=row["id"],
+            user_id=row["user_id"],
+            benchmark_name=row["benchmark_name"],
+            time_seconds=row["time_seconds"],
+            is_rx=bool(row["is_rx"]),
+            recorded_at=row["recorded_at"],
+            created_at=parse_iso_datetime(row["created_at"]),
+        )
+
+    def add_result(
+        self, user_id: int, benchmark_name: str, time_seconds: int, is_rx: bool, recorded_at: str
+    ) -> BenchmarkResult:
+        with self._get_connection() as conn:
+            row = conn.execute(
+                "INSERT INTO benchmark_results (user_id, benchmark_name, time_seconds, is_rx, recorded_at, created_at) VALUES (?, ?, ?, ?, ?, ?) RETURNING *",
+                (user_id, benchmark_name.strip(), time_seconds, int(is_rx), recorded_at, datetime.now().isoformat()),
+            ).fetchone()
+            conn.commit()
+            return self._row_to_result(row)
+
+    def get_results_for_benchmark(self, user_id: int, benchmark_name: str) -> list[BenchmarkResult]:
+        with self._get_connection() as conn:
+            rows = conn.execute(
+                "SELECT * FROM benchmark_results WHERE user_id = ? AND benchmark_name = ? ORDER BY recorded_at DESC",
+                (user_id, benchmark_name),
+            ).fetchall()
+            return [self._row_to_result(row) for row in rows]
+
+    def get_result(self, user_id: int, result_id: int) -> BenchmarkResult | None:
+        with self._get_connection() as conn:
+            row = conn.execute(
+                "SELECT * FROM benchmark_results WHERE id = ? AND user_id = ?",
+                (result_id, user_id),
+            ).fetchone()
+            return self._row_to_result(row) if row else None
+
+    def delete_result(self, user_id: int, result_id: int) -> bool:
+        with self._get_connection() as conn:
+            cursor = conn.execute(
+                "DELETE FROM benchmark_results WHERE id = ? AND user_id = ?",
+                (result_id, user_id),
+            )
+            conn.commit()
+            return cursor.rowcount > 0

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -9,6 +9,7 @@ from wodplanner.api.client import WodAppClient
 from wodplanner.app.config import settings
 from wodplanner.app.dependencies import (
     get_api_cache_service,
+    get_benchmark_service,
     get_friends_service,
     get_one_rep_max_service,
     get_preferences_service,
@@ -16,6 +17,7 @@ from wodplanner.app.dependencies import (
 )
 from wodplanner.models.auth import AuthSession
 from wodplanner.services import session as cookie_session
+from wodplanner.services.benchmark import BenchmarkService
 from wodplanner.services.friends import FriendsService
 from wodplanner.services.login_limiter import limiter
 from wodplanner.services.one_rep_max import OneRepMaxService
@@ -29,6 +31,7 @@ def _clear_dep_caches() -> None:
         get_preferences_service,
         get_schedule_service,
         get_one_rep_max_service,
+        get_benchmark_service,
         get_api_cache_service,
     ):
         fn.cache_clear()
@@ -115,3 +118,8 @@ def preferences_service(db_path) -> PreferencesService:
 @pytest.fixture
 def one_rep_max_service(db_path) -> OneRepMaxService:
     return OneRepMaxService(db_path)
+
+
+@pytest.fixture
+def benchmark_service(db_path) -> BenchmarkService:
+    return BenchmarkService(db_path)

--- a/tests/app/routers/test_views.py
+++ b/tests/app/routers/test_views.py
@@ -387,3 +387,79 @@ class TestAddDeleteOneRepMax:
         app_client.cookies.set("session", session_cookie)
         response = app_client.delete(f"/one-rep-maxes/{entry.id}/delete")
         assert response.status_code == 200
+
+
+class TestBenchmarkModal:
+    def test_renders(self, app_client, session_cookie, schedule_service):
+        from datetime import date
+
+        schedule_service.add(
+            Schedule(date=date(2026, 4, 25), class_type="CrossFit", metcon="Fran for time", gym_id=100)
+        )
+        app_client.cookies.set("session", session_cookie)
+        response = app_client.get(
+            "/appointments/1/benchmark",
+            params={"date_start": "2026-04-25 10:00", "class_name": "CrossFit"},
+        )
+        assert response.status_code == 200
+        assert "Fran" in response.text
+
+    def test_shows_history(self, app_client, session_cookie, schedule_service, benchmark_service):
+        from datetime import date
+
+        schedule_service.add(
+            Schedule(date=date(2026, 4, 25), class_type="CrossFit", metcon="Fran", gym_id=100)
+        )
+        benchmark_service.add_result(
+            user_id=42, benchmark_name="Fran", time_seconds=180, is_rx=True, recorded_at="2026-05-05"
+        )
+        app_client.cookies.set("session", session_cookie)
+        response = app_client.get(
+            "/appointments/1/benchmark",
+            params={"date_start": "2026-04-25 10:00", "class_name": "CrossFit"},
+        )
+        assert response.status_code == 200
+        assert "3:00" in response.text
+
+
+class TestAddDeleteBenchmarkResult:
+    def test_add(self, app_client, session_cookie, benchmark_service):
+        app_client.cookies.set("session", session_cookie)
+        response = app_client.post(
+            "/benchmark-results/add",
+            data={
+                "benchmark_name": "Fran",
+                "minutes": "3",
+                "seconds": "0",
+                "is_rx": "true",
+                "recorded_at": "2026-05-05",
+            },
+        )
+        assert response.status_code == 200
+        results = benchmark_service.get_results_for_benchmark(42, "Fran")
+        assert len(results) == 1
+        assert results[0].time_seconds == 180
+
+    def test_add_invalid_time(self, app_client, session_cookie):
+        app_client.cookies.set("session", session_cookie)
+        response = app_client.post(
+            "/benchmark-results/add",
+            data={
+                "benchmark_name": "Fran",
+                "minutes": "0",
+                "seconds": "0",
+                "is_rx": "true",
+                "recorded_at": "2026-05-05",
+            },
+        )
+        assert response.status_code == 400
+
+    def test_delete(self, app_client, session_cookie, benchmark_service):
+        r = benchmark_service.add_result(
+            user_id=42, benchmark_name="Fran", time_seconds=180, is_rx=True, recorded_at="2026-05-05"
+        )
+        app_client.cookies.set("session", session_cookie)
+        response = app_client.delete(f"/benchmark-results/{r.id}/delete")
+        assert response.status_code == 200
+        results = benchmark_service.get_results_for_benchmark(42, "Fran")
+        assert len(results) == 0

--- a/tests/services/test_benchmark.py
+++ b/tests/services/test_benchmark.py
@@ -172,3 +172,73 @@ class TestBenchmarkService:
         svc.add_benchmark_wod("Test Benchmark", "The Girls")
         result = svc.add_benchmark_wod("Test Benchmark", "Hero")
         assert result is False
+
+
+class TestBenchmarkResultModel:
+    def test_can_create_result(self):
+        from wodplanner.models.benchmark import BenchmarkResult
+
+        r = BenchmarkResult(
+            user_id=42,
+            benchmark_name="Fran",
+            time_seconds=180,
+            is_rx=True,
+            recorded_at="2026-05-05",
+        )
+        assert r.user_id == 42
+        assert r.benchmark_name == "Fran"
+        assert r.time_seconds == 180
+        assert r.is_rx is True
+        assert r.recorded_at == "2026-05-05"
+
+
+class TestBenchmarkResultService:
+    def test_add_and_get_results(self, db_path):
+        svc = BenchmarkService(db_path)
+        svc.add_result(user_id=1, benchmark_name="Fran", time_seconds=180, is_rx=True, recorded_at="2026-05-05")
+        results = svc.get_results_for_benchmark(user_id=1, benchmark_name="Fran")
+        assert len(results) == 1
+        assert results[0].time_seconds == 180
+        assert results[0].is_rx is True
+
+    def test_results_ordered_by_date_desc(self, db_path):
+        svc = BenchmarkService(db_path)
+        svc.add_result(user_id=1, benchmark_name="Fran", time_seconds=300, is_rx=True, recorded_at="2026-05-04")
+        svc.add_result(user_id=1, benchmark_name="Fran", time_seconds=180, is_rx=True, recorded_at="2026-05-05")
+        results = svc.get_results_for_benchmark(user_id=1, benchmark_name="Fran")
+        assert results[0].recorded_at == "2026-05-05"
+        assert results[1].recorded_at == "2026-05-04"
+
+    def test_scoped_by_user(self, db_path):
+        svc = BenchmarkService(db_path)
+        svc.add_result(user_id=1, benchmark_name="Fran", time_seconds=180, is_rx=True, recorded_at="2026-05-05")
+        results = svc.get_results_for_benchmark(user_id=2, benchmark_name="Fran")
+        assert len(results) == 0
+
+    def test_scoped_by_benchmark_name(self, db_path):
+        svc = BenchmarkService(db_path)
+        svc.add_result(user_id=1, benchmark_name="Fran", time_seconds=180, is_rx=True, recorded_at="2026-05-05")
+        svc.add_result(user_id=1, benchmark_name="Helen", time_seconds=600, is_rx=True, recorded_at="2026-05-05")
+        results = svc.get_results_for_benchmark(user_id=1, benchmark_name="Fran")
+        assert len(results) == 1
+        assert results[0].benchmark_name == "Fran"
+
+    def test_delete_result(self, db_path):
+        svc = BenchmarkService(db_path)
+        r = svc.add_result(user_id=1, benchmark_name="Fran", time_seconds=180, is_rx=True, recorded_at="2026-05-05")
+        svc.delete_result(user_id=1, result_id=r.id)
+        results = svc.get_results_for_benchmark(user_id=1, benchmark_name="Fran")
+        assert len(results) == 0
+
+    def test_delete_scoped_by_user(self, db_path):
+        svc = BenchmarkService(db_path)
+        r = svc.add_result(user_id=1, benchmark_name="Fran", time_seconds=180, is_rx=True, recorded_at="2026-05-05")
+        svc.delete_result(user_id=2, result_id=r.id)
+        results = svc.get_results_for_benchmark(user_id=1, benchmark_name="Fran")
+        assert len(results) == 1
+
+    def test_add_result_returns_model_with_id(self, db_path):
+        svc = BenchmarkService(db_path)
+        r = svc.add_result(user_id=1, benchmark_name="Fran", time_seconds=180, is_rx=True, recorded_at="2026-05-05")
+        assert r.id is not None
+        assert r.user_id == 1


### PR DESCRIPTION
## Summary

Implements benchmark WOD result logging via modal on the calendar, building on the detection infrastructure from Slice 1.

### Changes

- **Model**: `BenchmarkResult` with `user_id`, `benchmark_name`, `time_seconds`, `is_rx`, `recorded_at`
- **DB migration v602**: `benchmark_results` table
- **BenchmarkService CRUD**: `add_result`, `get_result`, `get_results_for_benchmark`, `delete_result` (all scoped by user)
- **Routes**:
  - `GET /appointments/{id}/benchmark` — returns benchmark modal HTML with pre-filled name + history
  - `POST /benchmark-results/add` — accepts minutes/seconds/RX/scaled, returns updated history partial
  - `DELETE /benchmark-results/{id}/delete` — removes entry, returns updated history partial
- **Templates**: `benchmark_modal.html` (mm:ss inputs, RX/scaled toggle, submit), `benchmark_history.html` (table with date/time/badge/delete)
- **Calendar**: stopwatch button now opens functional modal via HTMX
- **CSS**: benchmark form, table, badge (RX blue, scaled amber), radio group, responsive layout

### Acceptance criteria covered

- [x] `benchmark_results` table with columns `id`, `user_id`, `benchmark_name`, `time_seconds` (INT), `is_rx` (INT boolean), `recorded_at`, `created_at`
- [x] `BenchmarkService.add_result(...)` persists a result
- [x] `BenchmarkService.get_results_for_benchmark(user_id, benchmark_name)` returns history sorted by date DESC
- [x] `BenchmarkService.delete_result(user_id, result_id)` removes a result scoped by user
- [x] `GET /appointments/{id}/benchmark` returns the benchmark modal HTML with pre-filled benchmark name
- [x] `POST /benchmark-results/add` accepts form data and returns updated history partial
- [x] `DELETE /benchmark-results/{id}/delete` removes entry and returns updated history partial
- [x] Modal has minutes + seconds number inputs, RX/scaled radio toggle, and submit button
- [x] History table shows date, time (formatted as M:SS), RX/scaled badge, and delete button
- [x] Calendar stopwatch icon opens the functional benchmark modal
- [x] Tests cover service CRUD operations, modal route, and submit/delete routes
- [x] Imports/exports are clean, no circular deps

### Tests

All 643 existing tests pass, plus 13 new tests (8 service + 5 route).