### PR TITLE
feat: redesign friends page with card layout, avatars, and lightbox

### DIFF
--- a/src/wodplanner/app/routers/views.py
+++ b/src/wodplanner/app/routers/views.py
@@ -3,12 +3,14 @@
 import hashlib
 import json
 import logging
+import shutil
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Annotated
 
 import markdown
-from fastapi import APIRouter, Depends, Form, HTTPException, Request
+from fastapi import APIRouter, Depends, Form, HTTPException, Request, UploadFile
+from fastapi import File as FastAPIFile
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 
@@ -73,6 +75,32 @@ def _format_benchmark_entries(entries):
         }
         for e in entries
     ]
+
+
+def _relative_time(dt: datetime) -> str:
+    now = dt.tzinfo and datetime.now(dt.tzinfo) or datetime.now()
+    diff = now - dt
+    if diff.days < 0:
+        return "just now"
+    if diff.days == 0:
+        hours = diff.seconds // 3600
+        if hours == 0:
+            minutes = diff.seconds // 60
+            return "just now" if minutes < 1 else f"{minutes}m ago"
+        return f"{hours}h ago"
+    if diff.days == 1:
+        return "yesterday"
+    if diff.days < 30:
+        return f"{diff.days}d ago"
+    if diff.days < 365:
+        months = diff.days // 30
+        return f"{months}mo ago"
+    years = diff.days // 365
+    return f"{years}y ago"
+
+
+_UPLOAD_DIR = Path(__file__).parent.parent / "static" / "uploads" / "avatars"
+_ALLOWED_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
 
 
 def _similarity_score(exercise: str, suggested: list[str]) -> int:
@@ -603,15 +631,22 @@ def friends_page(
     request: Request,
     session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
     friends_service: FriendsService = Depends(get_friends_service),
+    prefs_service: PreferencesService = Depends(get_preferences_service),
 ):
     """Friends management page."""
     friends = friends_service.get_all(session.user_id)
+    friend_user_ids = [f.appuser_id for f in friends]
+    avatar_map = prefs_service.get_avatar_filenames(friend_user_ids)
+    my_avatar = prefs_service.get_avatar_filename(session.user_id)
+
     friends_data = [
         {
             "id": f.id,
             "appuser_id": f.appuser_id,
             "name": f.name,
             "added_at": f.added_at.isoformat() if f.added_at else "",
+            "added_ago": _relative_time(f.added_at) if f.added_at else "",
+            "avatar": avatar_map.get(f.appuser_id),
         }
         for f in friends
     ]
@@ -622,6 +657,8 @@ def friends_page(
         {
             "active_page": "friends",
             "friends": friends_data,
+            "friend_count": len(friends_data),
+            "my_avatar": my_avatar,
             **get_user_context(session),
         },
     )
@@ -634,16 +671,22 @@ def add_friend_view(
     name: str = Form(...),
     session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
     friends_service: FriendsService = Depends(get_friends_service),
+    prefs_service: PreferencesService = Depends(get_preferences_service),
 ):
     """Add a friend (htmx form submission)."""
     friends_service.add(session.user_id, appuser_id, name)
     friends = friends_service.get_all(session.user_id)
+    friend_user_ids = [f.appuser_id for f in friends]
+    avatar_map = prefs_service.get_avatar_filenames(friend_user_ids)
+
     friends_data = [
         {
             "id": f.id,
             "appuser_id": f.appuser_id,
             "name": f.name,
             "added_at": f.added_at.isoformat() if f.added_at else "",
+            "added_ago": _relative_time(f.added_at) if f.added_at else "",
+            "avatar": avatar_map.get(f.appuser_id),
         }
         for f in friends
     ]
@@ -657,21 +700,62 @@ def delete_friend_view(
     friend_id: int,
     session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
     friends_service: FriendsService = Depends(get_friends_service),
+    prefs_service: PreferencesService = Depends(get_preferences_service),
 ):
     """Delete a friend (htmx)."""
     friends_service.delete(session.user_id, friend_id)
     friends = friends_service.get_all(session.user_id)
