### PR TITLE
chore: revert auto-merge test note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,7 @@ WodPlanner is a custom frontend for WodApp, a CrossFit class scheduling app. It 
 
 ## Git / Pull requests
 
-This project uses CI pipelines to validate PR's. When requested to create a branch and PR, also enable automerge so the PR merges automatically once CI passes.
-
-Auto-merge test: 2026-07-13 — verifying automerge behaviour with current branch protection rules.
+This project uses CI pipelines to validate PR's, when requested to create a branch and PR also use automerge
 
 ## Commands
 


### PR DESCRIPTION
Reverting the auto-merge test note from the previous PR. Testing if automerge now waits for CI.