### PR TITLE
fix: 📱 make 1RM modal wider with more height on mobile

### DIFF
--- a/src/wodplanner/app/static/css/style.css
+++ b/src/wodplanner/app/static/css/style.css
@@ -1165,6 +1165,15 @@ body {
     overflow-y: auto;
 }
 
+.modal-content--wide {
+    max-width: 900px;
+    width: 95%;
+}
+
+.modal-content--wide .modal-body {
+    max-height: 600px;
+}
+
 /* People list */
 .people-list {
     list-style: none;
@@ -1405,6 +1414,10 @@ body {
         width: calc(100vw - 2rem);
         max-height: 80vh;
         overflow-y: auto;
+    }
+
+    .modal-content--wide .modal-body {
+        max-height: unset;
     }
 
     .btn-sm {

--- a/src/wodplanner/app/templates/partials/one_rep_max_modal.html
+++ b/src/wodplanner/app/templates/partials/one_rep_max_modal.html
@@ -1,4 +1,4 @@
-<div class="modal-content">
+<div class="modal-content modal-content--wide">
     <div class="modal-header">
         <h3 class="modal-title">1 Rep Max</h3>
         <button class="modal-close" onclick="close1rmModal()" aria-label="Close">&times;</button>


### PR DESCRIPTION
Makes the 1RM modal wider (900px vs 600px) and allows the modal-body to grow taller on mobile by removing its max-height constraint when inside a wide modal.