### PR TITLE
feat: 💪 PR celebration — muscle emoji explosion

### DIFF
--- a/src/wodplanner/app/routers/views.py
+++ b/src/wodplanner/app/routers/views.py
@@ -975,6 +975,10 @@ def add_one_rep_max_view(
         entry_date = parse_iso_date(recorded_at)
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid date format.")
+
+    prev_max = one_rep_max_service.get_max_for_exercise(session.user_id, exercise)
+    is_pr = prev_max is not None and weight_kg > prev_max
+
     one_rep_max_service.add(
         user_id=session.user_id,
         exercise=exercise,
@@ -984,7 +988,7 @@ def add_one_rep_max_view(
 
     raw = one_rep_max_service.get_all(session.user_id)
     entries = _format_1rm_entries(raw)
-    return render(
+    resp = render(
         request,
         "partials/one_rep_max_history.html",
         {
@@ -992,6 +996,9 @@ def add_one_rep_max_view(
             "exercises_data_json": _build_exercises_chart_data(entries),
         },
     )
+    if is_pr:
+        resp.headers["HX-Trigger"] = "pr-celebration"
+    return resp
 
 
 @router.delete("/one-rep-maxes/{entry_id}/delete", response_class=HTMLResponse)

--- a/src/wodplanner/app/static/css/style.css
+++ b/src/wodplanner/app/static/css/style.css
@@ -1989,3 +1989,95 @@ body {
         color: #6ee7b7;
     }
 }
+
+/* PR Celebration Animation */
+.pr-celebration-container {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 99999;
+    overflow: hidden;
+}
+
+.pr-celebration-icon {
+    position: fixed;
+    left: 50%;
+    top: 50%;
+    font-size: 2rem;
+    transform: translate(-50%, -50%);
+    opacity: 0;
+    animation: pr-burst 3.5s cubic-bezier(.17,.67,.3,1) forwards;
+}
+
+.pr-celebration-confetti {
+    position: fixed;
+    left: 50%;
+    top: 50%;
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    transform: translate(-50%, -50%);
+    opacity: 0;
+    animation: pr-burst 3.5s cubic-bezier(.17,.67,.3,1) forwards;
+}
+
+.pr-celebration-banner {
+    position: fixed;
+    top: 30%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: linear-gradient(135deg, #7c3aed, #a855f7, #ec4899);
+    color: #fff;
+    padding: 1.25rem 3rem;
+    border-radius: 1rem;
+    font-size: 2rem;
+    font-weight: 700;
+    box-shadow: 0 8px 32px rgba(124, 58, 237, 0.4);
+    z-index: 100000;
+    opacity: 0;
+    animation: pr-banner-in 0.4s ease-out 0.15s forwards, pr-banner-out 0.5s ease-in 3.5s forwards;
+    pointer-events: none;
+}
+
+@keyframes pr-burst {
+    0% {
+        opacity: 1;
+        transform: translate(-50%, -50%) scale(0);
+    }
+    15% {
+        opacity: 1;
+        transform: translate(-50%, -50%) scale(1.3);
+    }
+    30% {
+        transform: translate(calc(-50% + var(--dx) * 0.5), calc(-50% + var(--dy) * 0.5)) scale(1) rotate(180deg);
+    }
+    100% {
+        opacity: 0;
+        transform: translate(calc(-50% + var(--dx)), calc(-50% + var(--dy))) scale(0.4) rotate(360deg);
+    }
+}
+
+@keyframes pr-banner-in {
+    0% {
+        opacity: 0;
+        transform: translate(-50%, -50%) scale(0.3);
+    }
+    50% {
+        transform: translate(-50%, -50%) scale(1.15);
+    }
+    100% {
+        opacity: 1;
+        transform: translate(-50%, -50%) scale(1);
+    }
+}
+
+@keyframes pr-banner-out {
+    0% {
+        opacity: 1;
+        transform: translate(-50%, -50%) scale(1);
+    }
+    100% {
+        opacity: 0;
+        transform: translate(-50%, -50%) scale(1.3);
+    }
+}

--- a/src/wodplanner/app/templates/base.html
+++ b/src/wodplanner/app/templates/base.html
@@ -310,6 +310,48 @@
             }
         });
 
+        // PR Celebration
+        document.addEventListener('pr-celebration', function() {
+            var container = document.createElement('div');
+            container.className = 'pr-celebration-container';
+            var icons = ['💪', '💪', '💪', '🏋️', '🏋️', '🏆', '💪', '💪', '💪', '🔥'];
+            for (var i = 0; i < 50; i++) {
+                var el = document.createElement('div');
+                el.className = 'pr-celebration-icon';
+                el.textContent = icons[i % icons.length];
+                var angle = Math.random() * 2 * Math.PI;
+                var dist = 150 + Math.random() * 400;
+                el.style.setProperty('--dx', Math.cos(angle) * dist + 'px');
+                el.style.setProperty('--dy', Math.sin(angle) * dist + 'px');
+                el.style.fontSize = (1.2 + Math.random() * 2.2) + 'rem';
+                el.style.animationDelay = (Math.random() * 0.6) + 's';
+                el.style.animationDuration = (2.5 + Math.random() * 1.5) + 's';
+                container.appendChild(el);
+            }
+            var confettiColors = ['#7c3aed', '#a855f7', '#ec4899', '#f59e0b', '#10b981', '#3b82f6', '#ef4444', '#14b8a6'];
+            for (var i = 0; i < 120; i++) {
+                var el = document.createElement('div');
+                el.className = 'pr-celebration-confetti';
+                var angle = Math.random() * 2 * Math.PI;
+                var dist = 200 + Math.random() * 500;
+                el.style.setProperty('--dx', Math.cos(angle) * dist + 'px');
+                el.style.setProperty('--dy', Math.sin(angle) * dist + 'px');
+                el.style.width = (4 + Math.random() * 10) + 'px';
+                el.style.height = (4 + Math.random() * 10) + 'px';
+                el.style.background = confettiColors[i % confettiColors.length];
+                el.style.borderRadius = Math.random() > 0.5 ? '50%' : '2px';
+                el.style.animationDelay = (Math.random() * 0.5) + 's';
+                el.style.animationDuration = (2.5 + Math.random() * 1.5) + 's';
+                container.appendChild(el);
+            }
+            var banner = document.createElement('div');
+            banner.className = 'pr-celebration-banner';
+            banner.textContent = '🔥 New PR! 🔥';
+            container.appendChild(banner);
+            document.body.appendChild(container);
+            setTimeout(function() { container.remove(); }, 5000);
+        });
+
         // Close calendar when clicking outside
         document.addEventListener('click', function(e) {
             var dropdown = document.getElementById('calendar-dropdown');


### PR DESCRIPTION
When you log a new 1RM that beats your previous best, the backend detects the PR and fires an `HX-Trigger: pr-celebration` header. The frontend responds with:

- **50 💪🏋️🏆🔥 icons** exploding from center in all directions
- **120 colored confetti particles** bursting alongside them
- **🔥 New PR! 🔥 banner** with a purple-pink gradient

Everything auto-clears after 5s. No new dependencies.