### PR TITLE
fix: handle missing CHANGELOG.md in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.14-slim
 
 WORKDIR /app
 COPY pyproject.toml .
+COPY CHANGELOG.md .
 
 # Stub package so pip can resolve deps without real source
 RUN mkdir -p src/wodplanner && touch src/wodplanner/__init__.py

--- a/src/wodplanner/app/routers/views.py
+++ b/src/wodplanner/app/routers/views.py
@@ -174,7 +174,10 @@ def changelog_page(
     """Render the CHANGELOG.md as an HTML page."""
     repo_root = Path(__file__).parent.parent.parent.parent.parent
     changelog_path = repo_root / "CHANGELOG.md"
-    raw = changelog_path.read_text(encoding="utf-8")
+    try:
+        raw = changelog_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        raw = "# Changelog\n\nChangelog file not found."
     html_content = markdown.markdown(
         raw,
         extensions=["fenced_code", "codehilite"],


### PR DESCRIPTION
- Copy CHANGELOG.md into the Docker image
- Gracefully handle FileNotFoundError on /changelog page
