### PR TITLE
feat: order 1RM and benchmark dropdowns by recency

### DIFF
--- a/src/wodplanner/app/routers/views.py
+++ b/src/wodplanner/app/routers/views.py
@@ -119,6 +119,19 @@ def _build_benchmark_chart_data(formatted_entries: list) -> str:
     return json.dumps(data).replace("</", "<\\/")
 
 
+def _ordered_by_recency(
+    formatted_entries: list[dict], key: str
+) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for e in formatted_entries:
+        name = e[key]
+        if name not in seen:
+            seen.add(name)
+            result.append(name)
+    return result
+
+
 router = APIRouter(tags=["views"])
 
 # Setup templates
@@ -517,6 +530,7 @@ def one_rep_max_page(
     past_exercises = one_rep_max_service.get_exercises(session.user_id)
     exercises = one_rep_max_service.get_exercise_list()
     entries = _format_1rm_entries(raw)
+    exercises_by_recency = _ordered_by_recency(entries, "exercise")
 
     return render(
         request,
@@ -527,6 +541,7 @@ def one_rep_max_page(
             "past_exercises": past_exercises,
             "default_exercise": entries[0]["exercise"] if entries else "",
             "entries": entries,
+            "exercises_by_recency": exercises_by_recency,
             "exercises_data_json": _build_exercises_chart_data(entries),
             "today": date.today().isoformat(),
             **get_user_context(session),
@@ -543,6 +558,7 @@ def benchmark_page(
     """Benchmark tracking page."""
     raw = benchmark_service.get_all_results(session.user_id)
     entries = _format_benchmark_entries(raw)
+    benchmarks_by_recency = _ordered_by_recency(entries, "benchmark_name")
     benchmark_list = benchmark_service.get_benchmark_list()
 
     return render(
@@ -552,6 +568,7 @@ def benchmark_page(
             "active_page": "benchmark",
             "benchmark_list": benchmark_list,
             "entries": entries,
+            "benchmarks_by_recency": benchmarks_by_recency,
             "benchmark_data_json": _build_benchmark_chart_data(entries),
             "today": date.today().isoformat(),
             **get_user_context(session),

--- a/src/wodplanner/app/templates/benchmark.html
+++ b/src/wodplanner/app/templates/benchmark.html
@@ -83,7 +83,7 @@
         <span class="card-title">Progress</span>
         <select id="benchmark-select" class="form-control form-control-inline" onchange="updateBenchmarkChart()">
             <option value="">— Select benchmark —</option>
-            {% for name in entries | map(attribute='benchmark_name') | unique | sort %}
+            {% for name in benchmarks_by_recency %}
             <option value="{{ name }}">{{ name }}</option>
             {% endfor %}
         </select>
@@ -203,7 +203,13 @@ document.addEventListener('htmx:afterSwap', function(e) {
         if (!select) return;
         var current = select.value;
         select.innerHTML = '<option value="">— Select benchmark —</option>';
-        Object.keys(__benchmarkData).sort().forEach(function(name) {
+        Object.keys(__benchmarkData)
+            .sort(function(a, b) {
+                var aLast = __benchmarkData[a][__benchmarkData[a].length - 1].date;
+                var bLast = __benchmarkData[b][__benchmarkData[b].length - 1].date;
+                return aLast < bLast ? 1 : aLast > bLast ? -1 : 0;
+            })
+            .forEach(function(name) {
             var opt = document.createElement('option');
             opt.value = name;
             opt.textContent = name;

--- a/src/wodplanner/app/templates/one_rep_max.html
+++ b/src/wodplanner/app/templates/one_rep_max.html
@@ -61,7 +61,7 @@
         <span class="card-title">Progress</span>
         <select id="exercise-select" class="form-control form-control-inline" onchange="update1rmChart()">
             <option value="">— Select exercise —</option>
-            {% for ex in entries | map(attribute='exercise') | unique | sort %}
+            {% for ex in exercises_by_recency %}
             <option value="{{ ex }}">{{ ex }}</option>
             {% endfor %}
         </select>
@@ -205,7 +205,13 @@ document.addEventListener('htmx:afterSwap', function(e) {
         if (!select) return;
         var current = select.value;
         select.innerHTML = '<option value="">— Select exercise —</option>';
-        Object.keys(__1rmData).sort().forEach(function(ex) {
+        Object.keys(__1rmData)
+            .sort(function(a, b) {
+                var aLast = __1rmData[a][__1rmData[a].length - 1].date;
+                var bLast = __1rmData[b][__1rmData[b].length - 1].date;
+                return aLast < bLast ? 1 : aLast > bLast ? -1 : 0;
+            })
+            .forEach(function(ex) {
             var opt = document.createElement('option');
             opt.value = ex;
             opt.textContent = ex;


### PR DESCRIPTION
Changes the 'Progress' chart dropdowns on the 1RM and Benchmark pages to show exercises/benchmarks ordered by most recently recorded instead of alphabetically. This makes it easier to find the exercise you just logged.

- Added `_ordered_by_recency()` helper in `views.py`
- Jinja templates and HTMX after-swap JS both use recency ordering