### PR TITLE
fix: banner text fades out at 3s while icons finish animation

### DIFF
--- a/src/wodplanner/app/static/css/style.css
+++ b/src/wodplanner/app/static/css/style.css
@@ -2049,7 +2049,7 @@ body {
     box-shadow: 0 8px 32px rgba(124, 58, 237, 0.4);
     z-index: 100000;
     opacity: 0;
-    animation: pr-banner-in 0.4s ease-out 0.15s forwards, pr-banner-out 0.5s ease-in 4.5s forwards;
+    animation: pr-banner-in 0.4s ease-out 0.15s forwards, pr-banner-out 0.5s ease-in 3s forwards;
     pointer-events: none;
 }
 

--- a/src/wodplanner/app/templates/base.html
+++ b/src/wodplanner/app/templates/base.html
@@ -349,7 +349,7 @@
             banner.textContent = '🔥 New PR! 🔥';
             container.appendChild(banner);
             document.body.appendChild(container);
-            setTimeout(function() { container.remove(); }, 3000);
+            setTimeout(function() { container.remove(); }, 7000);
         });
 
         // Close calendar when clicking outside


### PR DESCRIPTION
The banner text now fades out starting at 3s (CSS animation), while icons/confetti continue their full animation. Container cleanup moved to 7s.