### PR TITLE
feat: weekly sessions graph on homepage

### DIFF
--- a/src/wodplanner/app/dependencies.py
+++ b/src/wodplanner/app/dependencies.py
@@ -18,6 +18,7 @@ from wodplanner.services.one_rep_max import OneRepMaxService
 from wodplanner.services.preferences import PreferencesService
 from wodplanner.services.schedule import ScheduleService
 from wodplanner.services.subscription import SubscriptionService
+from wodplanner.services.subscription_tracker import SubscriptionTrackerService
 
 
 def _get_db_path() -> Path:
@@ -145,3 +146,9 @@ def get_subscription_service(
 ) -> SubscriptionService:
     """Create a per-request SubscriptionService."""
     return SubscriptionService(client=client)
+
+
+@lru_cache
+def get_subscription_tracker_service() -> SubscriptionTrackerService:
+    """Get the singleton subscription tracker service."""
+    return SubscriptionTrackerService(_get_db_path())

--- a/src/wodplanner/app/routers/views.py
+++ b/src/wodplanner/app/routers/views.py
@@ -22,6 +22,7 @@ from wodplanner.app.dependencies import (
     get_schedule_service,
     get_session_from_cookie,
     get_subscription_service,
+    get_subscription_tracker_service,
     require_session_for_view,
 )
 from wodplanner.models.auth import AuthSession
@@ -37,6 +38,7 @@ from wodplanner.services.preferences import PreferencesService
 from wodplanner.services.schedule import ScheduleService
 from wodplanner.services.schedule_lookup import match_schedule, match_schedules_for_date
 from wodplanner.services.subscription import SubscribeAction, SubscriptionService
+from wodplanner.services.subscription_tracker import SubscriptionTrackerService
 from wodplanner.utils.dates import parse_api_datetime, parse_iso_date
 
 logger = logging.getLogger(__name__)
@@ -168,8 +170,9 @@ def home_page(
     request: Request,
     session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
     client: WodAppClient = Depends(get_client_from_session_for_view),
+    tracker: SubscriptionTrackerService = Depends(get_subscription_tracker_service),
 ):
-    """Homepage showing upcoming reservations."""
+    """Homepage showing upcoming reservations and weekly stats."""
     reservations, company_images = client.get_upcoming_reservations()
 
     # Group by date for display
@@ -186,6 +189,25 @@ def home_page(
             "display_date": r.date_start.strftime("%B %d"),
         })
 
+    # Weekly stats
+    user_id = session.user_id
+    has_data = tracker.has_any_events(user_id)
+    chart_data: dict[str, list] = {"weeks": [], "past": [], "future": []}
+    week_stats = {"past": 0, "future": 0}
+    average = 0.0
+    weeks_tracked = 0
+
+    if has_data:
+        weekly = tracker.get_weekly_counts(user_id)
+        chart_data = {
+            "weeks": [w["week_start"] for w in weekly],
+            "past": [w["past"] for w in weekly],
+            "future": [w["future"] for w in weekly],
+        }
+        week_stats = tracker.get_current_week_stats(user_id)
+        average = round(tracker.get_average_per_week(user_id), 1)
+        weeks_tracked = tracker.get_weeks_tracked(user_id)
+
     return render(
         request,
         "home.html",
@@ -193,6 +215,11 @@ def home_page(
             "active_page": "home",
             "days": days,
             "gym_logo": company_images.get("logo", ""),
+            "has_chart_data": has_data,
+            "chart_data": json.dumps(chart_data).replace("</", "<\\/"),
+            "week_stats": week_stats,
+            "average": average,
+            "weeks_tracked": weeks_tracked,
             **get_user_context(session),
         },
     )
