### PR TITLE
feat: add security headers middleware

### DIFF
--- a/src/wodplanner/app/main.py
+++ b/src/wodplanner/app/main.py
@@ -66,6 +66,39 @@ class CloudflareIPMiddleware(BaseHTTPMiddleware):
         return cast(Response, await call_next(request))
 
 
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Set strict security headers on every response.
+
+    CSP allows known CDNs and inline scripts/styles (required by HTMX/Chart.js).
+    HSTS is production-only since dev runs on HTTP.
+    """
+
+    _csp = (
+        "default-src 'self'; "
+        "script-src 'self' https://unpkg.com https://cdn.jsdelivr.net 'unsafe-inline'; "
+        "style-src 'self' 'unsafe-inline'; "
+        "connect-src 'self'; "
+        "img-src 'self' https: data:; "
+        "font-src 'self'; "
+        "frame-src 'none'; "
+        "object-src 'none'; "
+        "base-uri 'none'; "
+        "form-action 'self'"
+    )
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        response = cast(Response, await call_next(request))
+        response.headers["Content-Security-Policy"] = self._csp
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        if settings.environment == "production":
+            response.headers["Strict-Transport-Security"] = (
+                "max-age=31536000; includeSubDomains"
+            )
+        return response
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     """Run pending schema migrations at startup."""
@@ -90,6 +123,7 @@ static_dir = Path(__file__).parent / "static"
 app.mount("/static", StaticFiles(directory=static_dir), name="static")
 
 app.add_middleware(CloudflareIPMiddleware)
+app.add_middleware(SecurityHeadersMiddleware)
 
 @app.exception_handler(WodAppError)
 async def wodapp_error_handler(request: Request, exc: WodAppError) -> Response:

--- a/tests/app/test_main.py
+++ b/tests/app/test_main.py
@@ -4,10 +4,17 @@ import logging
 from unittest.mock import MagicMock
 
 from fastapi import APIRouter
+from fastapi.responses import Response
 from fastapi.testclient import TestClient
 
 from wodplanner.api.client import AuthenticationError, WodAppError
-from wodplanner.app.main import CloudflareIPMiddleware, _StripZeroPort, app
+from wodplanner.app.config import settings
+from wodplanner.app.main import (
+    CloudflareIPMiddleware,
+    SecurityHeadersMiddleware,
+    _StripZeroPort,
+    app,
+)
 
 
 def _attach_temp_router(routes: APIRouter):
@@ -156,6 +163,97 @@ class TestStripZeroPortFilter:
         f = _StripZeroPort()
         record = logging.LogRecord("test", logging.INFO, "f", 1, "msg", None, None)
         assert f.filter(record) is True
+
+
+class TestSecurityHeadersMiddleware:
+    def test_all_security_headers_present(self, app_client):
+        resp = app_client.get("/health")
+        csp = resp.headers.get("content-security-policy")
+        assert csp is not None
+        assert "default-src 'self'" in csp
+        assert "script-src 'self'" in csp
+        assert "https://unpkg.com" in csp
+        assert "https://cdn.jsdelivr.net" in csp
+        assert "'unsafe-inline'" in csp
+        assert "frame-src 'none'" in csp
+        assert "object-src 'none'" in csp
+        assert "base-uri 'none'" in csp
+        assert resp.headers.get("x-frame-options") == "DENY"
+        assert resp.headers.get("x-content-type-options") == "nosniff"
+        assert resp.headers.get("referrer-policy") == "strict-origin-when-cross-origin"
+
+    def test_hsts_set_in_production(self):
+        mw = SecurityHeadersMiddleware(app=MagicMock())
+        request = MagicMock()
+        expected = Response()
+
+        async def call_next(_req):
+            return expected
+
+        import asyncio
+
+        prev = settings.environment
+        settings.environment = "production"
+        try:
+            result = asyncio.run(mw.dispatch(request, call_next))
+            assert result is expected
+            assert result.headers.get("strict-transport-security") == (
+                "max-age=31536000; includeSubDomains"
+            )
+        finally:
+            settings.environment = prev
+
+    def test_hsts_not_set_in_development(self):
+        mw = SecurityHeadersMiddleware(app=MagicMock())
+        request = MagicMock()
+        expected = Response()
+
+        async def call_next(_req):
+            return expected
+
+        import asyncio
+
+        prev = settings.environment
+        settings.environment = "development"
+        try:
+            result = asyncio.run(mw.dispatch(request, call_next))
+            assert result is expected
+            assert "strict-transport-security" not in result.headers
+        finally:
+            settings.environment = prev
+
+    def test_headers_set_on_error_responses(self, app_client):
+        router = APIRouter()
+
+        @router.get("/__test__/sec_err")
+        def boom():
+            raise WodAppError("boom")
+
+        cleanup = _attach_temp_router(router)
+        try:
+            resp = app_client.get("/__test__/sec_err")
+            assert resp.headers.get("content-security-policy") is not None
+            assert resp.headers.get("x-frame-options") == "DENY"
+            assert resp.headers.get("x-content-type-options") == "nosniff"
+        finally:
+            cleanup()
+
+    def test_headers_set_on_redirect_responses(self, app_client):
+        router = APIRouter()
+
+        @router.get("/__test__/sec_auth_err")
+        def boom():
+            raise AuthenticationError("expired")
+
+        cleanup = _attach_temp_router(router)
+        try:
+            resp = app_client.get("/__test__/sec_auth_err", follow_redirects=False)
+            assert resp.status_code == 303
+            assert resp.headers.get("content-security-policy") is not None
+            assert resp.headers.get("x-frame-options") == "DENY"
+            assert resp.headers.get("x-content-type-options") == "nosniff"
+        finally:
+            cleanup()
 
 
 class TestLifespanRunsMigrations:


### PR DESCRIPTION
Implements  (applied to every response):

| Header | Value | Condition |
|---|---|---|
| Content-Security-Policy | `default-src 'self'; script-src 'self' https://unpkg.com https://cdn.jsdelivr.net 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' https: data:; font-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'none'; form-action 'self'` | Always |
| X-Frame-Options | `DENY` | Always |
| X-Content-Type-Options | `nosniff` | Always |
| Referrer-Policy | `strict-origin-when-cross-origin` | Always |
| Strict-Transport-Security | `max-age=31536000; includeSubDomains` | Production only |

See `src/wodplanner/app/main.py:69-99`.

Closes the second HIGH checkbox in TODO.md.