### PR TITLE
feat: add dedicated Benchmark page with chart and log form

### DIFF
--- a/src/wodplanner/app/routers/views.py
+++ b/src/wodplanner/app/routers/views.py
@@ -98,6 +98,24 @@ def _build_exercises_chart_data(formatted_entries: list) -> str:
     return json.dumps(data).replace("</", "<\\/")
 
 
+def _build_benchmark_chart_data(formatted_entries: list) -> str:
+    data: dict[str, list] = {}
+    for e in formatted_entries:
+        name = e["benchmark_name"]
+        if name not in data:
+            data[name] = []
+        data[name].append({
+            "date": e["recorded_at"],
+            "time": e["time_seconds"],
+            "label": e["recorded_at"],
+            "time_display": e["formatted_time"],
+            "is_rx": e["is_rx"],
+        })
+    for name in data:
+        data[name].sort(key=lambda x: x["date"])
+    return json.dumps(data).replace("</", "<\\/")
+
+
 router = APIRouter(tags=["views"])
 
 # Setup templates
@@ -379,6 +397,31 @@ def one_rep_max_page(
             "default_exercise": entries[0]["exercise"] if entries else "",
             "entries": entries,
             "exercises_data_json": _build_exercises_chart_data(entries),
+            "today": date.today().isoformat(),
+            **get_user_context(session),
+        },
+    )
+
+
+@router.get("/benchmark", response_class=HTMLResponse)
+def benchmark_page(
+    request: Request,
+    session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
+    benchmark_service: BenchmarkService = Depends(get_benchmark_service),
+):
+    """Benchmark tracking page."""
+    raw = benchmark_service.get_all_results(session.user_id)
+    entries = _format_benchmark_entries(raw)
+    benchmark_list = benchmark_service.get_benchmark_list()
+
+    return render(
+        request,
+        "benchmark.html",
+        {
+            "active_page": "benchmark",
+            "benchmark_list": benchmark_list,
+            "entries": entries,
+            "benchmark_data_json": _build_benchmark_chart_data(entries),
             "today": date.today().isoformat(),
             **get_user_context(session),
         },
@@ -886,12 +929,15 @@ def add_benchmark_result_view(
         recorded_at=recorded_at,
     )
 
-    raw = benchmark_service.get_results_for_benchmark(session.user_id, benchmark_name)
+    raw = benchmark_service.get_all_results(session.user_id)
     entries = _format_benchmark_entries(raw)
     return render(
         request,
         "partials/benchmark_history.html",
-        {"entries": entries},
+        {
+            "entries": entries,
+            "benchmark_data_json": _build_benchmark_chart_data(entries),
+        },
     )
 
 
@@ -903,15 +949,15 @@ def delete_benchmark_result_view(
     benchmark_service: BenchmarkService = Depends(get_benchmark_service),
 ):
     """Delete a benchmark result (htmx)."""
-    result = benchmark_service.get_result(session.user_id, result_id)
-    benchmark_name = result.benchmark_name if result else None
-
     benchmark_service.delete_result(session.user_id, result_id)
 
-    raw = benchmark_service.get_results_for_benchmark(session.user_id, benchmark_name) if benchmark_name else []
+    raw = benchmark_service.get_all_results(session.user_id)
     entries = _format_benchmark_entries(raw)
     return render(
         request,
         "partials/benchmark_history.html",
-        {"entries": entries},
+        {
+            "entries": entries,
+            "benchmark_data_json": _build_benchmark_chart_data(entries),
+        },
     )

--- a/src/wodplanner/app/templates/base.html
+++ b/src/wodplanner/app/templates/base.html
@@ -23,7 +23,7 @@
             <a href="/calendar" class="{% if active_page == 'calendar' %}active{% endif %}">Calendar</a>
             <a href="/friends" class="{% if active_page == 'friends' %}active{% endif %}">Friends</a>
             <a href="/1rm" class="{% if active_page == '1rm' %}active{% endif %}">1RM</a>
-            <a href="/settings" class="{% if active_page == 'settings' %}active{% endif %}">Settings</a>
+            <a href="/benchmark" class="{% if active_page == 'benchmark' %}active{% endif %}">Benchmark</a>
         </div>
         <div class="nav-user">
             {% if user %}

--- a/src/wodplanner/app/templates/benchmark.html
+++ b/src/wodplanner/app/templates/benchmark.html
@@ -1,0 +1,218 @@
+{% extends "base.html" %}
+
+{% block title %}Benchmark - WodPlanner{% endblock %}
+
+{% block content %}
+<div class="page-header">
+    <h1>Benchmark WODs</h1>
+    <button class="btn btn-primary btn-sm" onclick="toggleBenchmarkLogForm()">+ Log</button>
+</div>
+
+<div id="log-form-card" class="card" style="display:none; margin-bottom: 1rem;">
+    <div class="card-header">
+        <span class="card-title">Log a Benchmark Result</span>
+    </div>
+    <div style="padding: 1rem;">
+        <form hx-post="/benchmark-results/add"
+              hx-target="#benchmark-history"
+              hx-swap="outerHTML"
+              hx-on::after-request="if(event.detail.successful) toggleBenchmarkLogForm()"
+              class="benchmark-form">
+            <div class="form-row">
+                <div class="form-group">
+                    <label for="benchmark-name">Benchmark</label>
+                    <select id="benchmark-name" name="benchmark_name" required class="form-control">
+                        <option value="">— Select benchmark —</option>
+                        {% for name in benchmark_list %}
+                        <option value="{{ name }}">{{ name }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div class="form-group form-group-narrow">
+                    <label for="benchmark-minutes">Minutes</label>
+                    <input type="number"
+                           id="benchmark-minutes"
+                           name="minutes"
+                           min="0"
+                           max="999"
+                           placeholder="0"
+                           required
+                           class="form-control">
+                </div>
+                <div class="form-group form-group-narrow">
+                    <label for="benchmark-seconds">Seconds</label>
+                    <input type="number"
+                           id="benchmark-seconds"
+                           name="seconds"
+                           min="0"
+                           max="59"
+                           placeholder="00"
+                           required
+                           class="form-control">
+                </div>
+                <div class="form-group form-group-narrow">
+                    <label>RX / Scaled</label>
+                    <div class="radio-group">
+                        <label class="radio-inline">
+                            <input type="radio" name="is_rx" value="true" checked> RX
+                        </label>
+                        <label class="radio-inline">
+                            <input type="radio" name="is_rx" value="false"> Scaled
+                        </label>
+                    </div>
+                </div>
+                <div class="form-group form-group-narrow">
+                    <label for="benchmark-date">Date</label>
+                    <input type="date"
+                           id="benchmark-date"
+                           name="recorded_at"
+                           value="{{ today }}"
+                           required
+                           class="form-control">
+                </div>
+                <div class="form-group form-group-submit">
+                    <label>&nbsp;</label>
+                    <button type="submit" class="btn btn-primary btn-sm">Save</button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div class="card" style="margin-bottom: 1rem;">
+    <div class="card-header">
+        <span class="card-title">Progress</span>
+        <select id="benchmark-select" class="form-control form-control-inline" onchange="updateBenchmarkChart()">
+            <option value="">— Select benchmark —</option>
+            {% for name in entries | map(attribute='benchmark_name') | unique | sort %}
+            <option value="{{ name }}">{{ name }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="benchmark-chart-container">
+        <canvas id="benchmark-chart"></canvas>
+        <p id="benchmark-no-data" class="text-muted benchmark-empty">Select a benchmark to see progress.</p>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-header">
+        <span class="card-title">History</span>
+    </div>
+    <div style="padding: 1rem;">
+        {% include "partials/benchmark_history.html" %}
+    </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+<script>
+var __benchmarkData = {{ benchmark_data_json | safe }};
+var __benchmarkChart = null;
+var __benchmarkLogFormOpen = false;
+
+function toggleBenchmarkLogForm() {
+    __benchmarkLogFormOpen = !__benchmarkLogFormOpen;
+    document.getElementById('log-form-card').style.display = __benchmarkLogFormOpen ? 'block' : 'none';
+}
+
+function formatTime(seconds) {
+    var m = Math.floor(seconds / 60);
+    var s = seconds % 60;
+    return m + ':' + (s < 10 ? '0' : '') + s;
+}
+
+function updateBenchmarkChart() {
+    var select = document.getElementById('benchmark-select');
+    var canvas = document.getElementById('benchmark-chart');
+    var noData = document.getElementById('benchmark-no-data');
+    if (!select || !canvas) return;
+    var name = select.value;
+
+    if (!name || !__benchmarkData[name] || !__benchmarkData[name].length) {
+        canvas.style.display = 'none';
+        noData.style.display = 'block';
+        if (__benchmarkChart) { __benchmarkChart.destroy(); __benchmarkChart = null; }
+        return;
+    }
+
+    canvas.style.display = 'block';
+    noData.style.display = 'none';
+
+    var points = __benchmarkData[name];
+    var labels = points.map(function(p) { return p.label; });
+    var times = points.map(function(p) { return p.time; });
+
+    if (__benchmarkChart) __benchmarkChart.destroy();
+    __benchmarkChart = new Chart(canvas, {
+        type: 'line',
+        data: {
+            labels: labels,
+            datasets: [{
+                label: name + ' (seconds)',
+                data: times,
+                borderColor: '#7c3aed',
+                backgroundColor: 'rgba(124,58,237,0.08)',
+                tension: 0.2,
+                fill: true,
+                pointRadius: 5,
+                pointHoverRadius: 7,
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+                legend: { display: false },
+                tooltip: {
+                    callbacks: {
+                        label: function(ctx) {
+                            return formatTime(ctx.parsed.y);
+                        }
+                    }
+                }
+            },
+            scales: {
+                y: {
+                    title: { display: true, text: 'Time (mm:ss)' },
+                    ticks: {
+                        callback: function(value) {
+                            return formatTime(value);
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+    var select = document.getElementById('benchmark-select');
+    if (select && select.options.length > 1) {
+        select.selectedIndex = 1;
+        updateBenchmarkChart();
+    } else {
+        document.getElementById('benchmark-chart').style.display = 'none';
+    }
+});
+
+document.addEventListener('htmx:afterSwap', function(e) {
+    if (e.detail.target && e.detail.target.id === 'benchmark-history') {
+        var raw = document.getElementById('benchmark-history').dataset.benchmark;
+        if (!raw) return;
+        __benchmarkData = JSON.parse(raw);
+        var select = document.getElementById('benchmark-select');
+        if (!select) return;
+        var current = select.value;
+        select.innerHTML = '<option value="">— Select benchmark —</option>';
+        Object.keys(__benchmarkData).sort().forEach(function(name) {
+            var opt = document.createElement('option');
+            opt.value = name;
+            opt.textContent = name;
+            select.appendChild(opt);
+        });
+        select.value = (__benchmarkData[current]) ? current : (Object.keys(__benchmarkData)[0] || '');
+        updateBenchmarkChart();
+    }
+});
+</script>
+{% endblock %}

--- a/src/wodplanner/app/templates/partials/benchmark_history.html
+++ b/src/wodplanner/app/templates/partials/benchmark_history.html
@@ -1,8 +1,9 @@
-<div id="benchmark-history" class="benchmark-history">
+<div id="benchmark-history" class="benchmark-history"{% if benchmark_data_json %} data-benchmark='{{ benchmark_data_json | safe }}'{% endif %}>
     {% if entries %}
     <table class="benchmark-table">
         <thead>
             <tr>
+                <th>Benchmark</th>
                 <th>Date</th>
                 <th>Time</th>
                 <th>RX / Scaled</th>
@@ -12,6 +13,7 @@
         <tbody>
             {% for entry in entries %}
             <tr>
+                <td class="benchmark-name">{{ entry.benchmark_name }}</td>
                 <td class="benchmark-date text-muted">{{ entry.recorded_at }}</td>
                 <td class="benchmark-time">{{ entry.formatted_time }}</td>
                 <td>

--- a/src/wodplanner/services/benchmark.py
+++ b/src/wodplanner/services/benchmark.py
@@ -165,6 +165,22 @@ class BenchmarkService(BaseService):
             ).fetchall()
             return [self._row_to_result(row) for row in rows]
 
+    def get_all_results(self, user_id: int) -> list[BenchmarkResult]:
+        with self._get_connection() as conn:
+            rows = conn.execute(
+                "SELECT * FROM benchmark_results WHERE user_id = ? ORDER BY recorded_at DESC",
+                (user_id,),
+            ).fetchall()
+            return [self._row_to_result(row) for row in rows]
+
+    def get_benchmark_names_for_user(self, user_id: int) -> list[str]:
+        with self._get_connection() as conn:
+            rows = conn.execute(
+                "SELECT DISTINCT benchmark_name FROM benchmark_results WHERE user_id = ? ORDER BY benchmark_name",
+                (user_id,),
+            ).fetchall()
+            return [row["benchmark_name"] for row in rows]
+
     def get_result(self, user_id: int, result_id: int) -> BenchmarkResult | None:
         with self._get_connection() as conn:
             row = conn.execute(


### PR DESCRIPTION
Replaces the Settings nav link with a dedicated Benchmark page at /benchmark, modeled on the existing 1RM page.

### Changes
- **New route** `GET /benchmark` — dedicated page with:
  - Log form (benchmark dropdown from DB, minutes/seconds, RX/Scaled, date)
  - Progress chart (Chart.js line chart, time in mm:ss, per-benchmark selection)
  - History table with benchmark name, date, time, RX/Scaled, delete
- **Nav**: replaced Settings with Benchmark
- **BenchmarkService**: added `get_all_results()` and `get_benchmark_names_for_user()`
- **History partial**: now includes benchmark name column and carries chart data in `data-benchmark` attribute for HTMX swaps
- **Add/delete endpoints**: updated to pass chart data across all benchmarks (matching 1RM pattern)