### PR TITLE
fix: 📱 responsive banner + bouncing emoji celebration

### DIFF
--- a/src/wodplanner/app/static/css/style.css
+++ b/src/wodplanner/app/static/css/style.css
@@ -2006,7 +2006,7 @@ body {
     font-size: 2rem;
     transform: translate(-50%, -50%);
     opacity: 0;
-    animation: pr-burst 3.5s cubic-bezier(.17,.67,.3,1) forwards;
+    animation: pr-burst-icon 5s ease-in-out forwards;
 }
 
 .pr-celebration-confetti {
@@ -2018,7 +2018,7 @@ body {
     border-radius: 2px;
     transform: translate(-50%, -50%);
     opacity: 0;
-    animation: pr-burst 3.5s cubic-bezier(.17,.67,.3,1) forwards;
+    animation: pr-burst-confetti 5s ease-in-out forwards;
 }
 
 .pr-celebration-banner {
@@ -2028,32 +2028,76 @@ body {
     transform: translate(-50%, -50%);
     background: linear-gradient(135deg, #7c3aed, #a855f7, #ec4899);
     color: #fff;
-    padding: 1.25rem 3rem;
+    padding: 1rem 2rem;
     border-radius: 1rem;
-    font-size: 2rem;
+    font-size: clamp(1.25rem, 6vw, 2rem);
     font-weight: 700;
+    white-space: nowrap;
     box-shadow: 0 8px 32px rgba(124, 58, 237, 0.4);
     z-index: 100000;
     opacity: 0;
-    animation: pr-banner-in 0.4s ease-out 0.15s forwards, pr-banner-out 0.5s ease-in 3.5s forwards;
+    animation: pr-banner-in 0.4s ease-out 0.15s forwards, pr-banner-out 0.5s ease-in 4.5s forwards;
     pointer-events: none;
 }
 
-@keyframes pr-burst {
+@keyframes pr-burst-icon {
     0% {
         opacity: 1;
         transform: translate(-50%, -50%) scale(0);
     }
-    15% {
+    10% {
         opacity: 1;
         transform: translate(-50%, -50%) scale(1.3);
     }
-    30% {
-        transform: translate(calc(-50% + var(--dx) * 0.5), calc(-50% + var(--dy) * 0.5)) scale(1) rotate(180deg);
+    25% {
+        transform: translate(calc(-50% + var(--dx)), calc(-50% + var(--dy))) scale(1) rotate(180deg);
+    }
+    33% {
+        transform: translate(calc(-50% + var(--dx) * 0.7), calc(-50% + var(--dy) * 0.7)) scale(1.05) rotate(220deg);
+    }
+    41% {
+        transform: translate(calc(-50% + var(--dx) * 0.92), calc(-50% + var(--dy) * 0.92)) scale(0.95) rotate(300deg);
+    }
+    47% {
+        transform: translate(calc(-50% + var(--dx) * 0.82), calc(-50% + var(--dy) * 0.82)) scale(1.02) rotate(330deg);
+    }
+    52% {
+        transform: translate(calc(-50% + var(--dx) * 0.97), calc(-50% + var(--dy) * 0.97)) scale(0.98) rotate(350deg);
+    }
+    55% {
+        transform: translate(calc(-50% + var(--dx)), calc(-50% + var(--dy))) scale(1) rotate(360deg);
     }
     100% {
         opacity: 0;
-        transform: translate(calc(-50% + var(--dx)), calc(-50% + var(--dy))) scale(0.4) rotate(360deg);
+        transform: translate(calc(-50% + var(--dx)), calc(-50% + var(--dy))) scale(0.6) rotate(360deg);
+    }
+}
+
+@keyframes pr-burst-confetti {
+    0% {
+        opacity: 1;
+        transform: translate(-50%, -50%) scale(0);
+    }
+    20% {
+        transform: translate(calc(-50% + var(--dx)), calc(-50% + var(--dy))) rotate(180deg);
+    }
+    30% {
+        transform: translate(calc(-50% + var(--dx) * 0.6), calc(-50% + var(--dy) * 0.6)) rotate(270deg);
+    }
+    40% {
+        transform: translate(calc(-50% + var(--dx) * 0.85), calc(-50% + var(--dy) * 0.85)) rotate(400deg);
+    }
+    48% {
+        transform: translate(calc(-50% + var(--dx) * 0.75), calc(-50% + var(--dy) * 0.75)) rotate(450deg);
+    }
+    55% {
+        transform: translate(calc(-50% + var(--dx) * 0.95), calc(-50% + var(--dy) * 0.95)) rotate(500deg);
+    }
+    60% {
+        transform: translate(calc(-50% + var(--dx)), calc(-50% + var(--dy))) rotate(540deg);
+    }
+    100% {
+        opacity: 0;
     }
 }
 

--- a/src/wodplanner/app/templates/base.html
+++ b/src/wodplanner/app/templates/base.html
@@ -325,7 +325,7 @@
                 el.style.setProperty('--dy', Math.sin(angle) * dist + 'px');
                 el.style.fontSize = (1.2 + Math.random() * 2.2) + 'rem';
                 el.style.animationDelay = (Math.random() * 0.6) + 's';
-                el.style.animationDuration = (2.5 + Math.random() * 1.5) + 's';
+                el.style.animationDuration = (4 + Math.random() * 2) + 's';
                 container.appendChild(el);
             }
             var confettiColors = ['#7c3aed', '#a855f7', '#ec4899', '#f59e0b', '#10b981', '#3b82f6', '#ef4444', '#14b8a6'];
@@ -341,7 +341,7 @@
                 el.style.background = confettiColors[i % confettiColors.length];
                 el.style.borderRadius = Math.random() > 0.5 ? '50%' : '2px';
                 el.style.animationDelay = (Math.random() * 0.5) + 's';
-                el.style.animationDuration = (2.5 + Math.random() * 1.5) + 's';
+                el.style.animationDuration = (4 + Math.random() * 2) + 's';
                 container.appendChild(el);
             }
             var banner = document.createElement('div');
@@ -349,7 +349,7 @@
             banner.textContent = '🔥 New PR! 🔥';
             container.appendChild(banner);
             document.body.appendChild(container);
-            setTimeout(function() { container.remove(); }, 5000);
+            setTimeout(function() { container.remove(); }, 6500);
         });
 
         // Close calendar when clicking outside


### PR DESCRIPTION
Follow-up to #178:\n\n- **Banner** now uses  so '🔥 New PR! 🔥' fits on any screen\n- **Icons** bounce 3x on landing (70% → 92% → 82% → 97% → settle) before fading — animation extended to 5s\n- **Confetti** has its own bounce pattern with wider wobbles