### PR TITLE
fix: check WodApp API response before recording session tracker events

### DIFF
--- a/src/wodplanner/app/routers/views.py
+++ b/src/wodplanner/app/routers/views.py
@@ -655,14 +655,14 @@ def subscribe_view(
     start = parse_api_datetime(date_start)
     end = parse_api_datetime(date_end)
 
-    subscription_service.act(
+    result = subscription_service.act(
         appointment_id=appointment_id,
         start=start,
         end=end,
         action=SubscribeAction.SUBSCRIBE,
     )
 
-    if not prefs_service.is_tracking_disabled(session.user_id):
+    if result.subscribedWithSuccess and not prefs_service.is_tracking_disabled(session.user_id):
         tracker.record_subscribe(
             user_id=session.user_id,
             appointment_id=appointment_id,
@@ -749,14 +749,14 @@ def unsubscribe_view(
         else SubscribeAction.UNSUBSCRIBE
     )
 
-    subscription_service.act(
+    result = subscription_service.act(
         appointment_id=appointment_id,
         start=start,
         end=end,
         action=action,
     )
 
-    if is_waitinglist != "true" and not prefs_service.is_tracking_disabled(session.user_id):
+    if result.subscribedWithSuccess and is_waitinglist != "true" and not prefs_service.is_tracking_disabled(session.user_id):
         tracker.record_unsubscribe(
             user_id=session.user_id,
             appointment_id=appointment_id,

--- a/src/wodplanner/services/subscription.py
+++ b/src/wodplanner/services/subscription.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from enum import Enum
 
 from wodplanner.api.client import WodAppClient
+from wodplanner.models.calendar import SubscribeResponse
 
 logger = logging.getLogger(__name__)
 
@@ -28,8 +29,8 @@ class SubscriptionService:
         start: datetime,
         end: datetime,
         action: SubscribeAction,
-    ) -> None:
-        self._dispatch(appointment_id, start, end, action)
+    ) -> SubscribeResponse:
+        return self._dispatch(appointment_id, start, end, action)
 
     def _dispatch(
         self,
@@ -37,7 +38,7 @@ class SubscriptionService:
         start: datetime,
         end: datetime,
         action: SubscribeAction,
-    ) -> None:
+    ) -> SubscribeResponse:
         dispatch_map = {
             SubscribeAction.SUBSCRIBE: self._client.subscribe,
             SubscribeAction.WAITLIST: self._client.subscribe_waitinglist,
@@ -45,4 +46,4 @@ class SubscriptionService:
             SubscribeAction.UNSUBSCRIBE_WAITLIST: self._client.unsubscribe_waitinglist,
         }
         handler = dispatch_map[action]
-        handler(appointment_id, start, end)
+        return handler(appointment_id, start, end)

--- a/src/wodplanner/services/subscription_tracker.py
+++ b/src/wodplanner/services/subscription_tracker.py
@@ -59,6 +59,19 @@ class SubscriptionTrackerService(BaseService):
         class_end: datetime | None = None,
     ) -> None:
         with self._get_connection() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                """
+                SELECT SUM(CASE WHEN event_type = 'subscribe' THEN 1 ELSE -1 END) AS net
+                FROM subscription_events
+                WHERE user_id = ? AND appointment_id = ?
+                """,
+                (user_id, appointment_id),
+            ).fetchone()
+            current_net = row["net"] if row and row["net"] is not None else 0
+            if current_net > 0:
+                conn.execute("ROLLBACK")
+                return
             conn.execute(
                 """
                 INSERT INTO subscription_events (user_id, appointment_id, class_name, event_type, class_date, class_end, created_at)
@@ -67,12 +80,14 @@ class SubscriptionTrackerService(BaseService):
                 (user_id, appointment_id, class_name, class_date.isoformat(),
                  self._aware(class_end).isoformat() if class_end else None, datetime.now(_TZ).isoformat()),
             )
+            conn.commit()
 
     def record_unsubscribe(
         self, user_id: int, appointment_id: int, class_name: str, class_date: date,
         class_end: datetime | None = None,
     ) -> None:
         with self._get_connection() as conn:
+            conn.execute("BEGIN IMMEDIATE")
             row = conn.execute(
                 """
                 SELECT SUM(CASE WHEN event_type = 'subscribe' THEN 1 ELSE -1 END) AS net
@@ -83,6 +98,7 @@ class SubscriptionTrackerService(BaseService):
             ).fetchone()
             current_net = row["net"] if row and row["net"] is not None else 0
             if current_net <= 0:
+                conn.execute("ROLLBACK")
                 return
             conn.execute(
                 """
@@ -92,6 +108,7 @@ class SubscriptionTrackerService(BaseService):
                 (user_id, appointment_id, class_name, class_date.isoformat(),
                  self._aware(class_end).isoformat() if class_end else None, datetime.now(_TZ).isoformat()),
             )
+            conn.commit()
 
     @staticmethod
     def _aware(dt: datetime) -> datetime:


### PR DESCRIPTION
## Problem

Users reported incorrect weekly session values on the home page chart. Investigation revealed two bugs in the session subscription tracking system.

### Bug 1: Phantom events recorded
`SubscriptionService._dispatch()` at `services/subscription.py:48` discarded the `SubscribeResponse` from the WodApp API. The API can return `status=OK` but `subscribedWithSuccess=0` (e.g., appointment full, signup window closed). The views in `views.py` blindly recorded tracker events without checking → **phantom sessions on chart**.

Production data confirmed this: 4 of 5 users have appointments where the net count is 0 (session vanished) instead of 1.

### Bug 2: Race condition on subscribe/unsubscribe
`record_unsubscribe` did SELECT-then-INSERT without atomic locking. Two concurrent requests (double-click, HTMX race) could both insert events, creating duplicate pairs. Production data shows cases like: subscribe → unsubscribe at 12:52:36 → subscribe at 12:52:37 (1 second later) → all netting to zero.

## Fix

**`services/subscription.py`** — `act()` and `_dispatch()` now return `SubscribeResponse` instead of `None`.

**`app/routers/views.py`** — Both `subscribe_view` and `unsubscribe_view` check `result.subscribedWithSuccess` before recording tracker events.

**`services/subscription_tracker.py`** — Both `record_subscribe` and `record_unsubscribe` now:
- Use `BEGIN IMMEDIATE` + `COMMIT` for atomicity (prevents race condition)
- `record_subscribe` guards against double-counting (skips if `net > 0`)

## Verification
- All 284 existing tests pass
- Ruff lint and mypy type checks pass