### PR TITLE
fix: benchmark modal 404s when class name is the benchmark (e.g. Murph)

### DIFF
--- a/src/wodplanner/app/routers/views.py
+++ b/src/wodplanner/app/routers/views.py
@@ -817,15 +817,17 @@ def benchmark_modal_view(
     schedule_date = parse_iso_date(date_start.split(" ")[0])
     schedule = match_schedule(class_name, schedule_date, gym_id=session.gym_id, schedule_service=schedule_service)
 
-    benchmark_name = None
-    if schedule:
+    benchmark_names = benchmark_service.get_benchmark_list()
+    lower_class = class_name.lower()
+    benchmark_name = next((n for n in benchmark_names if n.lower() == lower_class), None)
+
+    if not benchmark_name and schedule:
         texts = [
             getattr(schedule, "warmup_mobility", None),
             getattr(schedule, "strength_specialty", None),
             getattr(schedule, "metcon", None),
             getattr(schedule, "raw_content", None),
         ]
-        benchmark_names = benchmark_service.get_benchmark_list()
         benchmark_name = find_benchmark_in_schedule(texts, benchmark_names)
 
     if not benchmark_name:


### PR DESCRIPTION
## Summary

- The benchmark modal route (`GET /appointments/{id}/benchmark`) only scanned schedule text to resolve the benchmark name. Classes named after a benchmark (e.g. a WodApp event literally called "Murph") have no PDF schedule entry — `schedule` was `None`, detection skipped, 404 returned, modal never opened.
- Fix mirrors the `day_card.py` fix from #88: check `class_name` directly against the benchmark list first, fall back to schedule text scan.

## Test plan

- [ ] All 648 tests pass
- [ ] Clicking benchmark button on a "Murph" class opens the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)