### PR TITLE
feat: auto-detect Benchmark WODs during schedule PDF import

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ ruff check .
 mypy src
 
 # Import workout schedule from PDF (--dry-run to preview)
+# Auto-detects Benchmark WODs (Benchmark 'Name' or Benchmark Name) and 1RM exercises interactively
 # Test PDFs in examples/pdf/ (Bull_202602.pdf–Bull_202605.pdf)
 import-schedule schedule.pdf --year 2026 --gym-id 2495
 import-schedule schedule.pdf --year 2026 --gym-id 2495 --dry-run
@@ -43,6 +44,9 @@ import-schedule schedule.pdf --year 2026 --gym-id 2495 --dry-run
 # Manage 1RM exercise list (fuzzy-match, add new, rename)
 add-1rm --exercise "Back Squat"
 add-1rm  # interactive: shows existing list, prompts for name
+
+# Manage benchmark WOD list (add names for detection)
+add-benchmark --name "Nasty Girls"
 
 # Backup database (safe during live writes, keeps 7 by default)
 backup-db

--- a/src/wodplanner/cli/import_schedule.py
+++ b/src/wodplanner/cli/import_schedule.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pdfplumber
 
 from wodplanner.models.schedule import Schedule
+from wodplanner.services.benchmark import BenchmarkService, extract_benchmark_names
 from wodplanner.services.migrations import ensure_migrations
 from wodplanner.services.one_rep_max import (
     OneRepMaxService,
@@ -323,7 +324,31 @@ def main():
                 exercises.sort()
                 print(f'  Added new exercise: "{resolved}"')
             else:
-                print(f'  Matched "{raw_name}" → "{resolved}"')
+                print(f'  Matched "{raw_name}" \u2192 "{resolved}"')
+
+    # Resolve benchmark WODs found in the PDF
+    bm_service = BenchmarkService(args.db)
+    existing_benchmarks = bm_service.get_benchmark_list()
+
+    all_bm_raw: list[str] = []
+    for s in schedules:
+        all_bm_raw.extend(extract_benchmark_names(s.metcon or ""))
+
+    unique_bm = list(dict.fromkeys(all_bm_raw))
+    if unique_bm:
+        print("\n--- Benchmark WOD Detection ---")
+        for name in unique_bm:
+            if name in existing_benchmarks:
+                print(f'  Already exists: "{name}"')
+            else:
+                answer = input(f'  Add "{name}" to benchmark list? [y/N]: ').strip().lower()
+                if answer == "y":
+                    bm_service.add_benchmark_wod(name, "Benchmark")
+                    existing_benchmarks.append(name)
+                    existing_benchmarks.sort()
+                    print(f'  Added: "{name}"')
+                else:
+                    print(f'  Skipped: "{name}"')
 
     # Save to database
     print(f"\nSaving to database: {args.db}")

--- a/src/wodplanner/services/benchmark.py
+++ b/src/wodplanner/services/benchmark.py
@@ -9,6 +9,30 @@ from wodplanner.services import migrations
 from wodplanner.services.base import BaseService
 from wodplanner.utils.dates import parse_iso_datetime
 
+_BENCHMARK_PATTERN = re.compile(
+    r'Benchmark\s+\u2018([^\u2019]+)\u2019|Benchmark\s+([^\n]+)',
+    re.IGNORECASE,
+)
+
+
+def extract_benchmark_names(text: str | None) -> list[str]:
+    """Extract benchmark WOD names from schedule text.
+
+    Matches patterns like:
+      Benchmark 'Cindy'            -> "Cindy"
+      Benchmark 'Nasty Girls'      -> "Nasty Girls"
+      Benchmark Battle of the Bull 22.3  -> "Battle of the Bull 22.3"
+    """
+    if not text:
+        return []
+    names = []
+    for match in _BENCHMARK_PATTERN.finditer(text):
+        name = (match.group(1) or match.group(2)).strip().rstrip(',.:;')
+        if name:
+            names.append(name)
+    return names
+
+
 _SEED_BENCHMARKS: dict[str, list[str]] = {
     "The Girls": [
         "Fran", "Helen", "Cindy", "Annie", "Isabel", "Jackie", "Karen",

--- a/tests/cli/test_import_schedule_main.py
+++ b/tests/cli/test_import_schedule_main.py
@@ -19,6 +19,14 @@ def _schedule() -> Schedule:
     )
 
 
+def _schedule_with_benchmark() -> Schedule:
+    return Schedule(
+        date=date(2026, 5, 22),
+        class_type="CrossFit",
+        metcon="MetCon\nBenchmark \u2018Nasty Girls\u2019\n3 Rounds Of",
+    )
+
+
 class TestImportScheduleMain:
     def test_missing_pdf_exits_1(self, monkeypatch, tmp_path, capsys):
         monkeypatch.setattr(
@@ -123,3 +131,63 @@ class TestImportScheduleMain:
                 import_schedule.main()
         out = capsys.readouterr().out
         assert "..." in out
+
+    def test_benchmark_detected_and_added(self, monkeypatch, tmp_path):
+        pdf = tmp_path / "x.pdf"
+        pdf.touch()
+        db = tmp_path / "test.db"
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "import-schedule",
+                str(pdf),
+                "--year",
+                "2026",
+                "--gym-id",
+                "100",
+                "--db",
+                str(db),
+            ],
+        )
+        schedule = _schedule_with_benchmark()
+        with patch.object(
+            import_schedule, "extract_schedules_from_pdf", return_value=[schedule]
+        ), patch.object(
+            import_schedule, "resolve_exercise_interactive", return_value=None
+        ), patch("builtins.input", return_value="y"):
+            import_schedule.main()
+        from wodplanner.services.benchmark import BenchmarkService
+
+        bm_svc = BenchmarkService(db)
+        names = bm_svc.get_benchmark_list()
+        assert "Nasty Girls" in names
+
+    def test_benchmark_detected_and_skipped(self, monkeypatch, tmp_path):
+        pdf = tmp_path / "x.pdf"
+        pdf.touch()
+        db = tmp_path / "test.db"
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "import-schedule",
+                str(pdf),
+                "--year",
+                "2026",
+                "--gym-id",
+                "100",
+                "--db",
+                str(db),
+            ],
+        )
+        schedule = _schedule_with_benchmark()
+        with patch.object(
+            import_schedule, "extract_schedules_from_pdf", return_value=[schedule]
+        ), patch.object(
+            import_schedule, "resolve_exercise_interactive", return_value=None
+        ), patch("builtins.input", return_value="n"):
+            import_schedule.main()
+        from wodplanner.services.benchmark import BenchmarkService
+
+        bm_svc = BenchmarkService(db)
+        names = bm_svc.get_benchmark_list()
+        assert "Nasty Girls" not in names

