### PR TITLE
feat: add tracking toggle setting with delete support and seed-subscriptions CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,10 @@ add-1rm  # interactive: shows existing list, prompts for name
 # Manage benchmark WOD list (add names for detection)
 add-benchmark --name "Nasty Girls"
 
+# Seed test data for the weekly chart on the home page (--dry-run to preview)
+seed-subscriptions --user-id 123 --weeks 12 --avg-per-week 3
+seed-subscriptions --user-id 123 --weeks 26 --avg-per-week 4 --dry-run
+
 # Backup database (safe during live writes, keeps 7 by default)
 backup-db
 backup-db --db-path /data/wodplanner.db --backup-dir /data/backups --keep 7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ import-schedule = "wodplanner.cli.import_schedule:main"
 backup-db = "wodplanner.cli.backup_db:main"
 add-1rm = "wodplanner.cli.add_1rm:main"
 add-benchmark = "wodplanner.cli.add_benchmark:main"
+seed-subscriptions = "wodplanner.cli.seed_subscriptions:main"
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/src/wodplanner/app/routers/views.py
+++ b/src/wodplanner/app/routers/views.py
@@ -191,6 +191,7 @@ def home_page(
     session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
     client: WodAppClient = Depends(get_client_from_session_for_view),
     tracker: SubscriptionTrackerService = Depends(get_subscription_tracker_service),
+    prefs_service: PreferencesService = Depends(get_preferences_service),
 ):
     """Homepage showing upcoming reservations and weekly stats."""
     reservations, company_images = client.get_upcoming_reservations()
@@ -209,24 +210,26 @@ def home_page(
             "display_date": r.date_start.strftime("%B %d"),
         })
 
-    # Weekly stats
+    # Weekly stats (skip if tracking disabled)
     user_id = session.user_id
-    has_data = tracker.has_any_events(user_id)
+    has_data = False
     chart_data: dict[str, list] = {"weeks": [], "past": [], "future": []}
     week_stats = {"past": 0, "future": 0}
     average = 0.0
     weeks_tracked = 0
 
