### PR TITLE
feat: redesign header with two-row layout, icons, and user dropdown

### DIFF
--- a/src/wodplanner/app/static/css/style.css
+++ b/src/wodplanner/app/static/css/style.css
@@ -40,10 +40,13 @@ body {
 .navbar {
     background: var(--gray-900);
     color: white;
-    padding: 0.15rem 1rem;
+}
+
+.nav-top-row {
     display: flex;
     align-items: center;
-    gap: 2rem;
+    padding: 0.5rem 1rem;
+    gap: 1rem;
 }
 
 .nav-brand a {
@@ -53,32 +56,146 @@ body {
     font-weight: 700;
 }
 
-.nav-links {
+.nav-user {
+    margin-left: auto;
     display: flex;
-    gap: 1rem;
+    align-items: center;
+    gap: 0.25rem;
 }
 
-.nav-links a {
+.nav-icon-link {
+    display: flex;
+    align-items: center;
     color: var(--gray-300);
     text-decoration: none;
-    padding: 0.5rem 1rem;
+    padding: 0.25rem;
     border-radius: 0.375rem;
-    transition: background-color 0.2s;
+    transition: background-color 0.15s, color 0.15s;
 }
 
-.nav-links a:hover {
+.nav-icon-link:hover {
     background: var(--gray-700);
     color: white;
 }
 
-.nav-links a.active {
-    background: var(--primary);
+/* User dropdown */
+.user-dropdown {
+    position: relative;
+}
+
+.user-dropdown-toggle {
+    background: none;
+    border: none;
+    color: var(--gray-300);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.375rem;
+    font-size: 0.9375rem;
+    transition: background-color 0.15s, color 0.15s;
+    font-family: inherit;
+}
+
+.user-dropdown-toggle:hover {
+    background: var(--gray-700);
     color: white;
 }
 
-.nav-user {
-    margin-left: auto;
+.user-dropdown-menu {
+    display: none;
+    position: absolute;
+    right: 0;
+    top: 100%;
+    margin-top: 0.25rem;
+    background: white;
+    border: 1px solid var(--gray-200);
+    border-radius: 0.5rem;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+    min-width: 160px;
+    z-index: 100;
+    overflow: hidden;
+}
+
+.user-dropdown-menu.open {
+    display: block;
+}
+
+.dropdown-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    color: var(--gray-700);
+    text-decoration: none;
+    font-size: 0.875rem;
+    transition: background-color 0.15s;
+    border: none;
+    background: none;
+    width: 100%;
+    cursor: pointer;
+    font-family: inherit;
+}
+
+.dropdown-item:hover {
+    background: var(--gray-100);
+}
+
+.dropdown-item--danger {
+    color: var(--danger);
+}
+
+.dropdown-item-form {
+    margin: 0;
+}
+
+.dropdown-divider {
+    height: 1px;
+    background: var(--gray-200);
+    margin: 0.25rem 0;
+}
+
+/* Nav tabs */
+.nav-tabs {
+    display: flex;
+    justify-content: center;
+    gap: 0;
+    padding: 0 1rem;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+}
+
+.nav-tabs::-webkit-scrollbar {
+    display: none;
+}
+
+.tab {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
     color: var(--gray-300);
+    text-decoration: none;
+    padding: 0.5rem 1rem;
+    font-size: 0.875rem;
+    border-bottom: 2px solid transparent;
+    transition: color 0.15s, border-color 0.15s;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.tab:hover {
+    color: white;
+}
+
+.tab.active {
+    color: white;
+    border-bottom-color: var(--primary);
+}
+
+.tab svg {
+    flex-shrink: 0;
 }
 
 /* Container */
@@ -1330,32 +1447,26 @@ body {
         margin: 0;
     }
 
-    .navbar {
-        flex-wrap: wrap;
-        padding: 0.15rem 1rem;
-        gap: 0;
+    .nav-top-row {
+        padding: 0.35rem 0.75rem;
     }
 
-    .nav-brand {
-        flex: 1 0 auto;
+    .nav-tabs {
+        justify-content: center;
+        padding: 0.25rem 0.5rem;
     }
 
-    .nav-links {
-        order: 3;
-        width: 100%;
-        padding: 0.5rem 0;
-        border-top: 1px solid var(--gray-700);
-        gap: 0.25rem;
+    .tab {
+        padding: 0.35rem 0.5rem;
+        font-size: 0.8125rem;
     }
 
-    .nav-links a {
-        padding: 0.5rem 0.75rem;
-        font-size: 0.875rem;
+    .tab svg {
+        width: 14px;
+        height: 14px;
     }
 
     .nav-user {
-        margin-left: auto;
-        gap: 0.5rem;
         font-size: 0.875rem;
     }
 
@@ -2007,20 +2118,6 @@ body {
     color: #065f46;
     font-size: 0.9rem;
     margin-top: 1rem;
-}
-
-.settings-icon {
-    display: inline-flex;
-    align-items: center;
-    vertical-align: middle;
-    margin-left: 0.5rem;
-    color: var(--gray-500);
-    text-decoration: none;
-    transition: color 0.15s;
-}
-
-.settings-icon:hover {
-    color: var(--text-primary);
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/wodplanner/app/templates/base.html
+++ b/src/wodplanner/app/templates/base.html
@@ -16,29 +16,57 @@
 </head>
 <body>
     <nav class="navbar">
-        <div class="nav-brand">
-            <a href="/">WodPlanner</a>
-        </div>
-        <div class="nav-links">
-            <a href="/" class="{% if active_page == 'home' %}active{% endif %}">Home</a>
-            <a href="/calendar" class="{% if active_page == 'calendar' %}active{% endif %}">Calendar</a>
-            <a href="/friends" class="{% if active_page == 'friends' %}active{% endif %}">Friends</a>
-            <a href="/1rm" class="{% if active_page == '1rm' %}active{% endif %}">1RM</a>
-            <a href="/benchmark" class="{% if active_page == 'benchmark' %}active{% endif %}">Benchmark</a>
-        </div>
-        <div class="nav-user">
+        <div class="nav-top-row">
+            <div class="nav-brand">
+                <a href="/">WodPlanner</a>
+            </div>
             {% if user %}
-            <span>{{ user.firstname }}</span>
-            <a href="/settings" class="settings-icon" title="Settings" aria-label="Settings">
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <circle cx="12" cy="12" r="3"></circle>
-                    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
-                </svg>
-            </a>
-            <form action="/api/auth/logout" method="post" style="display: inline; margin-left: 0.75rem;" onsubmit="return confirm('Are you sure you want to log out?');">
-                <button type="submit" class="btn btn-sm btn-secondary">Logout</button>
-            </form>
+            <div class="nav-user">
+                <a href="/friends" class="nav-icon-link" title="Friends" aria-label="Friends">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>
+                </a>
+                <div class="user-dropdown">
+                    <button class="user-dropdown-toggle" onclick="toggleUserDropdown(event)">
+                        {{ user.firstname }}
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+                    </button>
+                    <div class="user-dropdown-menu" id="user-dropdown-menu">
+                        <a href="/settings" class="dropdown-item">
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <circle cx="12" cy="12" r="3"></circle>
+                                <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+                            </svg>
+                            Settings
+                        </a>
+                        <div class="dropdown-divider"></div>
+                        <form action="/api/auth/logout" method="post" class="dropdown-item-form">
+                            <button type="submit" class="dropdown-item dropdown-item--danger">
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+                                Logout
+                            </button>
+                        </form>
+                    </div>
+                </div>
+            </div>
             {% endif %}
+        </div>
+<div class="nav-tabs">
+            <a href="/" class="tab {% if active_page == 'home' %}active{% endif %}">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12l9-9 9 9"/><path d="M5 10v9a1 1 0 001 1h3v-5h6v5h3a1 1 0 001-1v-9"/></svg>
+                Home
+            </a>
+            <a href="/calendar" class="tab {% if active_page == 'calendar' %}active{% endif %}">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+                Calendar
+            </a>
+            <a href="/1rm" class="tab {% if active_page == '1rm' %}active{% endif %}">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12l-4 14H10L6 5z"/><path d="M4 5h16"/></svg>
+                1RM
+            </a>
+            <a href="/benchmark" class="tab {% if active_page == 'benchmark' %}active{% endif %}">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/></svg>
+                Benchmark
+            </a>
         </div>
     </nav>
 
@@ -273,6 +301,18 @@
             document.getElementById('calendar-dropdown').classList.remove('active');
             htmx.ajax('GET', '/calendar/' + dateStr, {target: '#calendar-content', swap: 'innerHTML'});
         }
+
+        // User dropdown
+        function toggleUserDropdown(e) {
+            e.stopPropagation();
+            document.getElementById('user-dropdown-menu').classList.toggle('open');
+        }
+        document.addEventListener('click', function(e) {
+            var menu = document.getElementById('user-dropdown-menu');
+            if (menu && menu.classList.contains('open') && !e.target.closest('.user-dropdown')) {
+                menu.classList.remove('open');
+            }
+        });
 
         // Toast + form helpers
         function showToast(msg) {


### PR DESCRIPTION
Redesigned the navigation header:

- Two-row layout: brand + user dropdown on top, tab bar below
- Clean tab-style nav links with inline SVG icons
- User dropdown replaces inline logout form + gear icon
- Friends icon in the top row linking to /friends
- Responsive — tabs scroll on mobile, icons scale down
- Removed old .settings-icon CSS