@@ -554,6 +581,7 @@ def subscribe_view(
     appointment_id: int,
     date_start: str = Form(...),
     date_end: str = Form(...),
+    class_name: str = Form(""),
     session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
     client: WodAppClient = Depends(get_client_from_session_for_view),
     friends_service: FriendsService = Depends(get_friends_service),
@@ -561,6 +589,7 @@ def subscribe_view(
     schedule_service: ScheduleService = Depends(get_schedule_service),
     subscription_service: SubscriptionService = Depends(get_subscription_service),
     benchmark_service: BenchmarkService = Depends(get_benchmark_service),
+    tracker: SubscriptionTrackerService = Depends(get_subscription_tracker_service),
 ):
     """Subscribe to appointment from calendar (htmx)."""
     start = parse_api_datetime(date_start)
@@ -571,6 +600,13 @@ def subscribe_view(
         start=start,
         end=end,
         action=SubscribeAction.SUBSCRIBE,
+    )
+
+    tracker.record_subscribe(
+        user_id=session.user_id,
+        appointment_id=appointment_id,
+        class_name=class_name,
+        class_date=start.date(),
     )
 
     # Return updated calendar
@@ -631,6 +667,7 @@ def unsubscribe_view(
     date_start: str = Form(...),
     date_end: str = Form(...),
     is_waitinglist: str = Form("false"),
+    class_name: str = Form(""),
     session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
     client: WodAppClient = Depends(get_client_from_session_for_view),
     friends_service: FriendsService = Depends(get_friends_service),
@@ -638,6 +675,7 @@ def unsubscribe_view(
     schedule_service: ScheduleService = Depends(get_schedule_service),
     subscription_service: SubscriptionService = Depends(get_subscription_service),
     benchmark_service: BenchmarkService = Depends(get_benchmark_service),
+    tracker: SubscriptionTrackerService = Depends(get_subscription_tracker_service),
 ):
     """Unsubscribe from appointment (htmx)."""
     start = parse_api_datetime(date_start)
@@ -655,6 +693,14 @@ def unsubscribe_view(
         end=end,
         action=action,
     )
+
+    if is_waitinglist != "true":
+        tracker.record_unsubscribe(
+            user_id=session.user_id,
+            appointment_id=appointment_id,
+            class_name=class_name,
+            class_date=start.date(),
+        )
 
     # Return updated calendar
     return calendar_day_partial(

--- a/src/wodplanner/app/templates/base.html
+++ b/src/wodplanner/app/templates/base.html
@@ -12,6 +12,7 @@
     <link rel="shortcut icon" href="/static/favicon.ico">
     <link rel="manifest" href="/static/site.webmanifest">
     <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
 </head>
 <body>
     <nav class="navbar">
@@ -330,5 +331,7 @@
         })();
     </script>
     {% endif %}
+
+    {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/src/wodplanner/app/templates/home.html
+++ b/src/wodplanner/app/templates/home.html
@@ -36,4 +36,107 @@
     <a href="/calendar" class="btn btn-sm btn-secondary">Browse calendar</a>
 </div>
 {% endif %}
+
+{% if has_chart_data %}
+<div class="card" style="margin-top: 1.25rem;">
+    <div class="card-header">
+        <span class="card-title">Weekly Sessions</span>
+        <span class="text-muted">This week: {{ week_stats.past }} completed, {{ week_stats.future }} planned</span>
+    </div>
+    <div style="padding: 0.75rem 1rem 0.25rem;">
+        <canvas id="weeklyChart" height="180"></canvas>
+    </div>
+    <div style="display: flex; gap: 1.5rem; padding: 0.25rem 1rem 0.75rem; font-size: 0.875rem; color: var(--gray-500);">
+        <span style="display: flex; align-items: center; gap: 0.35rem;">
+            <span style="display: inline-block; width: 10px; height: 10px; border-radius: 2px; background: #3b82f6;"></span>
+            Completed
+        </span>
+        <span style="display: flex; align-items: center; gap: 0.35rem;">
+            <span style="display: inline-block; width: 10px; height: 10px; border-radius: 2px; background: #93c5fd; opacity: 0.6;"></span>
+            Planned
+        </span>
+        <span>Avg: <strong>{{ average }}</strong> /week ({{ weeks_tracked }} weeks)</span>
+    </div>
+</div>
+{% else %}
+<div class="card" style="text-align: center; padding: 2rem 1rem; margin-top: 1.25rem;">
+    <p class="text-muted" style="margin: 0;">Your weekly stats will appear here once you subscribe to your first CrossFit class.</p>
+</div>
+{% endif %}
+{% endblock %}
+
+{% block scripts %}
+{% if has_chart_data %}
+<script>
+(function() {
+    var data = {{ chart_data|safe }};
+    var ctx = document.getElementById('weeklyChart').getContext('2d');
+    new Chart(ctx, {
+        type: 'bar',
+        data: {
+            labels: data.weeks.map(function(w) {
+                var parts = w.split('-');
+                var year = parts[0];
+                var month = parseInt(parts[1], 10);
+                var day = parseInt(parts[2], 10);
+                var d = new Date(year, month - 1, day);
+                var monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+                return monthNames[d.getMonth()] + ' ' + day;
+            }),
+            datasets: [{
+                label: 'Completed',
+                data: data.past,
+                backgroundColor: '#3b82f6',
+                borderRadius: 2,
+                barPercentage: 0.7,
+            }, {
+                label: 'Planned',
+                data: data.future,
+                backgroundColor: 'rgba(147, 197, 253, 0.5)',
+                borderRadius: 2,
+                barPercentage: 0.7,
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+                legend: { display: false },
+                tooltip: {
+                    callbacks: {
+                        label: function(context) {
+                            return context.dataset.label + ': ' + context.raw + ' session' + (context.raw !== 1 ? 's' : '');
+                        }
+                    }
+                }
+            },
+            scales: {
+                x: {
+                    stacked: true,
+                    grid: { display: false },
+                    ticks: {
+                        maxTicksLimit: 12,
+                        font: { size: 10 },
+                        color: '#999',
+                        maxRotation: 45,
+                    }
+                },
+                y: {
+                    stacked: true,
+                    beginAtZero: true,
+                    ticks: {
+                        precision: 0,
+                        font: { size: 10 },
+                        color: '#999',
+                    },
+                    grid: {
+                        color: 'rgba(0,0,0,0.06)',
+                    }
+                }
+            }
+        }
+    });
+})();
+</script>
+{% endif %}
 {% endblock %}

--- a/src/wodplanner/app/templates/partials/calendar_content.html
+++ b/src/wodplanner/app/templates/partials/calendar_content.html
@@ -146,7 +146,7 @@
                 {% elif appt.status == 'subscribed' or appt.status == 'waiting' %}
                     <button class="btn btn-danger btn-sm"
                             hx-post="/appointments/{{ appt.id }}/unsubscribe"
-                            hx-vals='{"date_start": "{{ appt.date_start }} {{ appt.time_start }}", "date_end": "{{ appt.date_end }} {{ appt.time_end }}", "is_waitinglist": "{{ 'true' if appt.status == 'waiting' else 'false' }}"}'
+                            hx-vals='{"date_start": "{{ appt.date_start }} {{ appt.time_start }}", "date_end": "{{ appt.date_end }} {{ appt.time_end }}", "is_waitinglist": "{{ 'true' if appt.status == 'waiting' else 'false' }}", "class_name": "{{ appt.name }}"}'
                             hx-target="#calendar-content"
                             hx-swap="innerHTML"
                             hx-confirm="Sign out of {{ appt.name }}?">
@@ -156,7 +156,7 @@
                     {% if appt.status == 'open' %}
                     <button class="btn btn-primary btn-sm"
                             hx-post="/appointments/{{ appt.id }}/subscribe"
-                            hx-vals='{"date_start": "{{ appt.date_start }} {{ appt.time_start }}", "date_end": "{{ appt.date_end }} {{ appt.time_end }}"}'
+                            hx-vals='{"date_start": "{{ appt.date_start }} {{ appt.time_start }}", "date_end": "{{ appt.date_end }} {{ appt.time_end }}", "class_name": "{{ appt.name }}"}'
                             hx-target="#calendar-content"
                             hx-swap="innerHTML">
                         Sign up

--- a/src/wodplanner/services/migrations.py
+++ b/src/wodplanner/services/migrations.py
@@ -98,6 +98,7 @@ def _import_services_for_registration() -> None:
         one_rep_max,
         preferences,
         schedule,
+        subscription_tracker,
     )
 
 

--- a/src/wodplanner/services/subscription_tracker.py
+++ b/src/wodplanner/services/subscription_tracker.py
@@ -1,0 +1,221 @@
+"""SubscriptionTrackerService — log subscribe/unsubscribe events for weekly session tracking."""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from datetime import date, datetime, timedelta
+
+from wodplanner.services import migrations
+from wodplanner.services.base import BaseService
+
+logger = logging.getLogger(__name__)
+
+def _migrate_v700(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS subscription_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            appointment_id INTEGER NOT NULL,
+            class_name TEXT NOT NULL,
+            event_type TEXT NOT NULL CHECK(event_type IN ('subscribe', 'unsubscribe')),
+            class_date TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_sub_events_user_date ON subscription_events(user_id, class_date)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_sub_events_user_appt ON subscription_events(user_id, appointment_id)"
+    )
+
+
+migrations.register(
+    700,
+    "Create subscription_events table for weekly session tracking",
+    _migrate_v700,
+)
+
+
+class SubscriptionTrackerService(BaseService):
+    def record_subscribe(
+        self, user_id: int, appointment_id: int, class_name: str, class_date: date
+    ) -> None:
+        with self._get_connection() as conn:
+            conn.execute(
+                """
+                INSERT INTO subscription_events (user_id, appointment_id, class_name, event_type, class_date, created_at)
+                VALUES (?, ?, ?, 'subscribe', ?, ?)
+                """,
+                (user_id, appointment_id, class_name, class_date.isoformat(), datetime.now().isoformat()),
+            )
+
+    def record_unsubscribe(
+        self, user_id: int, appointment_id: int, class_name: str, class_date: date
+    ) -> None:
+        with self._get_connection() as conn:
+            row = conn.execute(
+                """
+                SELECT SUM(CASE WHEN event_type = 'subscribe' THEN 1 ELSE -1 END) AS net
+                FROM subscription_events
+                WHERE user_id = ? AND appointment_id = ?
+                """,
+                (user_id, appointment_id),
+            ).fetchone()
+            current_net = row["net"] if row and row["net"] is not None else 0
+            if current_net <= 0:
+                return
+            conn.execute(
+                """
+                INSERT INTO subscription_events (user_id, appointment_id, class_name, event_type, class_date, created_at)
+                VALUES (?, ?, ?, 'unsubscribe', ?, ?)
+                """,
+                (user_id, appointment_id, class_name, class_date.isoformat(), datetime.now().isoformat()),
+            )
+
+    def get_weekly_counts(
+        self, user_id: int, weeks: int = 52
+    ) -> list[dict]:
+        """Return list of {week_start, past_count, future_count} for last N weeks."""
+        today = date.today()
+        # Start of current week (Monday)
+        current_monday = today - timedelta(days=today.weekday())
+        # Go back N weeks from Monday after current week so we get full weeks
+        start = current_monday - timedelta(weeks=weeks)
+
+        with self._get_connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT
+                    class_date,
+                    SUM(CASE WHEN event_type = 'subscribe' THEN 1 ELSE -1 END) AS net
+                FROM subscription_events
+                WHERE user_id = ?
+                  AND class_date >= ?
+                GROUP BY appointment_id
+                HAVING net > 0
+                """,
+                (user_id, start.isoformat()),
+            ).fetchall()
+
+        # Group by week, split past vs future
+        weeks_data: dict[str, dict] = {}
+        for row in rows:
+            d = date.fromisoformat(row["class_date"])
+            week_monday = d - timedelta(days=d.weekday())
+            key = week_monday.isoformat()
+            if key not in weeks_data:
+                weeks_data[key] = {"past": 0, "future": 0}
+            if d < today:
+                weeks_data[key]["past"] += row["net"]
+            else:
+                weeks_data[key]["future"] += row["net"]
+
+        # Build complete list of 52 weeks
+        result = []
+        for i in range(weeks):
+            monday = current_monday + timedelta(weeks=i - weeks + 1)
+            key = monday.isoformat()
+            entry = weeks_data.get(key, {"past": 0, "future": 0})
+            entry["week_start"] = key
+            result.append(entry)
+
+        return result
+
+    def get_current_week_stats(self, user_id: int) -> dict:
+        """Return {past, future} for current week."""
+        today = date.today()
+        current_monday = today - timedelta(days=today.weekday())
+        return self._get_week_stats(user_id, current_monday)
+
+    def _get_week_stats(self, user_id: int, week_monday: date) -> dict:
+        today = date.today()
+        week_end = week_monday + timedelta(days=7)
+        with self._get_connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT
+                    class_date,
+                    SUM(CASE WHEN event_type = 'subscribe' THEN 1 ELSE -1 END) AS net
+                FROM subscription_events
+                WHERE user_id = ?
+                  AND class_date >= ?
+                  AND class_date < ?
+                GROUP BY appointment_id
+                HAVING net > 0
+                """,
+                (user_id, week_monday.isoformat(), week_end.isoformat()),
+            ).fetchall()
+
+        past = 0
+        future = 0
+        for row in rows:
+            d = date.fromisoformat(row["class_date"])
+            if d < today:
+                past += row["net"]
+            else:
+                future += row["net"]
+        return {"past": past, "future": future}
+
+    def get_average_per_week(self, user_id: int) -> float:
+        """Average past sessions per complete week."""
+        today = date.today()
+        current_monday = today - timedelta(days=today.weekday())
+
+        with self._get_connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT
+                    class_date,
+                    SUM(CASE WHEN event_type = 'subscribe' THEN 1 ELSE -1 END) AS net
+                FROM subscription_events
+                WHERE user_id = ?
+                  AND class_date < ?
+                GROUP BY appointment_id
+                HAVING net > 0
+                """,
+                (user_id, current_monday.isoformat()),
+            ).fetchall()
+
+        if not rows:
+            return 0.0
+
+        # Group into weeks
+        week_counts: dict[str, int] = {}
+        for row in rows:
+            d = date.fromisoformat(row["class_date"])
+            week_key = (d - timedelta(days=d.weekday())).isoformat()
+            week_counts[week_key] = week_counts.get(week_key, 0) + row["net"]
+
+        if not week_counts:
+            return 0.0
+
+        return sum(week_counts.values()) / len(week_counts)
+
+    def has_any_events(self, user_id: int) -> bool:
+        with self._get_connection() as conn:
+            row = conn.execute(
+                "SELECT 1 FROM subscription_events WHERE user_id = ? LIMIT 1",
+                (user_id,),
+            ).fetchone()
+            return row is not None
+
+    def get_weeks_tracked(self, user_id: int) -> int:
+        """Number of distinct weeks with past sessions."""
+        today = date.today()
+        current_monday = today - timedelta(days=today.weekday())
+        with self._get_connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT DISTINCT
+                    CAST(JULIANDAY(class_date) - JULIANDAY('2000-01-03') AS INTEGER) / 7 AS week_num
+                FROM subscription_events
+                WHERE user_id = ?
+                  AND class_date < ?
+                """,
+                (user_id, current_monday.isoformat()),
+            ).fetchall()
+            return len(rows)