+    friend_user_ids = [f.appuser_id for f in friends]
+    avatar_map = prefs_service.get_avatar_filenames(friend_user_ids)
+
     friends_data = [
         {
             "id": f.id,
             "appuser_id": f.appuser_id,
             "name": f.name,
             "added_at": f.added_at.isoformat() if f.added_at else "",
+            "added_ago": _relative_time(f.added_at) if f.added_at else "",
+            "avatar": avatar_map.get(f.appuser_id),
         }
         for f in friends
     ]
 
     return render(request, "partials/friends_list.html", {"friends": friends_data})
+
+
+@router.post("/avatar/upload", response_class=RedirectResponse)
+def upload_avatar(
+    request: Request,
+    avatar: UploadFile = FastAPIFile(...),
+    session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
+    prefs_service: PreferencesService = Depends(get_preferences_service),
+):
+    ext = Path(avatar.filename or "").suffix.lower()
+    if ext not in _ALLOWED_EXTENSIONS:
+        raise HTTPException(status_code=400, detail="Invalid file type")
+
+    filename = f"avatar_{session.user_id}{ext}"
+    _UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Remove old avatar if exists (any extension) — under both user_id and appuser_id
+    def _remove_old(user_id: int) -> None:
+        for old_ext in _ALLOWED_EXTENSIONS:
+            old_path = _UPLOAD_DIR / f"avatar_{user_id}{old_ext}"
+            if old_path.exists():
+                old_path.unlink()
+                return
+    _remove_old(session.user_id)
+    if session.appuser_id and session.appuser_id != session.user_id:
+        _remove_old(session.appuser_id)
+
+    filepath = _UPLOAD_DIR / filename
+    with filepath.open("wb") as f:
+        shutil.copyfileobj(avatar.file, f)
+
+    prefs_service.set_avatar_filename(session.user_id, filename)
+    if session.appuser_id and session.appuser_id != session.user_id:
+        prefs_service.set_avatar_filename(session.appuser_id, filename)
+    return RedirectResponse(url="/friends", status_code=303)
 
 
 @router.post("/appointments/{appointment_id}/subscribe", response_class=HTMLResponse)
