### PR TITLE
feat: replace 1RM modal history table with chart and percentage calculator

### DIFF
--- a/src/wodplanner/app/routers/views.py
+++ b/src/wodplanner/app/routers/views.py
@@ -5,7 +5,7 @@ import json
 import logging
 from datetime import date, datetime, timedelta
 from pathlib import Path
-from typing import Annotated, cast
+from typing import Annotated
 
 import markdown
 from fastapi import APIRouter, Depends, Form, HTTPException, Request
@@ -919,17 +919,9 @@ def one_rep_max_modal_view(
     raw = one_rep_max_service.get_all(session.user_id)
     today = date.today().isoformat()
 
-    formatted = [
-        {
-            "id": e.id,
-            "exercise": e.exercise,
-            "weight_kg": e.weight_kg,
-            "recorded_at": e.recorded_at.strftime("%b %d, %Y"),
-        }
-        for e in raw
-    ]
-    if suggested_exercises:
-        formatted.sort(key=lambda e: -_similarity_score(cast("str", e["exercise"]), suggested_exercises))
+    formatted = _format_1rm_entries(raw)
+
+    default_exercise = suggested_exercises[0] if suggested_exercises else (formatted[0]["exercise"] if formatted else "")
 
     return render(
         request,
@@ -938,9 +930,11 @@ def one_rep_max_modal_view(
             "suggested_exercises": suggested_exercises,
             "exercises": exercises,
             "entries": formatted,
+            "default_exercise": default_exercise,
             "today": today,
             "show_date": False,
             "preset_date": schedule_date.isoformat(),
+            "exercises_data_json": _build_exercises_chart_data(formatted),
         },
     )
 

--- a/src/wodplanner/app/static/css/style.css
+++ b/src/wodplanner/app/static/css/style.css
@@ -850,24 +850,29 @@ body {
     flex: 0 0 auto;
 }
 
-/* Modal form: 2-row grid on all screen sizes */
+/* Modal form: single row - exercise | weight | save */
 .one-rm-form--modal .form-row {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr auto auto;
     align-items: end;
     gap: 0.5rem;
 }
 
 .one-rm-form--modal .form-row > :nth-child(1) {
-    grid-column: 1 / -1;
-}
-
-.one-rm-form--modal .form-row > :nth-child(2) {
     grid-column: 1;
 }
 
-.one-rm-form--modal .form-row > :nth-child(3) {
+.one-rm-form--modal .form-row > :nth-child(2) {
     grid-column: 2;
+}
+
+.one-rm-form--modal .form-row > :nth-child(3) {
+    grid-column: 3;
+}
+
+.one-rm-form--modal .form-group-narrow {
+    flex: none;
+    min-width: 90px;
 }
 
 .one-rm-form--modal .form-group-submit .btn {

--- a/src/wodplanner/app/templates/partials/one_rep_max_modal.html
+++ b/src/wodplanner/app/templates/partials/one_rep_max_modal.html
@@ -14,14 +14,11 @@
             <div class="form-row">
                 <div class="form-group">
                     <label for="1rm-exercise">Exercise</label>
-                    <select id="1rm-exercise" name="exercise" required class="form-control">
+                    <select id="1rm-exercise" name="exercise" required class="form-control" onchange="modalUpdate1rmChart()">
                         {% for ex in exercises %}
                         <option value="{{ ex }}" {% if suggested_exercises and ex == suggested_exercises[0] %}selected{% endif %}>{{ ex }}</option>
                         {% endfor %}
                     </select>
-                    {% if suggested_exercises %}
-                    <p class="text-muted" style="font-size:0.8rem; margin-top:0.25rem;">Suggested from today's workout: {{ suggested_exercises | join(', ') }}</p>
-                    {% endif %}
                 </div>
                 <div class="form-group form-group-narrow">
                     <label for="1rm-weight">Weight (kg)</label>
@@ -53,6 +50,115 @@
             </div>
         </form>
 
-        {% include "partials/one_rep_max_history.html" %}
+        <div class="modal-chart-section" id="modal-chart-section">
+            <div id="modal-pct-section" class="one-rm-pct-section" style="padding:1rem 1rem 0.5rem;display:none">
+                <div class="one-rm-pct-center">
+                    <div class="one-rm-pct-controls">
+                        <button class="one-rm-pct-btn" onclick="modalStepPct(-5)">−</button>
+                        <span id="modal-pct-display" class="one-rm-pct-pct one-rm-pct-label">100%</span>
+                        <button class="one-rm-pct-btn" onclick="modalStepPct(+5)">+</button>
+                    </div>
+                    <span id="modal-pct-weight" class="one-rm-pct-kg one-rm-big-weight">—</span>
+                </div>
+            </div>
+            <div class="one-rm-chart-container" style="height:200px;">
+                <canvas id="modal-1rm-chart" style="display:none"></canvas>
+                <p id="modal-1rm-no-data" class="text-muted one-rm-empty">No 1RM entries yet for this exercise.</p>
+            </div>
+        </div>
+
+        <div id="one-rep-max-history"{% if exercises_data_json %} data-exercises='{{ exercises_data_json | safe }}'{% endif %}></div>
     </div>
 </div>
+<style>
+#one-rep-max-history { display: none !important; }
+</style>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+<script>
+var __modal1rmData = {{ exercises_data_json | safe }};
+var __modal1rmChart = null;
+var __modal1rmMaxWeight = null;
+var __modal1rmCurrentPct = 100;
+
+function modalStepPct(delta) {
+    modalSetPct(Math.min(100, Math.max(0, __modal1rmCurrentPct + delta)));
+}
+
+function modalSetPct(pct) {
+    __modal1rmCurrentPct = pct;
+    modalUpdatePctDisplay();
+}
+
+function modalUpdatePctDisplay() {
+    document.getElementById('modal-pct-display').textContent = __modal1rmCurrentPct + '%';
+    document.getElementById('modal-pct-weight').textContent = __modal1rmMaxWeight !== null
+        ? (Math.round(__modal1rmMaxWeight * __modal1rmCurrentPct / 100 * 2) / 2).toFixed(1) + ' kg'
+        : '—';
+}
+
+function modalUpdate1rmChart() {
+    var select = document.getElementById('1rm-exercise');
+    var canvas = document.getElementById('modal-1rm-chart');
+    if (!select || !canvas) return;
+    var exercise = select.value;
+
+    if (!exercise || !__modal1rmData[exercise] || !__modal1rmData[exercise].length) {
+        canvas.style.display = 'none';
+        document.getElementById('modal-1rm-no-data').style.display = 'block';
+        document.getElementById('modal-pct-section').style.display = 'none';
+        if (__modal1rmChart) { __modal1rmChart.destroy(); __modal1rmChart = null; }
+        return;
+    }
+
+    canvas.style.display = 'block';
+    document.getElementById('modal-1rm-no-data').style.display = 'none';
+
+    var points = __modal1rmData[exercise];
+    var labels = points.map(function(p) { return p.label; });
+    var weights = points.map(function(p) { return p.weight; });
+
+    __modal1rmMaxWeight = Math.max.apply(null, points.map(function(p) { return p.weight; }));
+    document.getElementById('modal-pct-section').style.display = 'block';
+    modalSetPct(100);
+
+    if (__modal1rmChart) __modal1rmChart.destroy();
+    __modal1rmChart = new Chart(canvas, {
+        type: 'line',
+        data: {
+            labels: labels,
+            datasets: [{
+                label: exercise + ' (kg)',
+                data: weights,
+                borderColor: '#7c3aed',
+                backgroundColor: 'rgba(124,58,237,0.08)',
+                tension: 0.2,
+                fill: true,
+                pointRadius: 5,
+                pointHoverRadius: 7,
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: { legend: { display: false } },
+            scales: {
+                y: {
+                    title: { display: true, text: 'Weight (kg)' },
+                    ticks: { precision: 1 }
+                }
+            }
+        }
+    });
+}
+
+document.addEventListener('htmx:afterSwap', function(e) {
+    if (e.detail.target && e.detail.target.id === 'one-rep-max-history') {
+        var raw = document.getElementById('one-rep-max-history').dataset.exercises;
+        if (!raw) return;
+        __modal1rmData = JSON.parse(raw);
+        modalUpdate1rmChart();
+    }
+});
+
+modalUpdate1rmChart();
+</script>


### PR DESCRIPTION
- Show Chart.js line chart with progress graph instead of raw entries list
- Add -/+ percentage scaling buttons to calculate working weights from max
- Compact single-row form layout (exercise | weight | save)
- Remove suggested exercises hint text to save space
- Show 'no data' message when exercise has no entries
