### PR TITLE
fix: add Gymnastics101 alias for Gymnastics 101 schedule mapping

### DIFF
--- a/src/wodplanner/services/schedule.py
+++ b/src/wodplanner/services/schedule.py
@@ -26,7 +26,7 @@ CLASS_NAME_MAPPING: dict[str, list[str]] = {
     "CrossFit & Teen Athlete": ["CrossFit", "Teen Athlete"],
     "Strongman": ["Strongman"],
     "Strongman101": ["Strongman101", "Strongman 101"],
-    "Gymnastics 101": ["Gymnastics 101"],
+    "Gymnastics 101": ["Gymnastics 101", "Gymnastics101"],
     "HyCross 101": ["HyCross 101", "Hyrox 101", "HyCross101"],
 }
 


### PR DESCRIPTION
The WodApp API returns `Gymnastics101` (no space) for this class, but the `CLASS_NAME_MAPPING` only listed `Gymnastics 101` as an alias, causing the schedule lookup to fail and show 'No workout schedule available'.

Similar entries (e.g. `HyCross 101` → `HyCross101`) already included the no-space variant, but `Gymnastics 101` was missing it.