### PR TITLE
fix: calendar month pagination buttons close dropdown immediately

### DIFF
--- a/src/wodplanner/app/templates/base.html
+++ b/src/wodplanner/app/templates/base.html
@@ -188,9 +188,9 @@
             var prevMonthDays = new Date(year, month, 0).getDate();
 
             var html = '<div class="calendar-header">';
-            html += '<button onclick="changeMonth(-1)">&larr;</button>';
+            html += '<button onclick="changeMonth(-1); event.stopPropagation();">&larr;</button>';
             html += '<span class="calendar-month-year">' + monthNames[month] + ' ' + year + '</span>';
-            html += '<button onclick="changeMonth(1)">&rarr;</button>';
+            html += '<button onclick="changeMonth(1); event.stopPropagation();">&rarr;</button>';
             html += '</div>';
 
             html += '<div class="calendar-weekdays">';


### PR DESCRIPTION
When clicking the prev/next month arrows in the drop-down calendar, the dropdown closes immediately instead of navigating to the new month.

**Root cause:** changeMonth() calls renderCalendar() which replaces dropdown.innerHTML, detaching the clicked button from the DOM. The click event bubbles to the document-level click-outside handler, which can't find the button inside .date-picker-wrapper (it's detached), so it closes the dropdown.

**Fix:** Added event.stopPropagation() to the month nav button onclick handlers, preventing the event from reaching the close handler.