### PR TITLE
fix: reduce PR celebration banner duration from 6.5s to 3s

### DIFF
--- a/src/wodplanner/app/templates/base.html
+++ b/src/wodplanner/app/templates/base.html
@@ -349,7 +349,7 @@
             banner.textContent = '🔥 New PR! 🔥';
             container.appendChild(banner);
             document.body.appendChild(container);
-            setTimeout(function() { container.remove(); }, 6500);
+            setTimeout(function() { container.remove(); }, 3000);
         });
 
         // Close calendar when clicking outside


### PR DESCRIPTION
Reduces the 'New PR' celebration banner timeout from 6.5s to 3s as requested.