-    if has_data:
-        weekly = tracker.get_weekly_counts(user_id)
-        chart_data = {
-            "weeks": [w["week_start"] for w in weekly],
-            "past": [w["past"] for w in weekly],
-            "future": [w["future"] for w in weekly],
-        }
-        week_stats = tracker.get_current_week_stats(user_id)
-        average = round(tracker.get_average_per_week(user_id), 1)
-        weeks_tracked = tracker.get_weeks_tracked(user_id)
+    if not prefs_service.is_tracking_disabled(user_id):
+        has_data = tracker.has_any_events(user_id)
+        if has_data:
+            weekly = tracker.get_weekly_counts(user_id)
+            chart_data = {
+                "weeks": [w["week_start"] for w in weekly],
+                "past": [w["past"] for w in weekly],
+                "future": [w["future"] for w in weekly],
+            }
+            week_stats = tracker.get_current_week_stats(user_id)
+            average = round(tracker.get_average_per_week(user_id), 1)
+            weeks_tracked = tracker.get_weeks_tracked(user_id)
 
     return render(
         request,
@@ -431,12 +434,14 @@ def settings_page(
     """Settings page."""
     hidden_types = prefs_service.get_hidden_class_types(session.user_id)
     filters = [{"name": t, "hidden": t in hidden_types} for t in FILTERABLE_CLASS_TYPES]
+    tracking_disabled = prefs_service.is_tracking_disabled(session.user_id)
     return render(
         request,
         "settings.html",
         {
             "active_page": "",
             "filters": filters,
+            "tracking_disabled": tracking_disabled,
             **get_user_context(session),
         },
     )
@@ -464,6 +469,36 @@ def settings_toggle_filter(
     hidden_types = prefs_service.get_hidden_class_types(session.user_id)
     filters = [{"name": t, "hidden": t in hidden_types} for t in FILTERABLE_CLASS_TYPES]
     return render(request, "partials/settings_filters.html", {"filters": filters})
+
+
+@router.post("/settings/toggle-tracking", response_class=HTMLResponse)
+def toggle_tracking(
+    request: Request,
+    enable: str = Form("true"),
+    delete_data: str = Form("false"),
+    session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
+    prefs_service: PreferencesService = Depends(get_preferences_service),
+    tracker: SubscriptionTrackerService = Depends(get_subscription_tracker_service),
+):
+    """Enable or disable session tracking."""
+    disabled = enable != "true"
+    prefs_service.set_tracking_disabled(session.user_id, disabled)
+
+    if delete_data == "true":
+        tracker.delete_all_for_user(session.user_id)
+
+    return HTMLResponse("")
+
+
+@router.post("/settings/delete-tracking-data", response_class=HTMLResponse)
+def delete_tracking_data(
+    request: Request,
+    session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
+    tracker: SubscriptionTrackerService = Depends(get_subscription_tracker_service),
+):
+    """Delete all tracking data for the current user."""
+    tracker.delete_all_for_user(session.user_id)
+    return HTMLResponse('<p class="success-msg">Tracking data deleted.</p>')
 
 
 @router.get("/1rm", response_class=HTMLResponse)
@@ -622,13 +657,14 @@ def subscribe_view(
         action=SubscribeAction.SUBSCRIBE,
     )
 
-    tracker.record_subscribe(
-        user_id=session.user_id,
-        appointment_id=appointment_id,
-        class_name=class_name,
-        class_date=start.date(),
-        class_end=end,
-    )
+    if not prefs_service.is_tracking_disabled(session.user_id):
+        tracker.record_subscribe(
+            user_id=session.user_id,
+            appointment_id=appointment_id,
+            class_name=class_name,
+            class_date=start.date(),
+            class_end=end,
+        )
 
     # Return updated calendar
     return calendar_day_partial(
@@ -715,7 +751,7 @@ def unsubscribe_view(
         action=action,
     )
 
-    if is_waitinglist != "true":
+    if is_waitinglist != "true" and not prefs_service.is_tracking_disabled(session.user_id):
         tracker.record_unsubscribe(
             user_id=session.user_id,
             appointment_id=appointment_id,

--- a/src/wodplanner/app/templates/settings.html
+++ b/src/wodplanner/app/templates/settings.html
@@ -33,6 +33,26 @@
         </div>
     </section>
 
+    <section class="card settings-section">
+        <h2>Session Tracking</h2>
+        <p class="settings-description">Track your class attendance to see weekly stats on the home page.</p>
+        <div class="settings-item">
+            <label>Tracking is {{ 'disabled' if tracking_disabled else 'enabled' }}</label>
+            <button class="btn btn-sm {{ 'btn-secondary' if tracking_disabled else 'btn-danger' }}"
+                    onclick="toggleTracking(event)"
+                    id="tracking-toggle-btn">
+                {{ 'Enable' if tracking_disabled else 'Disable' }} tracking
+            </button>
+        </div>
+        {% if tracking_disabled %}
+        <div class="settings-item" style="margin-top: 0.5rem;">
+            <label style="color: var(--gray-400);">Delete my tracking data</label>
+            <button class="btn btn-sm btn-secondary"
+                    onclick="deleteTrackingData(event)">Delete</button>
+        </div>
+        {% endif %}
+    </section>
+
 </div>
 
 <!-- Reset Tutorial Confirmation Modal -->
@@ -57,6 +77,7 @@
 </div>
 
 <div id="reset-result"></div>
+<div id="tracking-result"></div>
 
 <script>
     function openConfirmModal() {
@@ -68,5 +89,35 @@
     document.getElementById('reset-confirm-modal').addEventListener('click', function(e) {
         if (e.target === this) closeConfirmModal();
     });
+
+    function toggleTracking(event) {
+        var btn = event.currentTarget;
+        var currentlyDisabled = {{ 'true' if tracking_disabled else 'false' }};
+        if (currentlyDisabled) {
+            // Enable tracking
+            htmx.ajax('POST', '/settings/toggle-tracking', {
+                values: {enable: 'true', delete_data: 'false'},
+                target: '#tracking-result',
+                swap: 'innerHTML',
+            }).then(function() { location.reload(); });
+        } else {
+            // Disable tracking
+            if (!confirm('Disable session tracking? The weekly chart will be hidden on the home page.')) return;
+            var deleteData = confirm('Delete existing tracking data too? This cannot be undone.');
+            htmx.ajax('POST', '/settings/toggle-tracking', {
+                values: {enable: 'false', delete_data: deleteData ? 'true' : 'false'},
+                target: '#tracking-result',
+                swap: 'innerHTML',
+            }).then(function() { location.reload(); });
+        }
+    }
+
+    function deleteTrackingData(event) {
+        if (!confirm('Delete all your tracking data? This cannot be undone.')) return;
+        htmx.ajax('POST', '/settings/delete-tracking-data', {
+            target: '#tracking-result',
+            swap: 'innerHTML',
+        }).then(function() { location.reload(); });
+    }
 </script>
 {% endblock %}

--- a/src/wodplanner/cli/seed_subscriptions.py
+++ b/src/wodplanner/cli/seed_subscriptions.py
@@ -1,0 +1,117 @@
+"""CLI tool to seed subscription_events with realistic test data for development.
+
+Usage:
+    seed-subscriptions --user-id 123 --dry-run
+    seed-subscriptions --user-id 123 --weeks 26 --avg-per-week 4
+    seed-subscriptions --user-id 123 --db-path /tmp/test.db
+"""
+
+import argparse
+import os
+import random
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+from wodplanner.services.subscription_tracker import SubscriptionTrackerService
+
+CLASS_NAMES = [
+    "CrossFit", "CrossFit", "CrossFit", "CrossFit",
+    "Olympic Lifting", "Gymnastics",
+]
+
+
+def generate_events(
+    user_id: int,
+    weeks: int,
+    avg_per_week: int,
+    dry_run: bool,
+    db_path: Path,
+) -> None:
+    svc = SubscriptionTrackerService(db_path) if not dry_run else None
+    today = date.today()
+    total = 0
+    next_appt_id = 900000
+
+    print(
+        f"Simulating {weeks} weeks of sessions for user {user_id} "
+        f"(avg {avg_per_week}/week, dry_run={dry_run})"
+    )
+
+    for week_offset in range(weeks, 0, -1):
+        monday = today - timedelta(weeks=week_offset)
+        count = max(1, avg_per_week + random.randint(-1, 1))
+        days = sorted(random.sample(range(5), count))
+
+        session_days = []
+        for dow in days:
+            class_date = monday + timedelta(days=dow)
+            class_name = random.choice(CLASS_NAMES)
+            hour = random.choice([7, 8, 9, 12, 17, 18, 19])
+            class_start = datetime(
+                class_date.year, class_date.month, class_date.day, hour, 0
+            )
+            class_end = class_start + timedelta(hours=1)
+            if not dry_run:
+                svc.record_subscribe(
+                    user_id=user_id,
+                    appointment_id=next_appt_id,
+                    class_name=class_name,
+                    class_date=class_date,
+                    class_end=class_end,
+                )
+            session_days.append(f"{class_date.strftime('%a')} {class_name}")
+            next_appt_id += 1
+            total += 1
+
+        print(
+            f"  Week {monday.isoformat()}: {len(days)} sessions"
+            f" — {', '.join(session_days)}"
+        )
+
+    if dry_run:
+        print(f"\nTotal: {total} events (DRY RUN — no changes made)")
+    else:
+        print(f"\nTotal: {total} events inserted")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Seed test subscription events for the weekly chart"
+    )
+    parser.add_argument("--user-id", type=int, required=True, help="WodApp user ID")
+    parser.add_argument(
+        "--db-path",
+        type=Path,
+        default=Path(os.environ.get("DB_PATH", "/data/wodplanner.db")),
+        help="Path to SQLite database (default: $DB_PATH env var or /data/wodplanner.db)",
+    )
+    parser.add_argument(
+        "--weeks",
+        type=int,
+        default=12,
+        help="Number of weeks to go back and fill (default: 12)",
+    )
+    parser.add_argument(
+        "--avg-per-week",
+        type=int,
+        default=3,
+        help="Average sessions per week (default: 3, varies ±1)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview events without inserting",
+    )
+    args = parser.parse_args()
+
+    generate_events(
+        user_id=args.user_id,
+        weeks=args.weeks,
+        avg_per_week=args.avg_per_week,
+        dry_run=args.dry_run,
+        db_path=args.db_path,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/wodplanner/cli/seed_subscriptions.py
+++ b/src/wodplanner/cli/seed_subscriptions.py
@@ -52,6 +52,7 @@ def generate_events(
             )
             class_end = class_start + timedelta(hours=1)
             if not dry_run:
+                assert svc is not None
                 svc.record_subscribe(
                     user_id=user_id,
                     appointment_id=next_appt_id,

--- a/src/wodplanner/services/preferences.py
+++ b/src/wodplanner/services/preferences.py
@@ -113,7 +113,7 @@ class PreferencesService(BaseService):
 
     def is_tracking_disabled(self, user_id: int) -> bool:
         value = self._get(user_id, "tracking_disabled", "false")
-        return json.loads(value)
+        return cast("bool", json.loads(value))
 
     def set_tracking_disabled(self, user_id: int, disabled: bool) -> None:
         self._set(user_id, "tracking_disabled", json.dumps(disabled))

--- a/src/wodplanner/services/preferences.py
+++ b/src/wodplanner/services/preferences.py
@@ -14,6 +14,7 @@ class UserPreferences:
     """User preferences."""
     hidden_class_types: list[str] = field(default_factory=list)
     dismissed_tooltips: list[str] = field(default_factory=list)
+    tracking_disabled: bool = False
 
 
 def _migrate_v300(conn: sqlite3.Connection) -> None:
@@ -110,6 +111,13 @@ class PreferencesService(BaseService):
     def reset_tooltips(self, user_id: int) -> None:
         self._set(user_id, "dismissed_tooltips", "[]")
 
+    def is_tracking_disabled(self, user_id: int) -> bool:
+        value = self._get(user_id, "tracking_disabled", "false")
+        return json.loads(value)
+
+    def set_tracking_disabled(self, user_id: int, disabled: bool) -> None:
+        self._set(user_id, "tracking_disabled", json.dumps(disabled))
+
     def get_for_user(self, user_id: int) -> UserPreferences:
         """Get all preferences for a user in a single query."""
         with self._get_connection() as conn:
@@ -124,6 +132,8 @@ class PreferencesService(BaseService):
                 prefs.hidden_class_types = json.loads(value)
             elif key == "dismissed_tooltips":
                 prefs.dismissed_tooltips = json.loads(value)
+            elif key == "tracking_disabled":
+                prefs.tracking_disabled = json.loads(value)
         return prefs
 
     def get_all(self, user_id: int) -> UserPreferences:

--- a/src/wodplanner/services/subscription_tracker.py
+++ b/src/wodplanner/services/subscription_tracker.py
@@ -228,6 +228,14 @@ class SubscriptionTrackerService(BaseService):
 
         return sum(week_counts.values()) / len(week_counts)
 
+    def delete_all_for_user(self, user_id: int) -> None:
+        with self._get_connection() as conn:
+            conn.execute(
+                "DELETE FROM subscription_events WHERE user_id = ?",
+                (user_id,),
+            )
+            conn.commit()
+
     def has_any_events(self, user_id: int) -> bool:
         with self._get_connection() as conn:
             row = conn.execute(

--- a/tests/services/test_preferences.py
+++ b/tests/services/test_preferences.py
@@ -60,6 +60,29 @@ class TestPreferencesService:
         assert svc.get_hidden_class_types(user_id=1) == ["CrossFit"]
         assert svc.get_hidden_class_types(user_id=2) == ["Gymnastics"]
 
+    def test_tracking_disabled_default_false(self, db_path):
+        svc = PreferencesService(db_path)
+        assert svc.is_tracking_disabled(user_id=1) is False
+
+    def test_set_tracking_disabled(self, db_path):
+        svc = PreferencesService(db_path)
+        svc.set_tracking_disabled(user_id=1, disabled=True)
+        assert svc.is_tracking_disabled(user_id=1) is True
+        svc.set_tracking_disabled(user_id=1, disabled=False)
+        assert svc.is_tracking_disabled(user_id=1) is False
+
+    def test_tracking_disabled_in_get_all(self, db_path):
+        svc = PreferencesService(db_path)
+        svc.set_tracking_disabled(user_id=1, disabled=True)
+        prefs = svc.get_all(user_id=1)
+        assert prefs.tracking_disabled is True
+
+    def test_tracking_disabled_user_isolation(self, db_path):
+        svc = PreferencesService(db_path)
+        svc.set_tracking_disabled(user_id=1, disabled=True)
+        assert svc.is_tracking_disabled(user_id=1) is True
+        assert svc.is_tracking_disabled(user_id=2) is False
+
     def test_migration_from_old_schema(self, tmp_path, clean_registry):
         import sqlite3
 

--- a/tests/services/test_subscription_tracker.py
+++ b/tests/services/test_subscription_tracker.py
@@ -134,3 +134,19 @@ class TestWeeksTracked:
         svc.record_subscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=past)
         weeks = svc.get_weeks_tracked(1)
         assert weeks > 0
+
+
+class TestDeleteAllForUser:
+    def test_deletes_all_events_for_user(self, db_path):
+        svc = SubscriptionTrackerService(db_path)
+        svc.record_subscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=date(2026, 6, 1))
+        svc.record_subscribe(user_id=1, appointment_id=11, class_name="CrossFit", class_date=date(2026, 6, 2))
+        svc.record_subscribe(user_id=2, appointment_id=12, class_name="CrossFit", class_date=date(2026, 6, 1))
+        svc.delete_all_for_user(user_id=1)
+        assert not svc.has_any_events(1)
+        assert svc.has_any_events(2)
+
+    def test_noop_when_no_data(self, db_path):
+        svc = SubscriptionTrackerService(db_path)
+        svc.delete_all_for_user(user_id=1)
+        assert not svc.has_any_events(1)


### PR DESCRIPTION
Adds a user setting to disable session tracking on the home page, with optional data deletion and a CLI tool to seed test data.