### PR TITLE
feat: add settings page with gear icon, tutorial reset, and calendar filters

### DIFF
--- a/src/wodplanner/app/routers/views.py
+++ b/src/wodplanner/app/routers/views.py
@@ -375,6 +375,50 @@ def dismiss_tooltip(
     return HTMLResponse("")
 
 
+@router.get("/settings", response_class=HTMLResponse)
+def settings_page(
+    request: Request,
+    session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
+    prefs_service: PreferencesService = Depends(get_preferences_service),
+):
+    """Settings page."""
+    hidden_types = prefs_service.get_hidden_class_types(session.user_id)
+    filters = [{"name": t, "hidden": t in hidden_types} for t in FILTERABLE_CLASS_TYPES]
+    return render(
+        request,
+        "settings.html",
+        {
+            "active_page": "",
+            "filters": filters,
+            **get_user_context(session),
+        },
+    )
+
+
+@router.post("/settings/reset-tutorial", response_class=HTMLResponse)
+def reset_tutorial(
+    session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
+    prefs_service: PreferencesService = Depends(get_preferences_service),
+):
+    """Reset all dismissed tooltips."""
+    prefs_service.reset_tooltips(session.user_id)
+    return HTMLResponse('<p class="success-msg">Tutorial will show again on your next visit.</p>')
+
+
+@router.post("/settings/toggle-filter/{class_type}", response_class=HTMLResponse)
+def settings_toggle_filter(
+    request: Request,
+    class_type: str,
+    session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
+    prefs_service: PreferencesService = Depends(get_preferences_service),
+):
+    """Toggle a class type filter from the settings page."""
+    prefs_service.toggle_hidden_class_type(session.user_id, class_type)
+    hidden_types = prefs_service.get_hidden_class_types(session.user_id)
+    filters = [{"name": t, "hidden": t in hidden_types} for t in FILTERABLE_CLASS_TYPES]
+    return render(request, "partials/settings_filters.html", {"filters": filters})
+
+
 @router.get("/1rm", response_class=HTMLResponse)
 def one_rep_max_page(
     request: Request,

--- a/src/wodplanner/app/static/css/style.css
+++ b/src/wodplanner/app/static/css/style.css
@@ -1909,3 +1909,78 @@ body {
         color: #86efac;
     }
 }
+
+/* Settings page */
+.settings-sections {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    max-width: 600px;
+}
+
+.settings-section h2 {
+    margin: 0 0 1rem;
+    font-size: 1.1rem;
+    color: var(--text-secondary);
+}
+
+.settings-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.75rem 0;
+    border-top: 1px solid var(--gray-200);
+}
+
+.settings-item.disabled {
+    opacity: 0.5;
+    pointer-events: none;
+}
+
+.coming-soon {
+    font-size: 0.85rem;
+    color: var(--gray-500);
+    font-style: italic;
+}
+
+.settings-description {
+    margin: 0 0 0.75rem;
+    font-size: 0.9rem;
+    color: var(--gray-500);
+}
+
+.settings-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.success-msg {
+    padding: 0.75rem 1rem;
+    border-radius: 0.375rem;
+    background: #d1fae5;
+    color: #065f46;
+    font-size: 0.9rem;
+    margin-top: 1rem;
+}
+
+.settings-icon {
+    display: inline-flex;
+    align-items: center;
+    vertical-align: middle;
+    margin-left: 0.5rem;
+    color: var(--gray-500);
+    text-decoration: none;
+    transition: color 0.15s;
+}
+
+.settings-icon:hover {
+    color: var(--text-primary);
+}
+
+@media (prefers-color-scheme: dark) {
+    .success-msg {
+        background: #064e3b;
+        color: #6ee7b7;
+    }
+}

--- a/src/wodplanner/app/templates/base.html
+++ b/src/wodplanner/app/templates/base.html
@@ -28,7 +28,13 @@
         <div class="nav-user">
             {% if user %}
             <span>{{ user.firstname }}</span>