--- a/tests/services/test_benchmark.py
+++ b/tests/services/test_benchmark.py
@@ -3,7 +3,11 @@
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
-from wodplanner.services.benchmark import BenchmarkService, find_benchmark_in_schedule
+from wodplanner.services.benchmark import (
+    BenchmarkService,
+    extract_benchmark_names,
+    find_benchmark_in_schedule,
+)
 
 
 class TestFindBenchmarkInSchedule:
@@ -70,6 +74,42 @@ class TestFindBenchmarkInSchedule:
             benchmark_names=names,
         )
         assert result == "Fran"
+
+
+class TestExtractBenchmarkNames:
+    def test_empty_text_returns_empty(self):
+        assert extract_benchmark_names(None) == []
+        assert extract_benchmark_names("") == []
+
+    def test_quoted_benchmark_extracts_name(self):
+        text = "MetCon\nBenchmark \u2018Cindy\u2019\n20min AMRAP"
+        result = extract_benchmark_names(text)
+        assert result == ["Cindy"]
+
+    def test_unquoted_benchmark_extracts_name(self):
+        text = "MetCon\nBenchmark Battle of the Bull 22.3\n3 Rounds For Time"
+        result = extract_benchmark_names(text)
+        assert result == ["Battle of the Bull 22.3"]
+
+    def test_multiple_benchmarks_in_text(self):
+        text = "Benchmark \u2018Nasty Girls\u2019 and Benchmark \u2018Helen\u2019"
+        result = extract_benchmark_names(text)
+        assert result == ["Nasty Girls", "Helen"]
+
+    def test_no_benchmark_prefix_returns_empty(self):
+        text = "Just a normal metcon with no benchmarks"
+        result = extract_benchmark_names(text)
+        assert result == []
+
+    def test_benchmark_in_mobility_column_ignored(self):
+        text = "Mobility: Banded Shoulder Dislocation"
+        result = extract_benchmark_names(text)
+        assert result == []
+
+    def test_benchmark_with_trailing_punctuation_stripped(self):
+        text = "Benchmark \u2018Hero DT\u2019: For Time"
+        result = extract_benchmark_names(text)
+        assert result == ["Hero DT"]
 
 
 class TestDayCardEnrichment:


### PR DESCRIPTION
## Summary

Adds `extract_benchmark_names()` in `services/benchmark.py` that scans schedule metcon text for `Benchmark 'Name'` or `Benchmark Name` patterns during `import-schedule`.

Mirrors the existing 1RM exercise resolution flow — detected names are presented interactively (y/N prompt) and added to `benchmark_wods` table when accepted.

## Details

- **Regex**: `Benchmark ⒽNameⒽ` (single-quoted, unicode curly quotes) or `Benchmark Name` (unquoted, until newline) — tested against all 4 example PDFs, zero false positives
- **Re-import safe**: schedule upsert uses `ON CONFLICT(date, class_type, gym_id) DO UPDATE SET` — no duplicate rows
- **No render-time changes**: existing `find_benchmark_in_schedule` + DB-list scan detects names automatically once in the DB

## Coverage

- `extract_benchmark_names`: 7 tests (empty/quoted/unquoted/multiple/no-match/mobility-column/trailing-punctuation)
- Import integration: 2 tests (added/skipped)
- All 662 existing tests pass