### PR TITLE
Highlight reservation days in calendar date picker

### DIFF
--- a/src/wodplanner/app/routers/views.py
+++ b/src/wodplanner/app/routers/views.py
@@ -244,6 +244,9 @@ def calendar_page(
     dismissed = set(prefs_service.get_dismissed_tooltips(session.user_id))
     appt_data = _fetch_calendar_data(session, target_date, client, friends_service, schedule_service, benchmark_service, set(hidden_types))
 
+    reservations, _ = client.get_upcoming_reservations()
+    reservation_dates = sorted({r.date_start.strftime("%Y-%m-%d") for r in reservations})
+
     weekday = target_date.strftime("%A")
     filters = [{"name": t, "hidden": t in hidden_types} for t in FILTERABLE_CLASS_TYPES]
 
@@ -260,6 +263,7 @@ def calendar_page(
             "today": date.today().isoformat(),
             "current_date": target_date.isoformat(),
             "filters": filters,
+            "reservation_dates": reservation_dates,
             **_get_tooltip_context(dismissed, appt_data),
             **get_user_context(session),
         },
@@ -286,6 +290,9 @@ def calendar_day_partial(
     dismissed = set(prefs_service.get_dismissed_tooltips(session.user_id))
     appt_data = _fetch_calendar_data(session, target_date, client, friends_service, schedule_service, benchmark_service, set(hidden_types))
 
+    reservations, _ = client.get_upcoming_reservations()
+    reservation_dates = sorted({r.date_start.strftime("%Y-%m-%d") for r in reservations})
+
     weekday = target_date.strftime("%A")
     filters = [{"name": t, "hidden": t in hidden_types} for t in FILTERABLE_CLASS_TYPES]
 
@@ -301,6 +308,7 @@ def calendar_day_partial(
             "today": date.today().isoformat(),
             "current_date": target_date.isoformat(),
             "filters": filters,
+            "reservation_dates": reservation_dates,
             **_get_tooltip_context(dismissed, appt_data),
         },
     )

--- a/src/wodplanner/app/static/css/style.css
+++ b/src/wodplanner/app/static/css/style.css
@@ -258,6 +258,10 @@ body {
     background: var(--primary-dark);
 }
 
+.calendar-day.has-reservation {
+    border-bottom: 3px solid var(--success);
+}
+
 /* Filters */
 .filters-toggle-btn {
     background: var(--gray-100);

--- a/src/wodplanner/app/templates/base.html
+++ b/src/wodplanner/app/templates/base.html
@@ -168,6 +168,15 @@
             var today = new Date();
             var todayStr = today.toISOString().split('T')[0];
 
+            var currentDateEl = document.querySelector('.current-date');
+            var reservationDates = [];
+            if (currentDateEl && currentDateEl.dataset.reservationDates) {
+                try {
+                    reservationDates = JSON.parse(currentDateEl.dataset.reservationDates);
+                } catch(e) {}
+            }
+            var reservationSet = new Set(reservationDates);
+
             var monthNames = ['January', 'February', 'March', 'April', 'May', 'June',
                               'July', 'August', 'September', 'October', 'November', 'December'];
             var dayNames = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'];
@@ -196,7 +205,9 @@
             for (var i = startDay - 1; i >= 0; i--) {
                 var day = prevMonthDays - i;
                 var dateStr = formatDate(year, month - 1, day);
-                html += '<div class="calendar-day other-month" onclick="selectDate(\'' + dateStr + '\')">' + day + '</div>';
+                var cls = 'calendar-day other-month';
+                if (reservationSet.has(dateStr)) cls += ' has-reservation';
+                html += '<div class="' + cls + '" onclick="selectDate(\'' + dateStr + '\')">' + day + '</div>';
             }
 
             // Current month days
@@ -205,6 +216,7 @@
                 var classes = 'calendar-day';
                 if (dateStr === todayStr) classes += ' today';
                 if (dateStr === selectedDate) classes += ' selected';
+                if (reservationSet.has(dateStr)) classes += ' has-reservation';
                 html += '<div class="' + classes + '" onclick="selectDate(\'' + dateStr + '\')">' + d + '</div>';
             }
 
@@ -213,7 +225,9 @@
             var remaining = (7 - (totalCells % 7)) % 7;
             for (var i = 1; i <= remaining; i++) {
                 var dateStr = formatDate(year, month + 1, i);
-                html += '<div class="calendar-day other-month" onclick="selectDate(\'' + dateStr + '\')">' + i + '</div>';
+                var cls = 'calendar-day other-month';
+                if (reservationSet.has(dateStr)) cls += ' has-reservation';
+                html += '<div class="' + cls + '" onclick="selectDate(\'' + dateStr + '\')">' + i + '</div>';
             }
 
             html += '</div>';

--- a/src/wodplanner/app/templates/calendar.html
+++ b/src/wodplanner/app/templates/calendar.html
@@ -13,7 +13,7 @@
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="15 18 9 12 15 6"></polyline></svg>
         </button>
         <div class="date-picker-wrapper{% if active_tooltip == 'date_picker' %} tooltip-btn-wrapper has-tooltip{% endif %}">
-            <span class="current-date" onclick="toggleCalendar(); dismissTooltip('date_picker', this.closest('.tooltip-btn-wrapper'));" data-date="{{ current_date }}">{{ display_date }}</span>
+            <span class="current-date" onclick="toggleCalendar(); dismissTooltip('date_picker', this.closest('.tooltip-btn-wrapper'));" data-date="{{ current_date }}" data-reservation-dates='{{ reservation_dates | tojson }}'>{{ display_date }}</span>
             <div id="calendar-dropdown" class="calendar-dropdown"></div>
             <div id="tooltip-date_picker" class="filter-tooltip date-picker" {% if active_tooltip != 'date_picker' %}hidden{% endif %}>
                 <p>Tap the date to jump to any day.</p>

--- a/src/wodplanner/app/templates/partials/calendar_day.html
+++ b/src/wodplanner/app/templates/partials/calendar_day.html
@@ -9,7 +9,7 @@
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="15 18 9 12 15 6"></polyline></svg>
     </button>
     <div class="date-picker-wrapper{% if active_tooltip == 'date_picker' %} tooltip-btn-wrapper has-tooltip{% endif %}">
-        <span class="current-date" onclick="toggleCalendar(); dismissTooltip('date_picker', this.closest('.tooltip-btn-wrapper'));" data-date="{{ current_date }}">{{ display_date }}</span>
+        <span class="current-date" onclick="toggleCalendar(); dismissTooltip('date_picker', this.closest('.tooltip-btn-wrapper'));" data-date="{{ current_date }}" data-reservation-dates='{{ reservation_dates | tojson }}'>{{ display_date }}</span>
         <div id="calendar-dropdown" class="calendar-dropdown"></div>
         <div id="tooltip-date_picker" class="filter-tooltip date-picker" {% if active_tooltip != 'date_picker' %}hidden{% endif %}>
             <p>Tap the date to jump to any day.</p>

--- a/tests/app/routers/test_views.py
+++ b/tests/app/routers/test_views.py
@@ -94,28 +94,64 @@ class TestHomePage:
 class TestCalendarPage:
     def test_renders(self, app_client, session_cookie, mock_wodapp_client):
         mock_wodapp_client.get_day_schedule.return_value = []
+        mock_wodapp_client.get_upcoming_reservations.return_value = ([], {})
         app_client.cookies.set("session", session_cookie)
         response = app_client.get("/calendar")
         assert response.status_code == 200
 
     def test_with_day_param(self, app_client, session_cookie, mock_wodapp_client):
         mock_wodapp_client.get_day_schedule.return_value = [_appt()]
+        mock_wodapp_client.get_upcoming_reservations.return_value = ([], {})
         app_client.cookies.set("session", session_cookie)
         response = app_client.get("/calendar?day=2026-04-25")
         assert response.status_code == 200
+
+    def test_reservation_dates_in_template(self, app_client, session_cookie, mock_wodapp_client):
+        mock_wodapp_client.get_day_schedule.return_value = []
+        mock_wodapp_client.get_upcoming_reservations.return_value = (
+            [
+                Reservation(id_appointment=1, name="CrossFit", date_start=datetime(2026, 4, 25, 10, 0)),
+                Reservation(id_appointment=2, name="Yoga", date_start=datetime(2026, 4, 27, 9, 0)),
+            ],
+            {},
+        )
+        app_client.cookies.set("session", session_cookie)
+        response = app_client.get("/calendar")
+        assert response.status_code == 200
+        assert 'data-reservation-dates=' in response.text
+        assert '"2026-04-25"' in response.text
+        assert '"2026-04-27"' in response.text
 
 
 class TestCalendarDayPartial:
     def test_partial(self, app_client, session_cookie, mock_wodapp_client):
         mock_wodapp_client.get_day_schedule.return_value = [_appt()]
+        mock_wodapp_client.get_upcoming_reservations.return_value = ([], {})
         app_client.cookies.set("session", session_cookie)
         response = app_client.get("/calendar/2026-04-25")
         assert response.status_code == 200
+
+    def test_reservation_dates_in_partial(self, app_client, session_cookie, mock_wodapp_client):
+        mock_wodapp_client.get_day_schedule.return_value = [_appt()]
+        mock_wodapp_client.get_upcoming_reservations.return_value = (
+            [
+                Reservation(id_appointment=1, name="CrossFit", date_start=datetime(2026, 4, 25, 10, 0)),
+                Reservation(id_appointment=2, name="Yoga", date_start=datetime(2026, 4, 27, 9, 0)),
+            ],
+            {},
+        )
+        app_client.cookies.set("session", session_cookie)
+        response = app_client.get("/calendar/2026-04-25")
+        assert response.status_code == 200
+        assert 'data-reservation-dates=' in response.text
+        assert '"2026-04-25"' in response.text
+        assert '"2026-04-27"' in response.text
 
 
 class TestToggleFilter:
     def test_toggle_persists(self, app_client, session_cookie, mock_wodapp_client, preferences_service):
         mock_wodapp_client.get_day_schedule.return_value = []
+        mock_wodapp_client.get_upcoming_reservations.return_value = ([], {})
         app_client.cookies.set("session", session_cookie)
         response = app_client.post(
             "/filters/toggle/CrossFit", data={"current_date": "2026-04-25"}
@@ -176,6 +212,7 @@ class TestSubscribeUnsubscribeViews:
             status="OK", subscribedWithSuccess=1
         )
         mock_wodapp_client.get_day_schedule.return_value = []
+        mock_wodapp_client.get_upcoming_reservations.return_value = ([], {})
         app_client.cookies.set("session", session_cookie)
         response = app_client.post(
             "/appointments/1/subscribe",
@@ -189,6 +226,7 @@ class TestSubscribeUnsubscribeViews:
             status="OK"
         )
         mock_wodapp_client.get_day_schedule.return_value = []
+        mock_wodapp_client.get_upcoming_reservations.return_value = ([], {})
         app_client.cookies.set("session", session_cookie)
         response = app_client.post(
             "/appointments/1/waitinglist",
@@ -199,6 +237,7 @@ class TestSubscribeUnsubscribeViews:
     def test_unsubscribe(self, app_client, session_cookie, mock_wodapp_client):
         mock_wodapp_client.unsubscribe.return_value = SubscribeResponse(status="OK")
         mock_wodapp_client.get_day_schedule.return_value = []
+        mock_wodapp_client.get_upcoming_reservations.return_value = ([], {})
         app_client.cookies.set("session", session_cookie)
         response = app_client.post(
             "/appointments/1/unsubscribe",
@@ -214,6 +253,7 @@ class TestSubscribeUnsubscribeViews:
     def test_unsubscribe_waitinglist(self, app_client, session_cookie, mock_wodapp_client):
         mock_wodapp_client.unsubscribe_waitinglist.return_value = SubscribeResponse(status="OK")
         mock_wodapp_client.get_day_schedule.return_value = []
+        mock_wodapp_client.get_upcoming_reservations.return_value = ([], {})
         app_client.cookies.set("session", session_cookie)
         response = app_client.post(
             "/appointments/1/unsubscribe",


### PR DESCRIPTION
Closes #103

- Wire reservation_dates through calendar_page and calendar_day_partial routes
- Add data-reservation-dates JSON attribute to .current-date span in both templates
- renderCalendar() JS reads dataset, appends `has-reservation` class to matching day cells
- CSS: `.calendar-day.has-reservation { border-bottom: 3px solid var(--success); }`
- OOB swap of #date-nav carries data-reservation-dates forward on navigation
- All 653 existing tests pass, 2 new integration tests cover the behavior