### PR TITLE
fix: scope cache keys to user_id to prevent cross-user reservation leak

### DIFF
--- a/src/wodplanner/api/client.py
+++ b/src/wodplanner/api/client.py
@@ -380,7 +380,7 @@ class WodAppClient:
         Returns:
             Tuple of (list of Reservation sorted by date_start, company_images)
         """
-        cache_key = f"{self.session.agenda_id}:upcoming_reservations"
+        cache_key = f"{self.session.user_id}:{self.session.agenda_id}:upcoming_reservations"
 
         if self._cache:
             cached = self._cache.get(cache_key)
@@ -431,7 +431,7 @@ class WodAppClient:
         expected_total: int | None = None,
     ) -> tuple[list[Member], WaitingList]:
         """Return subscribed members and waiting list. Cached when ApiCacheService is available."""
-        cache_key = f"{self.session.agenda_id}:{appointment_id}:{date_start.isoformat()}:{date_end.isoformat()}"
+        cache_key = f"{self.session.user_id}:{self.session.agenda_id}:{appointment_id}:{date_start.isoformat()}:{date_end.isoformat()}"
 
         if self._cache:
             cached = self._cache.get(cache_key)

--- a/tests/api/test_client.py
+++ b/tests/api/test_client.py
@@ -516,7 +516,7 @@ class TestWodAppClientGetUpcomingReservationsCache:
         )
         client._session = session
 
-        cache_key = "5:upcoming_reservations"
+        cache_key = "1:5:upcoming_reservations"
         pre_cache = (
             [Reservation(id_appointment=99, name="Cached", date_start=datetime(2026, 4, 23, 10, 0))],
             {"logo": "cached.png"},
@@ -587,7 +587,7 @@ class TestWodAppClientGetUpcomingReservationsCache:
         )
         client._session = session
 
-        cache_key = "5:upcoming_reservations"
+        cache_key = "1:5:upcoming_reservations"
         stale_data = (
             [Reservation(id_appointment=99, name="Stale", date_start=datetime(2026, 4, 23, 10, 0))],
             {},
@@ -694,7 +694,7 @@ class TestWodAppClientGetAppointmentMembers:
         )
         client._session = session
 
-        cache_key = f"5:1:{datetime(2026, 4, 23, 10, 0).isoformat()}:{datetime(2026, 4, 23, 11, 0).isoformat()}"
+        cache_key = f"1:5:1:{datetime(2026, 4, 23, 10, 0).isoformat()}:{datetime(2026, 4, 23, 11, 0).isoformat()}"
         pre_cache_members = [Member(id_appuser=99, name="CachedUser", imageURL="")]
         cache.set(cache_key, (pre_cache_members, WaitingList(total=0, members=[])))
 
@@ -748,7 +748,7 @@ class TestWodAppClientGetAppointmentMembers:
         )
         client._session = session
 
-        cache_key = f"5:1:{datetime(2026, 4, 23, 10, 0).isoformat()}:{datetime(2026, 4, 23, 11, 0).isoformat()}"
+        cache_key = f"1:5:1:{datetime(2026, 4, 23, 10, 0).isoformat()}:{datetime(2026, 4, 23, 11, 0).isoformat()}"
         pre_cache_members = [Member(id_appuser=99, name="CachedUser", imageURL="")]
         cache.set(cache_key, (pre_cache_members, WaitingList(total=0, members=[])))
 


### PR DESCRIPTION
## What

Cache keys for `get_upcoming_reservations()` and `get_appointment_members()` used only `agenda_id`, which is the same for all users at the same gym.

## Bug

When User A visits the homepage, their reservations are cached under `{agenda_id}:upcoming_reservations`. When User B (same gym) visits moments later, they get User A's cached reservations.

## Fix

Added `user_id` to both cache keys so each user has their own cache entries:

- `{agenda_id}:upcoming_reservations` → `{user_id}:{agenda_id}:upcoming_reservations`
- `{agenda_id}:{id}:{start}:{end}` → `{user_id}:{agenda_id}:{id}:{start}:{end}`

## Verification

- All 653 tests pass
- Ruff lint clean
- No new mypy errors