### PR TITLE
fix: renovate config and debug logging

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "repositories": ["sebastiaankok/wodplanner"],
   "gitAuthor": "Sebastiaan Kok <sebastiaan@linux.com>",
   "schedule": ["before 6am on Monday"],
   "timezone": "Europe/Amsterdam",


### PR DESCRIPTION
## Changes

- **renovate.json**: Restored `repositories` field (needed by `renovatebot/github-action` global mode), changed `matchManagers` from `pyproject` (invalid) to `pep621` (correct manager for PEP 621 format)
- **renovate.yml**: Added `LOG_LEVEL: debug` to diagnose future runs

## Root cause

Renovate was detecting the manager as `poetry` (which matches deprecated Poetry format), while the pyproject.toml uses PEP 621 format (`[project.dependencies]`). The `matchManagers: ["pyproject"]` rules never matched.