### PR TITLE
fix: use MAX(class_end) in GROUP BY for correct today's session classification

### DIFF
--- a/src/wodplanner/services/subscription_tracker.py
+++ b/src/wodplanner/services/subscription_tracker.py
@@ -123,7 +123,7 @@ class SubscriptionTrackerService(BaseService):
                 """
                 SELECT
                     class_date,
-                    class_end,
+                    MAX(class_end) AS class_end,
                     SUM(CASE WHEN event_type = 'subscribe' THEN 1 ELSE -1 END) AS net
                 FROM subscription_events
                 WHERE user_id = ?
@@ -172,7 +172,7 @@ class SubscriptionTrackerService(BaseService):
                 """
                 SELECT
                     class_date,
-                    class_end,
+                    MAX(class_end) AS class_end,
                     SUM(CASE WHEN event_type = 'subscribe' THEN 1 ELSE -1 END) AS net
                 FROM subscription_events
                 WHERE user_id = ?


### PR DESCRIPTION
The GROUP BY `appointment_id` query returned an arbitrary `class_end` value. When SQLite picked `NULL` (from an initial subscribe event without `class_end`), `_is_past` fell through to date-only comparison where `class_date < date.today()` is `False` for today's date, misclassifying past sessions as 'planned'.

Uses `MAX(class_end)` to ensure we always get the latest non-NULL end time.