### PR TITLE
fix: benchmark WOD detection bugs (false positives + Murph missed)

### DIFF
--- a/src/wodplanner/app/templates/partials/calendar_content.html
+++ b/src/wodplanner/app/templates/partials/calendar_content.html
@@ -88,7 +88,6 @@
                             <circle cx="12" cy="12" r="10"/>
                             <polyline points="12 6 12 12 16 14"/>
                         </svg>
-                        <span class="benchmark-label">{{ appt.benchmark_name }}</span>
                     </button>
                     {% if is_first_benchmark and show_benchmark_tooltip %}
                     <div id="tooltip-benchmark" class="filter-tooltip">

--- a/src/wodplanner/services/benchmark.py
+++ b/src/wodplanner/services/benchmark.py
@@ -1,5 +1,6 @@
 """Benchmark WOD detection and service."""
 
+import re
 import sqlite3
 from datetime import datetime
 
@@ -31,7 +32,7 @@ def find_benchmark_in_schedule(
         return None
     lower_combined = combined.lower()
     for name in benchmark_names:
-        if name.lower() in lower_combined:
+        if re.search(r'\b' + re.escape(name.lower()) + r'\b', lower_combined):
             return name
     return None
 

--- a/src/wodplanner/services/day_card.py
+++ b/src/wodplanner/services/day_card.py
@@ -46,8 +46,14 @@ def _find_benchmark(
     benchmark_names: list[str],
 ) -> str | None:
     """Check if appointment's matched Schedule contains a benchmark WOD."""
+    if not benchmark_names:
+        return None
+    lower_name = appt_name.lower()
+    for name in benchmark_names:
+        if name.lower() == lower_name:
+            return name
     sched = schedule_by_class_type.get(appt_name)
-    if sched is None or not benchmark_names:
+    if sched is None:
         return None
     texts = [
         getattr(sched, "warmup_mobility", None),

--- a/tests/services/test_benchmark.py
+++ b/tests/services/test_benchmark.py
@@ -55,6 +55,22 @@ class TestFindBenchmarkInSchedule:
         )
         assert result == "Cindy"
 
+    def test_no_match_for_partial_word(self):
+        names = ["Eva", "Grace", "Nancy"]
+        result = find_benchmark_in_schedule(
+            schedule_texts=["Coach: Evangelina | Warm-up: 400m run"],
+            benchmark_names=names,
+        )
+        assert result is None
+
+    def test_partial_word_does_not_shadow_real_match(self):
+        names = ["Eva", "Fran"]
+        result = find_benchmark_in_schedule(
+            schedule_texts=["Coach: Evangelina | Metcon: Fran"],
+            benchmark_names=names,
+        )
+        assert result == "Fran"
+
 
 class TestDayCardEnrichment:
     def test_benchmark_enrichment_adds_fields(self):

--- a/tests/services/test_day_card.py
+++ b/tests/services/test_day_card.py
@@ -242,6 +242,44 @@ class TestOneRMFlag:
         assert result[0].has_1rm is False
 
 
+class TestBenchmarkFlag:
+    def test_detected_from_appointment_name_no_schedule(self):
+        appt = _make_appointment(name="Murph")
+        result = build_day_cards(
+            appointments=[appt],
+            friends_by_appt_id={},
+            schedule_by_class_type={},
+            now=datetime(2026, 6, 10, tzinfo=TZ),
+            benchmark_names=["Murph", "Fran", "Helen"],
+        )
+        assert result[0].has_benchmark is True
+        assert result[0].benchmark_name == "Murph"
+
+    def test_appointment_name_match_case_insensitive(self):
+        appt = _make_appointment(name="murph")
+        result = build_day_cards(
+            appointments=[appt],
+            friends_by_appt_id={},
+            schedule_by_class_type={},
+            now=datetime(2026, 6, 10, tzinfo=TZ),
+            benchmark_names=["Murph", "Fran"],
+        )
+        assert result[0].has_benchmark is True
+        assert result[0].benchmark_name == "Murph"
+
+    def test_no_benchmark_for_non_benchmark_name_without_schedule(self):
+        appt = _make_appointment(name="CrossFit")
+        result = build_day_cards(
+            appointments=[appt],
+            friends_by_appt_id={},
+            schedule_by_class_type={},
+            now=datetime(2026, 6, 10, tzinfo=TZ),
+            benchmark_names=["Murph", "Fran"],
+        )
+        assert result[0].has_benchmark is False
+        assert result[0].benchmark_name is None
+
+
 class TestIsPast:
     def test_future_appointment_not_past(self):
         appt = _make_appointment()


### PR DESCRIPTION
## Summary

- **False positives**: `find_benchmark_in_schedule` used plain substring match — "Eva" hit inside coach names like "Evangelina". Switched to `\b` word-boundary regex.
- **Murph not detected**: Classes named after the benchmark (e.g. WodApp event literally called "Murph") have no PDF schedule entry. Detection bailed early when schedule lookup returned `None`. Now checks if `appt_name` itself exactly matches a benchmark name before falling back to schedule text scan.
- **Button showed name**: Removed `<span class="benchmark-label">` from calendar button — icon only now.

## Test plan

- [ ] `test_no_match_for_partial_word` — "Evangelina" does not trigger "Eva"
- [ ] `test_partial_word_does_not_shadow_real_match` — partial word + real match in same text → only real match returned
- [ ] `test_detected_from_appointment_name_no_schedule` — appt named "Murph", no schedule → detected
- [ ] `test_appointment_name_match_case_insensitive` — "murph" → "Murph"
- [ ] `test_no_benchmark_for_non_benchmark_name_without_schedule` — "CrossFit" with no schedule → no match
- [ ] All 643 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)