--- a/tests/services/test_subscription_tracker.py
+++ b/tests/services/test_subscription_tracker.py
@@ -1,0 +1,136 @@
+"""Tests for SubscriptionTrackerService."""
+
+from datetime import date, timedelta
+
+from wodplanner.services.subscription_tracker import SubscriptionTrackerService
+
+
+class TestRecordSubscribe:
+    def test_records_subscribe(self, db_path):
+        svc = SubscriptionTrackerService(db_path)
+        svc.record_subscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=date(2026, 6, 1))
+        assert svc.has_any_events(1)
+        assert not svc.has_any_events(2)
+
+    def test_records_any_class_type(self, db_path):
+        svc = SubscriptionTrackerService(db_path)
+        svc.record_subscribe(user_id=1, appointment_id=10, class_name="Yoga", class_date=date(2026, 6, 1))
+        assert svc.has_any_events(1)
+
+
+class TestRecordUnsubscribe:
+    def test_records_unsubscribe(self, db_path):
+        svc = SubscriptionTrackerService(db_path)
+        svc.record_subscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=date(2026, 6, 1))
+        svc.record_unsubscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=date(2026, 6, 1))
+        assert svc.has_any_events(1)
+
+    def test_ignores_unsubscribe_without_prior_subscribe(self, db_path):
+        svc = SubscriptionTrackerService(db_path)
+        svc.record_unsubscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=date(2026, 6, 1))
+        assert not svc.has_any_events(1)
+
+    def test_sub_then_unsub_net_zero_for_week(self, db_path):
+        svc = SubscriptionTrackerService(db_path)
+        svc.record_subscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=date(2026, 6, 1))
+        svc.record_unsubscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=date(2026, 6, 1))
+        weekly = svc.get_weekly_counts(user_id=1, weeks=52)
+        target_monday = date(2026, 6, 1) - timedelta(days=date(2026, 6, 1).weekday())
+        for w in weekly:
+            if w["week_start"] == target_monday.isoformat():
+                assert w["past"] == 0
+                break
+
+
+class TestWeeklyCounts:
+    def test_single_past_session(self, db_path):
+        svc = SubscriptionTrackerService(db_path)
+        svc.record_subscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=date(2026, 5, 1))
+        weekly = svc.get_weekly_counts(user_id=1, weeks=52)
+        target_monday = date(2026, 5, 1) - timedelta(days=date(2026, 5, 1).weekday())
+        for w in weekly:
+            if w["week_start"] == target_monday.isoformat():
+                assert w["past"] == 1
+                assert w["future"] == 0
+                break
+
+    def test_multiple_sessions_same_week(self, db_path):
+        svc = SubscriptionTrackerService(db_path)
+        svc.record_subscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=date(2026, 5, 4))
+        svc.record_subscribe(user_id=1, appointment_id=11, class_name="CrossFit", class_date=date(2026, 5, 6))
+        weekly = svc.get_weekly_counts(user_id=1, weeks=52)
+        target_monday = date(2026, 5, 4) - timedelta(days=date(2026, 5, 4).weekday())
+        for w in weekly:
+            if w["week_start"] == target_monday.isoformat():
+                assert w["past"] == 2
+                break
+
+    def test_returns_52_weeks(self, db_path):
+        svc = SubscriptionTrackerService(db_path)
+        svc.record_subscribe(user_id=1, appointment_id=1, class_name="CrossFit", class_date=date(2026, 1, 1))
+        weekly = svc.get_weekly_counts(user_id=1, weeks=52)
+        assert len(weekly) == 52
+
+    def test_user_scoping(self, db_path):
+        svc = SubscriptionTrackerService(db_path)
+        svc.record_subscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=date(2026, 5, 1))
+        svc.record_subscribe(user_id=2, appointment_id=11, class_name="CrossFit", class_date=date(2026, 5, 2))
+        weekly_user1 = svc.get_weekly_counts(user_id=1, weeks=52)
+        weekly_user2 = svc.get_weekly_counts(user_id=2, weeks=52)
+        target_monday = date(2026, 5, 1) - timedelta(days=date(2026, 5, 1).weekday())
+        target_key = target_monday.isoformat()
+        for w in weekly_user1:
+            if w["week_start"] == target_key:
+                assert w["past"] == 1
+                break
+        for w in weekly_user2:
+            if w["week_start"] == target_key:
+                assert w["past"] == 1
+                break
+
+    def test_pre_existing_unsubscribe_ignored(self, db_path):
+        svc = SubscriptionTrackerService(db_path)
+        svc.record_unsubscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=date(2026, 7, 12))
+        svc.record_subscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=date(2026, 7, 12))
+        weekly = svc.get_weekly_counts(user_id=1, weeks=52)
+        target_monday = date(2026, 7, 12) - timedelta(days=date(2026, 7, 12).weekday())
+        target_key = target_monday.isoformat()
+        for w in weekly:
+            if w["week_start"] == target_key:
+                assert w["future"] == 1 or w["past"] == 1
+                break
+
+
+class TestCurrentWeekStats:
+    def test_returns_counts(self, db_path):
+        svc = SubscriptionTrackerService(db_path)
+        today = date.today()
+        svc.record_subscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=today)
+        stats = svc.get_current_week_stats(user_id=1)
+        assert stats["future"] >= 1
+
+
+class TestAveragePerWeek:
+    def test_no_data_returns_zero(self, db_path):
+        svc = SubscriptionTrackerService(db_path)
+        assert svc.get_average_per_week(1) == 0.0
+
+    def test_one_week_one_session(self, db_path):
+        svc = SubscriptionTrackerService(db_path)
+        past_date = date.today() - timedelta(days=10)
+        svc.record_subscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=past_date)
+        avg = svc.get_average_per_week(1)
+        assert avg > 0
+
+
+class TestWeeksTracked:
+    def test_returns_zero_when_no_data(self, db_path):
+        svc = SubscriptionTrackerService(db_path)
+        assert svc.get_weeks_tracked(1) == 0
+
+    def test_counts_distinct_weeks(self, db_path):
+        svc = SubscriptionTrackerService(db_path)
+        past = date.today() - timedelta(days=30)
+        svc.record_subscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=past)
+        weeks = svc.get_weeks_tracked(1)
+        assert weeks > 0