@@ -847,12 +931,20 @@ def people_modal_view(
             prefs_service.set_my_appuser_id(session.user_id, current_appuser_id)
 
     participants = []
+    all_user_ids = [m.id_appuser for m in members]
+    avatar_map = prefs_service.get_avatar_filenames(all_user_ids)
+    # Current user's avatar is stored under session.user_id, not appuser_id
+    if current_appuser_id and current_appuser_id not in avatar_map:
+        my_avatar = prefs_service.get_avatar_filename(session.user_id)
+        if my_avatar:
+            avatar_map[current_appuser_id] = my_avatar
     for member in members:
         participants.append({
             "id": member.id_appuser,
             "name": member.name,
             "is_friend": member.id_appuser in friend_ids,
             "is_self": member.id_appuser == current_appuser_id,
+            "avatar": avatar_map.get(member.id_appuser),
         })
 
     # Sort: self first, then friends, then alphabetically
@@ -884,6 +976,7 @@ def add_friend_from_people(
     session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
     client: WodAppClient = Depends(get_client_from_session_for_view),
     friends_service: FriendsService = Depends(get_friends_service),
+    prefs_service: PreferencesService = Depends(get_preferences_service),
 ):
     """Add a friend from the people modal."""
     friends_service.add(session.user_id, appuser_id, name)
@@ -897,6 +990,7 @@ def add_friend_from_people(
         session=session,
         client=client,
         friends_service=friends_service,
+        prefs_service=prefs_service,
     )
 
 

--- a/src/wodplanner/app/static/css/style.css
+++ b/src/wodplanner/app/static/css/style.css
@@ -1995,6 +1995,33 @@ body {
         color: #cbd5e1;
     }
 
+    /* Friend avatar section (self upload) */
+    .friend-avatar-section {
+        background: #1e293b !important;
+    }
+
+    /* Friend cards */
+    .friend-card:hover {
+        background: #1e293b !important;
+    }
+
+    .friend-name {
+        color: #f1f5f9 !important;
+    }
+
+    .friend-meta {
+        color: #64748b !important;
+    }
+
+    .friend-remove:hover {
+        background: #450a0a !important;
+    }
+
+    /* Avatar lightbox */
+    .avatar-lightbox-overlay {
+        background: rgba(0, 0, 0, 0.8);
+    }
+
     /* Schedule modal */
     .schedule-section {
         border-color: #334155;
@@ -2260,5 +2287,276 @@ body {
     100% {
         opacity: 0;
         transform: translate(-50%, -50%) scale(1.3);
+    }
+}
+
+/* Friend cards */
+.friend-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.friend-card {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.625rem 0.75rem;
+    border-radius: 0.5rem;
+    transition: background 0.15s;
+}
+
+.friend-card:hover {
+    background: var(--gray-50);
+}
+
+.friend-avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.friend-avatar-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.friend-avatar-initials {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, var(--primary), #7c3aed);
+    color: white;
+    font-size: 0.875rem;
+    font-weight: 600;
+    border-radius: 50%;
+}
+
+.friend-info {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+}
+
+.friend-name {
+    font-weight: 600;
+    font-size: 0.9375rem;
+    color: var(--gray-900);
+}
+
+.friend-meta {
+    font-size: 0.8rem;
+    color: var(--gray-500);
+}
+
+.friend-remove {
+    background: none;
+    border: none;
+    color: var(--gray-400);
+    cursor: pointer;
+    padding: 0.375rem;
+    border-radius: 0.375rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: color 0.15s, background 0.15s;
+    flex-shrink: 0;
+}
+
+.friend-remove:hover {
+    color: var(--danger);
+    background: #fee2e2;
+}
+
+/* Avatar lightbox */
+.avatar-lightbox-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: 10000;
+    background: rgba(0, 0, 0, 0.6);
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+}
+
+.avatar-lightbox-overlay.active {
+    display: flex;
+}
+
+.avatar-lightbox-img {
+    max-width: 90vw;
+    max-height: 90vh;
+    border-radius: 0.75rem;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+    cursor: default;
+}
+
+/* Friend count badge */
+.friend-count-badge {
+    font-size: 0.875rem;
+    color: var(--gray-500);
+    font-weight: 500;
+    background: var(--gray-100);
+    padding: 0.25rem 0.75rem;
+    border-radius: 1rem;
+    white-space: nowrap;
+}
+
+/* Friend avatar section (self upload) */
+.friend-avatar-section {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1.25rem;
+    padding: 1rem 1.25rem;
+    background: white;
+    border-radius: 0.5rem;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+
+.friend-avatar-self {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    overflow: hidden;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.friend-avatar-self-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.friend-avatar-self-initials {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: linear-gradient(135deg, var(--primary), #7c3aed);
+        color: white;
+        font-size: 1.125rem;
+        font-weight: 600;
+        border-radius: 50%;
+    }
+
+    .friend-avatar-self-img,
+    .friend-avatar-img,
+    .person-avatar-img {
+        cursor: pointer;
+    }
+
+    .friend-avatar-upload {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.friend-avatar-label {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--gray-700);
+}
+
+.upload-btn {
+    position: relative;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+}
+
+.upload-input {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    cursor: pointer;
+}
+
+/* Empty state with icon */
+.empty-state-icon {
+    color: var(--gray-300);
+    margin-bottom: 0.75rem;
+    display: flex;
+    justify-content: center;
+}
+
+/* Person avatars in people modal */
+.person-left {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    min-width: 0;
+}
+
+.person-avatar {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    overflow: hidden;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.person-avatar-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.person-avatar-initials {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--gray-200);
+    color: var(--gray-600);
+    font-size: 0.65rem;
+    font-weight: 600;
+    border-radius: 50%;
+}
+
+.person-item.is-friend .person-avatar-initials {
+    background: #bfdbfe;
+    color: var(--primary);
+}
+
+.person-item.is-self .person-avatar-initials {
+    background: #bbf7d0;
+    color: var(--success);
+}
+
+@media (max-width: 640px) {
+    .friend-card {
+        padding: 0.5rem 0.5rem;
+    }
+    .friend-avatar {
+        width: 36px;
+        height: 36px;
+    }
+    .friend-avatar-section {
+        padding: 0.75rem 1rem;
+    }
+    .friend-avatar-self {
+        width: 40px;
+        height: 40px;
     }
 }

--- a/src/wodplanner/app/templates/base.html
+++ b/src/wodplanner/app/templates/base.html
@@ -477,5 +477,28 @@
     {% endif %}
 
     {% block scripts %}{% endblock %}
+
+    <div id="avatar-lightbox" class="avatar-lightbox-overlay" onclick="closeAvatarLightbox()">
+        <img id="avatar-lightbox-img" class="avatar-lightbox-img" src="" alt="Avatar" onclick="event.stopPropagation()">
+    </div>
+
+    <script>
+        document.addEventListener('click', function(e) {
+            var img = e.target.closest('.friend-avatar-img, .person-avatar-img, .friend-avatar-self-img');
+            if (img) {
+                openAvatarLightbox(img.src);
+            }
+        });
+        function openAvatarLightbox(src) {
+            document.getElementById('avatar-lightbox-img').src = src;
+            document.getElementById('avatar-lightbox').classList.add('active');
+        }
+        function closeAvatarLightbox() {
+            document.getElementById('avatar-lightbox').classList.remove('active');
+        }
+        document.addEventListener('keydown', function(e) {
+            if (e.key === 'Escape') closeAvatarLightbox();
+        });
+    </script>
 </body>
 </html>

--- a/src/wodplanner/app/templates/friends.html
+++ b/src/wodplanner/app/templates/friends.html
@@ -1,10 +1,33 @@
 {% extends "base.html" %}
-
 {% block title %}Friends - WodPlanner{% endblock %}
-
 {% block content %}
 <div class="page-header">
     <h1>Friends</h1>
+    {% if friend_count > 0 %}
+    <span class="friend-count-badge">{{ friend_count }} friend{% if friend_count != 1 %}s{% endif %}</span>
+    {% endif %}
+</div>
+
+<div class="friend-avatar-section">
+    <div class="friend-avatar-self">
+        {% if my_avatar %}
+        <img src="/static/uploads/avatars/{{ my_avatar }}" alt="Your avatar" class="friend-avatar-self-img">
+        {% else %}
+        <span class="friend-avatar-self-initials">{{ user.firstname[:2].upper() }}</span>
+        {% endif %}
+    </div>
+    <div class="friend-avatar-upload">
+        <span class="friend-avatar-label">Your photo</span>
+        <form action="/avatar/upload" method="post" enctype="multipart/form-data" id="avatar-form">
+            <label class="btn btn-sm btn-secondary upload-btn">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/>
+                </svg>
+                Upload
+                <input type="file" name="avatar" accept="image/jpeg,image/png,image/gif,image/webp" class="upload-input" onchange="document.getElementById('avatar-form').submit()">
+            </label>
+        </form>
+    </div>
 </div>
 
 <div id="friends-list">

--- a/src/wodplanner/app/templates/partials/friends_list.html
+++ b/src/wodplanner/app/templates/partials/friends_list.html
@@ -1,37 +1,41 @@
 <div class="card">
     {% if friends %}
-    <div class="table-scroll-wrapper">
-    <table class="table">
-        <thead>
-            <tr>
-                <th>Name</th>
-                <th>Added</th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for friend in friends %}
-            <tr>
-                <td><strong>{{ friend.name }}</strong></td>
-                <td class="text-muted">{{ friend.added_at[:10] if friend.added_at else '' }}</td>
-                <td>
-                    <button class="btn btn-danger btn-sm"
-                            hx-delete="/friends/{{ friend.id }}/delete"
-                            hx-target="#friends-list"
-                            hx-swap="innerHTML"
-                            hx-confirm="Remove {{ friend.name }} from friends?">
-                        Remove
-                    </button>
-                </td>
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
+    <div class="friend-list">
+        {% for friend in friends %}
+        <div class="friend-card">
+            <div class="friend-avatar">
+                {% if friend.avatar %}
+                <img src="/static/uploads/avatars/{{ friend.avatar }}" alt="" class="friend-avatar-img">
+                {% else %}
+                <span class="friend-avatar-initials">{{ friend.name[:2].upper() }}</span>
+                {% endif %}
+            </div>
+            <div class="friend-info">
+                <span class="friend-name">{{ friend.name }}</span>
+                <span class="friend-meta">Added {{ friend.added_ago }}</span>
+            </div>
+            <button class="friend-remove"
+                    hx-delete="/friends/{{ friend.id }}/delete"
+                    hx-target="#friends-list"
+                    hx-swap="innerHTML"
+                    hx-confirm="Remove {{ friend.name }} from friends?"
+                    title="Remove friend">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+                </svg>
+            </button>
+        </div>
+        {% endfor %}
     </div>
     {% else %}
     <div class="empty-state">
+        <div class="empty-state-icon">
+            <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/>
+            </svg>
+        </div>
         <h3>No friends yet</h3>
-        <p>Add friends to see which classes they're signed up for.</p>
+        <p>Add friends from the participants list of any class to see who's signed up.</p>
     </div>
     {% endif %}
 </div>

--- a/src/wodplanner/app/templates/partials/people_modal.html
+++ b/src/wodplanner/app/templates/partials/people_modal.html
@@ -10,11 +10,20 @@
         <ul class="people-list">
             {% for person in participants %}
             <li class="person-item {% if person.is_friend %}is-friend{% endif %}{% if person.is_self %} is-self{% endif %}">
-                <span class="person-name">{{ person.name }}{% if person.is_self %} (you){% endif %}</span>
+                <div class="person-left">
+                    <div class="person-avatar">
+                        {% if person.avatar %}
+                        <img src="/static/uploads/avatars/{{ person.avatar }}" alt="" class="person-avatar-img">
+                        {% else %}
+                        <span class="person-avatar-initials">{{ person.name[:2].upper() }}</span>
+                        {% endif %}
+                    </div>
+                    <span class="person-name">{{ person.name }}{% if person.is_self %} (you){% endif %}</span>
+                </div>
                 {% if person.is_self %}
                     {# No button for self #}
                 {% elif person.is_friend %}
-                <span class="friend-badge">Friend</span>
+                <span class="badge badge-info">Friend</span>
                 {% else %}
                 <button class="btn btn-sm btn-secondary add-friend-btn"
                         hx-post="/friends/add-from-people"

--- a/src/wodplanner/services/preferences.py
+++ b/src/wodplanner/services/preferences.py
@@ -138,3 +138,21 @@ class PreferencesService(BaseService):
 
     def get_all(self, user_id: int) -> UserPreferences:
         return self.get_for_user(user_id)
+
+    def get_avatar_filename(self, user_id: int) -> str | None:
+        value = self._get(user_id, "avatar_filename", "")
+        return value if value else None
+
+    def set_avatar_filename(self, user_id: int, filename: str) -> None:
+        self._set(user_id, "avatar_filename", filename)
+
+    def get_avatar_filenames(self, user_ids: list[int]) -> dict[int, str]:
+        if not user_ids:
+            return {}
+        with self._get_connection() as conn:
+            placeholders = ",".join("?" * len(user_ids))
+            rows = conn.execute(
+                f"SELECT user_id, value FROM preferences WHERE user_id IN ({placeholders}) AND key = 'avatar_filename'",
+                user_ids,
+            ).fetchall()
+        return {row["user_id"]: row["value"] for row in rows}


### PR DESCRIPTION
- Replace table with card-based friend list including avatar/initials, name, and relative time
- Add avatar upload endpoint and storage (local files + preferences table)
- Show avatars in the people modal with color-coded initials
- Add avatar lightbox (click to zoom) for all avatar images
- Add friend count badge and stats row
- Fix dark mode styling for new components
- Store avatar under both user_id and appuser_id for cross-lookup