-            <form action="/api/auth/logout" method="post" style="display: inline; margin-left: 1rem;">
+            <a href="/settings" class="settings-icon" title="Settings" aria-label="Settings">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="12" cy="12" r="3"></circle>
+                    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+                </svg>
+            </a>
+            <form action="/api/auth/logout" method="post" style="display: inline; margin-left: 0.75rem;">
                 <button type="submit" class="btn btn-sm btn-secondary">Logout</button>
             </form>
             {% endif %}

--- a/src/wodplanner/app/templates/partials/settings_filters.html
+++ b/src/wodplanner/app/templates/partials/settings_filters.html
@@ -1,0 +1,10 @@
+{% for filter in filters %}
+<label class="filter-toggle">
+    <input type="checkbox"
+           {% if filter.hidden %}checked{% endif %}
+           hx-post="/settings/toggle-filter/{{ filter.name }}"
+           hx-target="#settings-filters"
+           hx-swap="innerHTML">
+    {{ filter.name }}
+</label>
+{% endfor %}

--- a/src/wodplanner/app/templates/settings.html
+++ b/src/wodplanner/app/templates/settings.html
@@ -6,4 +6,67 @@
 <div class="page-header">
     <h1>Settings</h1>
 </div>
+
+<div class="settings-sections">
+
+    <section class="card settings-section">
+        <h2>Appearance</h2>
+        <div class="settings-item disabled">
+            <label>Color theme</label>
+            <span class="coming-soon">Coming soon</span>
+        </div>
+    </section>
+
+    <section class="card settings-section">
+        <h2>Tutorial</h2>
+        <div class="settings-item">
+            <label>Reset onboarding tooltips</label>
+            <button class="btn btn-sm btn-secondary" onclick="openConfirmModal()">Reset</button>
+        </div>
+    </section>
+
+    <section class="card settings-section">
+        <h2>Calendar Filters</h2>
+        <p class="settings-description">Hide class types from calendar pages.</p>
+        <div id="settings-filters" class="settings-filters">
+            {% include "partials/settings_filters.html" %}
+        </div>
+    </section>
+
+</div>
+
+<!-- Reset Tutorial Confirmation Modal -->
+<div id="reset-confirm-modal" class="modal">
+    <div class="modal-content" style="max-width: 400px;">
+        <div class="modal-header">
+            <h3>Reset Tutorial</h3>
+            <button class="modal-close" onclick="closeConfirmModal()">&times;</button>
+        </div>
+        <div class="modal-body">
+            <p>This will make all onboarding tooltips appear again on the calendar page. Continue?</p>
+            <div style="display: flex; gap: 0.5rem; justify-content: flex-end; margin-top: 1.5rem;">
+                <button class="btn btn-sm btn-secondary" onclick="closeConfirmModal()">Cancel</button>
+                <button class="btn btn-sm btn-primary"
+                        hx-post="/settings/reset-tutorial"
+                        hx-target="#reset-result"
+                        hx-swap="innerHTML"
+                        onclick="closeConfirmModal()">Reset</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div id="reset-result"></div>
+
+<script>
+    function openConfirmModal() {
+        document.getElementById('reset-confirm-modal').classList.add('active');
+    }
+    function closeConfirmModal() {
+        document.getElementById('reset-confirm-modal').classList.remove('active');
+    }
+    document.getElementById('reset-confirm-modal').addEventListener('click', function(e) {
+        if (e.target === this) closeConfirmModal();
+    });
+</script>
 {% endblock %}

--- a/src/wodplanner/services/preferences.py
+++ b/src/wodplanner/services/preferences.py
@@ -107,6 +107,9 @@ class PreferencesService(BaseService):
             dismissed.append(tooltip_id)
             self._set(user_id, "dismissed_tooltips", json.dumps(dismissed))
 
+    def reset_tooltips(self, user_id: int) -> None:
+        self._set(user_id, "dismissed_tooltips", "[]")
+
     def get_for_user(self, user_id: int) -> UserPreferences:
         """Get all preferences for a user in a single query."""
         with self._get_connection() as conn:


### PR DESCRIPTION
Adds a gear icon next to the user's name in the navbar that links to a new /settings page with three sections:

- **Appearance** — placeholder for future color theme feature (disabled, Coming soon)
- **Tutorial** — reset onboarding tooltips button with confirmation modal
- **Calendar Filters** — toggle class type checkboxes to hide from calendar pages