### PR DESCRIPTION
## Summary

Adds a stacked bar chart to the homepage showing sessions per week (rolling 52 weeks), with past (completed) and future (planned) differentiation, plus current week stats and average per week.

## Changes

**New files:**
- `src/wodplanner/services/subscription_tracker.py` — `SubscriptionTrackerService` + migration v700 (`subscription_events` table)
- `tests/services/test_subscription_tracker.py` — 15 tests

**Modified files:**
- `src/wodplanner/app/dependencies.py` — added `get_subscription_tracker_service` dependency
- `src/wodplanner/services/migrations.py` — registered the new module for auto-migration
- `src/wodplanner/app/routers/views.py` — `home_page` queries weekly stats; `subscribe_view` / `unsubscribe_view` record events
- `src/wodplanner/app/templates/partials/calendar_content.html` — passes `class_name` in HTMX hx-vals for tracking
- `src/wodplanner/app/templates/base.html` — added Chart.js CDN + `{% block scripts %}`
- `src/wodplanner/app/templates/home.html` — stacked bar chart canvas, empty state card, weekly stats + average display

## How it works

1. When a user clicks "Sign up" or "Sign out" on the calendar, the event is logged in `subscription_events`
2. The homepage queries weekly aggregates: past (class_date < today) vs future (class_date >= today)
3. Pre-existing subscriptions (created before tracking started) are handled gracefully — unmatched unsubscribes are ignored
4. All class types are counted (CrossFit, Olympic Lifting, Open Gym, etc.)
5. Chart.js renders a stacked bar chart with 52 weeks of data

## Design decisions

- **Event log model** (not aggregated counters) — allows reprocessing and handles edge cases
- **Net per appointment** — subscribe +1, unsubscribe -1; counted if net > 0
- **Current week included** — past vs future visual distinction via solid/hatched bars
- **Empty state** — info card shown until first subscribe event is recorded