### PR TITLE
feat: improve 1RM and benchmark tracking pages

### DIFF
--- a/src/wodplanner/app/routers/views.py
+++ b/src/wodplanner/app/routers/views.py
@@ -1164,6 +1164,70 @@ def delete_one_rep_max_view(
     )
 
 
+@router.get("/one-rep-maxes/{entry_id}/edit", response_class=HTMLResponse)
+def edit_one_rep_max_form_view(
+    request: Request,
+    entry_id: int,
+    session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
+    one_rep_max_service: OneRepMaxService = Depends(get_one_rep_max_service),
+):
+    """Get inline edit form for a 1rm entry."""
+    entry = one_rep_max_service.get_by_id(session.user_id, entry_id)
+    if not entry:
+        raise HTTPException(status_code=404, detail="Entry not found.")
+    exercises = one_rep_max_service.get_exercise_list()
+    return render(
+        request,
+        "partials/one_rep_max_edit_row.html",
+        {
+            "entry": _format_1rm_entries([entry])[0],
+            "exercises": exercises,
+            "entry_id": entry_id,
+        },
+    )
+
+
+@router.put("/one-rep-maxes/{entry_id}/edit", response_class=HTMLResponse)
+def update_one_rep_max_view(
+    request: Request,
+    entry_id: int,
+    exercise: str = Form(...),
+    weight_kg: float = Form(...),
+    recorded_at: str = Form(...),
+    session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
+    one_rep_max_service: OneRepMaxService = Depends(get_one_rep_max_service),
+):
+    """Update a 1rm entry (htmx)."""
+    exercise = exercise.strip()
+    if not one_rep_max_service.validate_exercise(exercise):
+        raise HTTPException(status_code=422, detail=f"Unknown exercise: '{exercise}'.")
+    if not (0 < weight_kg < 1000):
+        raise HTTPException(status_code=400, detail="Weight must be between 0 and 1000 kg.")
+    try:
+        entry_date = parse_iso_date(recorded_at)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid date format.")
+
+    prev_max = one_rep_max_service.get_max_for_exercise(session.user_id, exercise)
+    is_pr = prev_max is not None and weight_kg > prev_max
+
+    one_rep_max_service.update(session.user_id, entry_id, exercise, weight_kg, entry_date)
+
+    raw = one_rep_max_service.get_all(session.user_id)
+    entries = _format_1rm_entries(raw)
+    resp = render(
+        request,
+        "partials/one_rep_max_history.html",
+        {
+            "entries": entries,
+            "exercises_data_json": _build_exercises_chart_data(entries),
+        },
+    )
+    if is_pr:
+        resp.headers["HX-Trigger"] = "pr-celebration"
+    return resp
+
+
 @router.get("/appointments/{appointment_id}/benchmark", response_class=HTMLResponse)
 def benchmark_modal_view(
     request: Request,
@@ -1253,6 +1317,74 @@ def delete_benchmark_result_view(
 ):
     """Delete a benchmark result (htmx)."""
     benchmark_service.delete_result(session.user_id, result_id)
+
+    raw = benchmark_service.get_all_results(session.user_id)
+    entries = _format_benchmark_entries(raw)
+    return render(
+        request,
+        "partials/benchmark_history.html",
+        {
+            "entries": entries,
+            "benchmark_data_json": _build_benchmark_chart_data(entries),
+        },
+    )
+
+
+@router.get("/benchmark-results/{result_id}/edit", response_class=HTMLResponse)
+def edit_benchmark_result_form_view(
+    request: Request,
+    result_id: int,
+    session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
+    benchmark_service: BenchmarkService = Depends(get_benchmark_service),
+):
+    """Get inline edit form for a benchmark result."""
+    result = benchmark_service.get_result(session.user_id, result_id)
+    if not result:
+        raise HTTPException(status_code=404, detail="Result not found.")
+    benchmarks = benchmark_service.get_benchmark_list()
+    return render(
+        request,
+        "partials/benchmark_edit_row.html",
+        {
+            "result": {
+                "id": result.id,
+                "benchmark_name": result.benchmark_name,
+                "time_seconds": result.time_seconds,
+                "formatted_time": f"{result.time_seconds // 60}:{result.time_seconds % 60:02d}",
+                "is_rx": result.is_rx,
+                "recorded_at": result.recorded_at,
+            },
+            "benchmarks": benchmarks,
+            "result_id": result_id,
+        },
+    )
+
+
+@router.put("/benchmark-results/{result_id}/edit", response_class=HTMLResponse)
+def update_benchmark_result_view(
+    request: Request,
+    result_id: int,
+    benchmark_name: str = Form(...),
+    minutes: int = Form(...),
+    seconds: int = Form(...),
+    is_rx: str = Form("true"),
+    recorded_at: str = Form(...),
+    session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
+    benchmark_service: BenchmarkService = Depends(get_benchmark_service),
+):
+    """Update a benchmark result (htmx)."""
+    total_seconds = minutes * 60 + seconds
+    if total_seconds <= 0:
+        raise HTTPException(status_code=400, detail="Time must be greater than 0.")
+
+    benchmark_service.update_result(
+        user_id=session.user_id,
+        result_id=result_id,
+        benchmark_name=benchmark_name.strip(),
+        time_seconds=total_seconds,
+        is_rx=is_rx == "true",
+        recorded_at=recorded_at,
+    )
 
     raw = benchmark_service.get_all_results(session.user_id)
     entries = _format_benchmark_entries(raw)

--- a/src/wodplanner/app/static/css/style.css
+++ b/src/wodplanner/app/static/css/style.css
@@ -1141,6 +1141,115 @@ body {
     color: var(--danger);
 }
 
+.one-rm-actions {
+    display: flex;
+    gap: 0.25rem;
+    align-items: center;
+    justify-content: flex-end;
+}
+
+.btn-edit {
+    background: none;
+    border: none;
+    color: var(--gray-400);
+    cursor: pointer;
+    padding: 0.125rem 0.25rem;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+}
+
+.btn-edit:hover {
+    color: var(--primary);
+}
+
+.btn-cancel {
+    background: none;
+    border: 1px solid var(--gray-300);
+    color: var(--gray-500);
+    cursor: pointer;
+    line-height: 1;
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    font-size: 0.875rem;
+}
+
+.btn-cancel:hover {
+    background: var(--gray-100);
+}
+
+.one-rm-edit-row td {
+    padding: 0.5rem;
+    background: var(--gray-50);
+}
+
+.one-rm-form--inline .form-row {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.one-rm-form--inline .form-group {
+    margin-bottom: 0;
+    flex: 1;
+    min-width: 120px;
+}
+
+.one-rm-form--inline .form-group-narrow {
+    flex: 0 0 110px;
+    min-width: 90px;
+}
+
+.one-rm-form--inline .form-group-submit {
+    flex: 0 0 auto;
+}
+
+.benchmark-form--inline .form-row {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr) auto;
+    gap: 0.5rem;
+    align-items: end;
+}
+
+.benchmark-form--inline .form-group {
+    margin-bottom: 0;
+    min-width: 0;
+}
+
+.benchmark-form--inline .form-group-full {
+    grid-column: 1 / -1;
+}
+
+.benchmark-form--inline .form-group-submit {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.benchmark-form--inline .form-row + .form-row {
+    margin-top: 0.5rem;
+}
+
+.one-rm-edit-actions {
+    display: flex;
+    gap: 0.25rem;
+}
+
+@media (max-width: 640px) {
+    .benchmark-form--inline .form-row {
+        grid-template-columns: 1fr 1fr;
+    }
+    .benchmark-form--inline .form-group-submit {
+        grid-column: 1 / -1;
+    }
+}
+
+.form-control-sm {
+    font-size: 0.8125rem;
+    padding: 0.375rem 0.5rem;
+}
+
 .friend-count {
     position: absolute;
     top: -5px;
@@ -1941,6 +2050,10 @@ body {
 
     .one-rm-table td {
         border-color: #1e293b;
+    }
+
+    .one-rm-edit-row td {
+        background: #0f172a;
     }
 
     /* People list */

--- a/src/wodplanner/app/templates/benchmark.html
+++ b/src/wodplanner/app/templates/benchmark.html
@@ -20,12 +20,19 @@
             <div class="form-row">
                 <div class="form-group">
                     <label for="benchmark-name">Benchmark</label>
-                    <select id="benchmark-name" name="benchmark_name" required class="form-control">
-                        <option value="">— Select benchmark —</option>
+                    <input type="text"
+                           id="benchmark-name"
+                           name="benchmark_name"
+                           list="benchmark-list"
+                           placeholder="Search benchmark…"
+                           required
+                           class="form-control"
+                           autocomplete="off">
+                    <datalist id="benchmark-list">
                         {% for name in benchmark_list %}
-                        <option value="{{ name }}">{{ name }}</option>
+                        <option value="{{ name }}">
                         {% endfor %}
-                    </select>
+                    </datalist>
                 </div>
                 <div class="form-group form-group-narrow">
                     <label for="benchmark-minutes">Minutes</label>
@@ -103,7 +110,6 @@
     </div>
 </div>
 
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
 <script>
 var __benchmarkData = {{ benchmark_data_json | safe }};
 var __benchmarkChart = null;
@@ -138,8 +144,25 @@ function updateBenchmarkChart() {
     noData.style.display = 'none';
 
     var points = __benchmarkData[name];
-    var labels = points.map(function(p) { return p.label; });
-    var times = points.map(function(p) { return p.time; });
+    var sorted = points.slice().sort(function(a, b) { return a.date < b.date ? -1 : a.date > b.date ? 1 : 0; });
+    var labels = sorted.map(function(p) { return p.label; });
+    var times = sorted.map(function(p) { return p.time; });
+
+    var prColors = [], prRadii = [], prBorders = [];
+    var runningMin = Infinity;
+    for (var i = 0; i < sorted.length; i++) {
+        var t = sorted[i].time;
+        if (t < runningMin) {
+            runningMin = t;
+            prColors.push('#f59e0b');
+            prRadii.push(8);
+            prBorders.push('#d97706');
+        } else {
+            prColors.push('#7c3aed');
+            prRadii.push(4);
+            prBorders.push('#7c3aed');
+        }
+    }
 
     if (__benchmarkChart) __benchmarkChart.destroy();
     __benchmarkChart = new Chart(canvas, {
@@ -153,8 +176,11 @@ function updateBenchmarkChart() {
                 backgroundColor: 'rgba(124,58,237,0.08)',
                 tension: 0.2,
                 fill: true,
-                pointRadius: 5,
-                pointHoverRadius: 7,
+                pointBackgroundColor: prColors,
+                pointBorderColor: prBorders,
+                pointRadius: prRadii,
+                pointBorderWidth: 2,
+                pointHoverRadius: 10,
             }]
         },
         options: {

--- a/src/wodplanner/app/templates/one_rep_max.html
+++ b/src/wodplanner/app/templates/one_rep_max.html
@@ -20,11 +20,20 @@
             <div class="form-row">
                 <div class="form-group">
                     <label for="1rm-exercise">Exercise</label>
-                    <select id="1rm-exercise" name="exercise" required class="form-control">
+                    <input type="text"
+                           id="1rm-exercise"
+                           name="exercise"
+                           list="exercise-list"
+                           placeholder="Search exercise…"
+                           value="{{ default_exercise }}"
+                           required
+                           class="form-control"
+                           autocomplete="off">
+                    <datalist id="exercise-list">
                         {% for ex in exercises %}
-                        <option value="{{ ex }}" {% if ex == default_exercise %}selected{% endif %}>{{ ex }}</option>
+                        <option value="{{ ex }}">
                         {% endfor %}
-                    </select>
+                    </datalist>
                 </div>
                 <div class="form-group form-group-narrow">
                     <label for="1rm-weight">Weight (kg)</label>
@@ -91,7 +100,6 @@
     </div>
 </div>
 
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
 <script>
 var __1rmData = {{ exercises_data_json | safe }};
 var __1rmChart = null;
@@ -107,19 +115,8 @@ function toggle1rmLogForm() {
     document.getElementById('log-form-card').style.display = __1rmLogFormOpen ? 'block' : 'none';
 }
 
-function syncSliderFill(slider) {
-    var min = parseInt(slider.min, 10), max = parseInt(slider.max, 10);
-    var fill = (slider.value - min) / (max - min) * 100;
-    slider.style.setProperty('--fill', fill + '%');
-}
-
 function setPct(pct) {
     __1rmCurrentPct = pct;
-    var slider = document.getElementById('pct-slider');
-    if (slider) {
-        slider.value = pct;
-        syncSliderFill(slider);
-    }
     updatePctDisplay();
 }
 
@@ -149,10 +146,27 @@ function update1rmChart() {
     noData.style.display = 'none';
 
     var points = __1rmData[exercise];
-    var labels = points.map(function(p) { return p.label; });
-    var weights = points.map(function(p) { return p.weight; });
+    var sorted = points.slice().sort(function(a, b) { return a.date < b.date ? -1 : a.date > b.date ? 1 : 0; });
+    var labels = sorted.map(function(p) { return p.label; });
+    var weights = sorted.map(function(p) { return p.weight; });
 
-    __1rmMaxWeight = Math.max.apply(null, points.map(function(p) { return p.weight; }));
+    var prColors = [], prRadii = [], prBorders = [];
+    var runningMax = 0;
+    for (var i = 0; i < sorted.length; i++) {
+        var w = sorted[i].weight;
+        if (w > runningMax) {
+            runningMax = w;
+            prColors.push('#f59e0b');
+            prRadii.push(8);
+            prBorders.push('#d97706');
+        } else {
+            prColors.push('#7c3aed');
+            prRadii.push(4);
+            prBorders.push('#7c3aed');
+        }
+    }
+
+    __1rmMaxWeight = runningMax;
     document.getElementById('pct-section').style.display = 'block';
     setPct(100);
 
@@ -168,8 +182,11 @@ function update1rmChart() {
                 backgroundColor: 'rgba(124,58,237,0.08)',
                 tension: 0.2,
                 fill: true,
-                pointRadius: 5,
-                pointHoverRadius: 7,
+                pointBackgroundColor: prColors,
+                pointBorderColor: prBorders,
+                pointRadius: prRadii,
+                pointBorderWidth: 2,
+                pointHoverRadius: 10,
             }]
         },
         options: {

--- a/src/wodplanner/app/templates/partials/benchmark_edit_row.html
+++ b/src/wodplanner/app/templates/partials/benchmark_edit_row.html
@@ -1,0 +1,78 @@
+<tr id="edit-row-{{ result_id }}" class="one-rm-edit-row">
+    <td colspan="5">
+        <form hx-put="/benchmark-results/{{ result_id }}/edit"
+              hx-target="#benchmark-history"
+              hx-swap="outerHTML"
+              class="benchmark-form benchmark-form--inline">
+            <div class="form-row">
+                <div class="form-group form-group-full">
+                    <label for="benchmark-name-{{ result_id }}">Benchmark</label>
+                    <input type="text"
+                           id="benchmark-name-{{ result_id }}"
+                           name="benchmark_name"
+                           list="benchmark-list-{{ result_id }}"
+                           value="{{ result.benchmark_name }}"
+                           placeholder="Benchmark"
+                           required
+                           class="form-control form-control-sm"
+                           autocomplete="off">
+                    <datalist id="benchmark-list-{{ result_id }}">
+                        {% for name in benchmarks %}
+                        <option value="{{ name }}">
+                        {% endfor %}
+                    </datalist>
+                </div>
+            </div>
+            <div class="form-row">
+                <div class="form-group form-group-narrow">
+                    <label for="benchmark-minutes-{{ result_id }}">Minutes</label>
+                    <input type="number"
+                           id="benchmark-minutes-{{ result_id }}"
+                           name="minutes"
+                           value="{{ result.time_seconds // 60 }}"
+                           min="0"
+                           max="999"
+                           placeholder="0"
+                           required
+                           class="form-control form-control-sm">
+                </div>
+                <div class="form-group form-group-narrow">
+                    <label for="benchmark-seconds-{{ result_id }}">Seconds</label>
+                    <input type="number"
+                           id="benchmark-seconds-{{ result_id }}"
+                           name="seconds"
+                           value="{{ result.time_seconds % 60 }}"
+                           min="0"
+                           max="59"
+                           placeholder="00"
+                           required
+                           class="form-control form-control-sm">
+                </div>
+                <div class="form-group form-group-narrow">
+                    <label for="benchmark-is-rx-{{ result_id }}">RX / Scaled</label>
+                    <select id="benchmark-is-rx-{{ result_id }}" name="is_rx" class="form-control form-control-sm">
+                        <option value="true" {% if result.is_rx %}selected{% endif %}>RX</option>
+                        <option value="false" {% if not result.is_rx %}selected{% endif %}>Scaled</option>
+                    </select>
+                </div>
+                <div class="form-group form-group-narrow">
+                    <label for="benchmark-date-{{ result_id }}">Date</label>
+                    <input type="date"
+                           id="benchmark-date-{{ result_id }}"
+                           name="recorded_at"
+                           value="{{ result.recorded_at }}"
+                           required
+                           class="form-control form-control-sm">
+                </div>
+                <div class="form-group form-group-submit">
+                    <label>&nbsp;</label>
+                    <div class="one-rm-edit-actions">
+                        <button type="submit" class="btn btn-primary btn-sm">Save</button>
+                        <button type="button" class="btn btn-sm btn-cancel"
+                                onclick="var row = this.closest('tr'); row.parentElement.removeChild(row);" title="Cancel">&times;</button>
+                    </div>
+                </div>
+            </div>
+        </form>
+    </td>
+</tr>

--- a/src/wodplanner/app/templates/partials/benchmark_history.html
+++ b/src/wodplanner/app/templates/partials/benchmark_history.html
@@ -24,14 +24,23 @@
                     {% endif %}
                 </td>
                 <td>
+                    <div class="one-rm-actions">
+                    <button class="btn-edit"
+                            hx-get="/benchmark-results/{{ entry.id }}/edit"
+                            hx-target="closest tr"
+                            hx-swap="outerHTML"
+                            title="Edit">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/><path d="m15 5 4 4"/></svg>
+                    </button>
                     <button class="btn-delete"
                             hx-delete="/benchmark-results/{{ entry.id }}/delete"
                             hx-target="#benchmark-history"
                             hx-swap="outerHTML"
-                            hx-confirm="Delete this benchmark result?"
+                            hx-confirm="Delete {{ entry.benchmark_name }} {{ entry.formatted_time }} entry?"
                             title="Delete">
                         &times;
                     </button>
+                    </div>
                 </td>
             </tr>
             {% endfor %}

--- a/src/wodplanner/app/templates/partials/one_rep_max_edit_row.html
+++ b/src/wodplanner/app/templates/partials/one_rep_max_edit_row.html
@@ -1,0 +1,57 @@
+<tr id="edit-row-{{ entry_id }}" class="one-rm-edit-row">
+    <td colspan="4">
+        <form hx-put="/one-rep-maxes/{{ entry_id }}/edit"
+              hx-target="#one-rep-max-history"
+              hx-swap="outerHTML"
+              class="one-rm-form one-rm-form--inline">
+            <div class="form-row">
+                <div class="form-group">
+                    <label for="1rm-exercise-{{ entry_id }}">Exercise</label>
+                    <input type="text"
+                           id="1rm-exercise-{{ entry_id }}"
+                           name="exercise"
+                           list="exercise-list-{{ entry_id }}"
+                           value="{{ entry.exercise }}"
+                           placeholder="Exercise"
+                           required
+                           class="form-control form-control-sm"
+                           autocomplete="off">
+                    <datalist id="exercise-list-{{ entry_id }}">
+                        {% for ex in exercises %}
+                        <option value="{{ ex }}">
+                        {% endfor %}
+                    </datalist>
+                </div>
+                <div class="form-group form-group-narrow">
+                    <label for="1rm-weight-{{ entry_id }}">Weight (kg)</label>
+                    <input type="number"
+                           id="1rm-weight-{{ entry_id }}"
+                           name="weight_kg"
+                           value="{{ entry.weight_kg }}"
+                           min="1"
+                           max="999"
+                           step="0.5"
+                           required
+                           class="form-control form-control-sm">
+                </div>
+                <div class="form-group form-group-narrow">
+                    <label for="1rm-date-{{ entry_id }}">Date</label>
+                    <input type="date"
+                           id="1rm-date-{{ entry_id }}"
+                           name="recorded_at"
+                           value="{{ entry.recorded_at_iso }}"
+                           required
+                           class="form-control form-control-sm">
+                </div>
+                <div class="form-group form-group-submit">
+                    <label>&nbsp;</label>
+                    <div class="one-rm-edit-actions">
+                    <button type="submit" class="btn btn-primary btn-sm">Save</button>
+                    <button type="button" class="btn btn-sm btn-cancel"
+                            onclick="var row = this.closest('tr'); row.parentElement.removeChild(row);" title="Cancel">&times;</button>
+                    </div>
+                </div>
+            </div>
+        </form>
+    </td>
+</tr>

--- a/src/wodplanner/app/templates/partials/one_rep_max_history.html
+++ b/src/wodplanner/app/templates/partials/one_rep_max_history.html
@@ -16,14 +16,23 @@
                 <td class="one-rm-weight">{{ entry.weight_kg }} kg</td>
                 <td class="one-rm-date text-muted">{{ entry.recorded_at }}</td>
                 <td>
+                    <div class="one-rm-actions">
+                    <button class="btn-edit"
+                            hx-get="/one-rep-maxes/{{ entry.id }}/edit"
+                            hx-target="closest tr"
+                            hx-swap="outerHTML"
+                            title="Edit">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/><path d="m15 5 4 4"/></svg>
+                    </button>
                     <button class="btn-delete"
                             hx-delete="/one-rep-maxes/{{ entry.id }}/delete"
                             hx-target="#one-rep-max-history"
                             hx-swap="outerHTML"
-                            hx-confirm="Delete this 1rm entry?"
+                            hx-confirm="Delete {{ entry.exercise }} {{ entry.weight_kg }}kg entry?"
                             title="Delete">
                         &times;
                     </button>
+                    </div>
                 </td>
             </tr>
             {% endfor %}

--- a/src/wodplanner/app/templates/partials/one_rep_max_modal.html
+++ b/src/wodplanner/app/templates/partials/one_rep_max_modal.html
@@ -14,11 +14,21 @@
             <div class="form-row">
                 <div class="form-group">
                     <label for="1rm-exercise">Exercise</label>
-                    <select id="1rm-exercise" name="exercise" required class="form-control" onchange="modalUpdate1rmChart()">
+                    <input type="text"
+                           id="1rm-exercise"
+                           name="exercise"
+                           list="exercise-list"
+                           placeholder="Search exercise…"
+                           value="{{ default_exercise }}"
+                           required
+                           class="form-control"
+                           autocomplete="off"
+                           oninput="modalUpdate1rmChart()">
+                    <datalist id="exercise-list">
                         {% for ex in exercises %}
-                        <option value="{{ ex }}" {% if suggested_exercises and ex == suggested_exercises[0] %}selected{% endif %}>{{ ex }}</option>
+                        <option value="{{ ex }}">
                         {% endfor %}
-                    </select>
+                    </datalist>
                 </div>
                 <div class="form-group form-group-narrow">
                     <label for="1rm-weight">Weight (kg)</label>
@@ -73,7 +83,6 @@
 <style>
 #one-rep-max-history { display: none !important; }
 </style>
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
 <script>
 var __modal1rmData = {{ exercises_data_json | safe }};
 var __modal1rmChart = null;
@@ -114,10 +123,27 @@ function modalUpdate1rmChart() {
     document.getElementById('modal-1rm-no-data').style.display = 'none';
 
     var points = __modal1rmData[exercise];
-    var labels = points.map(function(p) { return p.label; });
-    var weights = points.map(function(p) { return p.weight; });
+    var sorted = points.slice().sort(function(a, b) { return a.date < b.date ? -1 : a.date > b.date ? 1 : 0; });
+    var labels = sorted.map(function(p) { return p.label; });
+    var weights = sorted.map(function(p) { return p.weight; });
 
-    __modal1rmMaxWeight = Math.max.apply(null, points.map(function(p) { return p.weight; }));
+    var prColors = [], prRadii = [], prBorders = [];
+    var runningMax = 0;
+    for (var i = 0; i < sorted.length; i++) {
+        var w = sorted[i].weight;
+        if (w > runningMax) {
+            runningMax = w;
+            prColors.push('#f59e0b');
+            prRadii.push(7);
+            prBorders.push('#d97706');
+        } else {
+            prColors.push('#7c3aed');
+            prRadii.push(4);
+            prBorders.push('#7c3aed');
+        }
+    }
+
+    __modal1rmMaxWeight = runningMax;
     document.getElementById('modal-pct-section').style.display = 'block';
     modalSetPct(100);
 
@@ -133,8 +159,11 @@ function modalUpdate1rmChart() {
                 backgroundColor: 'rgba(124,58,237,0.08)',
                 tension: 0.2,
                 fill: true,
-                pointRadius: 5,
-                pointHoverRadius: 7,
+                pointBackgroundColor: prColors,
+                pointBorderColor: prBorders,
+                pointRadius: prRadii,
+                pointBorderWidth: 2,
+                pointHoverRadius: 10,
             }]
         },
         options: {

--- a/src/wodplanner/services/benchmark.py
+++ b/src/wodplanner/services/benchmark.py
@@ -197,3 +197,12 @@ class BenchmarkService(BaseService):
             )
             conn.commit()
             return cursor.rowcount > 0
+
+    def update_result(self, user_id: int, result_id: int, benchmark_name: str, time_seconds: int, is_rx: bool, recorded_at: str) -> bool:
+        with self._get_connection() as conn:
+            cursor = conn.execute(
+                "UPDATE benchmark_results SET benchmark_name = ?, time_seconds = ?, is_rx = ?, recorded_at = ? WHERE id = ? AND user_id = ?",
+                (benchmark_name, time_seconds, int(is_rx), recorded_at, result_id, user_id),
+            )
+            conn.commit()
+            return cursor.rowcount > 0

--- a/src/wodplanner/services/one_rep_max.py
+++ b/src/wodplanner/services/one_rep_max.py
@@ -234,3 +234,20 @@ class OneRepMaxService(BaseService):
                 (user_id, exercise),
             ).fetchone()
             return row[0] if row and row[0] is not None else None
+
+    def get_by_id(self, user_id: int, entry_id: int) -> OneRepMax | None:
+        with self._get_connection() as conn:
+            row = conn.execute(
+                "SELECT * FROM one_rep_maxes WHERE id = ? AND user_id = ?",
+                (entry_id, user_id),
+            ).fetchone()
+            return self._row_to_model(row) if row else None
+
+    def update(self, user_id: int, entry_id: int, exercise: str, weight_kg: float, recorded_at: date) -> bool:
+        with self._get_connection() as conn:
+            cursor = conn.execute(
+                "UPDATE one_rep_maxes SET exercise = ?, weight_kg = ?, recorded_at = ? WHERE id = ? AND user_id = ?",
+                (exercise, weight_kg, recorded_at.isoformat(), entry_id, user_id),
+            )
+            conn.commit()
+            return cursor.rowcount > 0

--- a/tests/app/routers/test_views.py
+++ b/tests/app/routers/test_views.py
@@ -445,6 +445,79 @@ class TestAddDeleteOneRepMax:
         response = app_client.delete(f"/one-rep-maxes/{entry.id}/delete")
         assert response.status_code == 200
 
+    def test_edit_form_renders(self, app_client, session_cookie, one_rep_max_service):
+        from datetime import date as _date
+
+        entry = one_rep_max_service.add(
+            user_id=42, exercise="Back Squat", weight_kg=100, recorded_at=_date(2026, 4, 25)
+        )
+        app_client.cookies.set("session", session_cookie)
+        response = app_client.get(f"/one-rep-maxes/{entry.id}/edit")
+        assert response.status_code == 200
+        assert "Back Squat" in response.text
+        assert "100" in response.text
+
+    def test_edit_form_404(self, app_client, session_cookie):
+        app_client.cookies.set("session", session_cookie)
+        response = app_client.get("/one-rep-maxes/99999/edit")
+        assert response.status_code == 404
+
+    def test_update(self, app_client, session_cookie, one_rep_max_service):
+        from datetime import date as _date
+
+        entry = one_rep_max_service.add(
+            user_id=42, exercise="Back Squat", weight_kg=100, recorded_at=_date(2026, 4, 25)
+        )
+        app_client.cookies.set("session", session_cookie)
+        response = app_client.put(
+            f"/one-rep-maxes/{entry.id}/edit",
+            data={
+                "exercise": "Front Squat",
+                "weight_kg": "110",
+                "recorded_at": "2026-05-01",
+            },
+        )
+        assert response.status_code == 200
+        updated = one_rep_max_service.get_by_id(42, entry.id)
+        assert updated is not None
+        assert updated.exercise == "Front Squat"
+        assert updated.weight_kg == 110.0
+        assert updated.recorded_at.isoformat() == "2026-05-01"
+
+    def test_update_unknown_exercise_422(self, app_client, session_cookie, one_rep_max_service):
+        from datetime import date as _date
+
+        entry = one_rep_max_service.add(
+            user_id=42, exercise="Back Squat", weight_kg=100, recorded_at=_date(2026, 4, 25)
+        )
+        app_client.cookies.set("session", session_cookie)
+        response = app_client.put(
+            f"/one-rep-maxes/{entry.id}/edit",
+            data={
+                "exercise": "Unknown Exercise",
+                "weight_kg": "110",
+                "recorded_at": "2026-05-01",
+            },
+        )
+        assert response.status_code == 422
+
+    def test_update_invalid_weight(self, app_client, session_cookie, one_rep_max_service):
+        from datetime import date as _date
+
+        entry = one_rep_max_service.add(
+            user_id=42, exercise="Back Squat", weight_kg=100, recorded_at=_date(2026, 4, 25)
+        )
+        app_client.cookies.set("session", session_cookie)
+        response = app_client.put(
+            f"/one-rep-maxes/{entry.id}/edit",
+            data={
+                "exercise": "Back Squat",
+                "weight_kg": "9999",
+                "recorded_at": "2026-05-01",
+            },
+        )
+        assert response.status_code == 400
+
 
 class TestBenchmarkModal:
     def test_renders(self, app_client, session_cookie, schedule_service):
@@ -520,6 +593,65 @@ class TestAddDeleteBenchmarkResult:
         assert response.status_code == 200
         results = benchmark_service.get_results_for_benchmark(42, "Fran")
         assert len(results) == 0
+
+    def test_edit_form_renders(self, app_client, session_cookie, benchmark_service):
+        r = benchmark_service.add_result(
+            user_id=42, benchmark_name="Fran", time_seconds=180, is_rx=True, recorded_at="2026-05-05"
+        )
+        app_client.cookies.set("session", session_cookie)
+        response = app_client.get(f"/benchmark-results/{r.id}/edit")
+        assert response.status_code == 200
+        assert "Fran" in response.text
+        assert 'name="minutes"' in response.text
+        assert 'name="seconds"' in response.text
+        assert "Minutes" in response.text
+        assert "Seconds" in response.text
+        assert "RX / Scaled" in response.text
+
+    def test_edit_form_404(self, app_client, session_cookie):
+        app_client.cookies.set("session", session_cookie)
+        response = app_client.get("/benchmark-results/99999/edit")
+        assert response.status_code == 404
+
+    def test_update(self, app_client, session_cookie, benchmark_service):
+        r = benchmark_service.add_result(
+            user_id=42, benchmark_name="Fran", time_seconds=180, is_rx=True, recorded_at="2026-05-05"
+        )
+        app_client.cookies.set("session", session_cookie)
+        response = app_client.put(
+            f"/benchmark-results/{r.id}/edit",
+            data={
+                "benchmark_name": "Helen",
+                "minutes": "4",
+                "seconds": "30",
+                "is_rx": "false",
+                "recorded_at": "2026-06-01",
+            },
+        )
+        assert response.status_code == 200
+        result = benchmark_service.get_result(42, r.id)
+        assert result is not None
+        assert result.benchmark_name == "Helen"
+        assert result.time_seconds == 270
+        assert result.is_rx is False
+        assert result.recorded_at == "2026-06-01"
+
+    def test_update_invalid_time(self, app_client, session_cookie, benchmark_service):
+        r = benchmark_service.add_result(
+            user_id=42, benchmark_name="Fran", time_seconds=180, is_rx=True, recorded_at="2026-05-05"
+        )
+        app_client.cookies.set("session", session_cookie)
+        response = app_client.put(
+            f"/benchmark-results/{r.id}/edit",
+            data={
+                "benchmark_name": "Fran",
+                "minutes": "0",
+                "seconds": "0",
+                "is_rx": "true",
+                "recorded_at": "2026-06-01",
+            },
+        )
+        assert response.status_code == 400
 
 
 class TestRelativeTime:

--- a/tests/e2e/test_one_rep_max.py
+++ b/tests/e2e/test_one_rep_max.py
@@ -41,7 +41,7 @@ def test_add_1rm_entry_updates_history(page, auth_session):
     page.goto("/1rm")
     page.get_by_text("+ Log").click()
 
-    page.locator("select[name=exercise]").select_option("Back Squat")
+    page.locator("input[name=exercise]").fill("Back Squat")
     page.locator("input[name=weight_kg]").fill("100")
     page.locator("input[name=recorded_at]").fill(date.today().isoformat())
 

--- a/tests/services/test_benchmark.py
+++ b/tests/services/test_benchmark.py
@@ -298,3 +298,22 @@ class TestBenchmarkResultService:
         r = svc.add_result(user_id=1, benchmark_name="Fran", time_seconds=180, is_rx=True, recorded_at="2026-05-05")
         assert r.id is not None
         assert r.user_id == 1
+
+    def test_update_result(self, db_path):
+        svc = BenchmarkService(db_path)
+        r = svc.add_result(user_id=1, benchmark_name="Fran", time_seconds=180, is_rx=True, recorded_at="2026-05-05")
+        updated = svc.update_result(user_id=1, result_id=r.id, benchmark_name="Helen", time_seconds=240, is_rx=False, recorded_at="2026-06-01")
+        assert updated is True
+
+        result = svc.get_result(user_id=1, result_id=r.id)
+        assert result is not None
+        assert result.benchmark_name == "Helen"
+        assert result.time_seconds == 240
+        assert result.is_rx is False
+        assert result.recorded_at == "2026-06-01"
+
+    def test_update_result_scoped_by_user(self, db_path):
+        svc = BenchmarkService(db_path)
+        r = svc.add_result(user_id=1, benchmark_name="Fran", time_seconds=180, is_rx=True, recorded_at="2026-05-05")
+        updated = svc.update_result(user_id=2, result_id=r.id, benchmark_name="Helen", time_seconds=240, is_rx=False, recorded_at="2026-06-01")
+        assert updated is False

--- a/tests/services/test_one_rep_max.py
+++ b/tests/services/test_one_rep_max.py
@@ -196,3 +196,48 @@ class TestOneRepMaxService:
         entry = svc.add(user_id=1, exercise="Back Squat", weight_kg=100.0, recorded_at=date(2026, 1, 1))
         deleted = svc.delete(user_id=999, entry_id=entry.id)
         assert deleted is False
+
+    def test_get_by_id(self, db_path):
+        from datetime import date
+
+        svc = OneRepMaxService(db_path)
+        entry = svc.add(user_id=1, exercise="Back Squat", weight_kg=100.0, recorded_at=date(2026, 1, 1))
+        found = svc.get_by_id(user_id=1, entry_id=entry.id)
+        assert found is not None
+        assert found.weight_kg == 100.0
+        assert found.exercise == "Back Squat"
+
+    def test_get_by_id_not_found(self, db_path):
+        svc = OneRepMaxService(db_path)
+        found = svc.get_by_id(user_id=1, entry_id=99999)
+        assert found is None
+
+    def test_get_by_id_wrong_user(self, db_path):
+        from datetime import date
+
+        svc = OneRepMaxService(db_path)
+        entry = svc.add(user_id=1, exercise="Back Squat", weight_kg=100.0, recorded_at=date(2026, 1, 1))
+        found = svc.get_by_id(user_id=999, entry_id=entry.id)
+        assert found is None
+
+    def test_update(self, db_path):
+        from datetime import date
+
+        svc = OneRepMaxService(db_path)
+        entry = svc.add(user_id=1, exercise="Back Squat", weight_kg=100.0, recorded_at=date(2026, 1, 1))
+        updated = svc.update(user_id=1, entry_id=entry.id, exercise="Front Squat", weight_kg=110.0, recorded_at=date(2026, 2, 1))
+        assert updated is True
+
+        updated_entry = svc.get_by_id(user_id=1, entry_id=entry.id)
+        assert updated_entry is not None
+        assert updated_entry.exercise == "Front Squat"
+        assert updated_entry.weight_kg == 110.0
+        assert updated_entry.recorded_at == date(2026, 2, 1)
+
+    def test_update_wrong_user_returns_false(self, db_path):
+        from datetime import date
+
+        svc = OneRepMaxService(db_path)
+        entry = svc.add(user_id=1, exercise="Back Squat", weight_kg=100.0, recorded_at=date(2026, 1, 1))
+        updated = svc.update(user_id=999, entry_id=entry.id, exercise="Front Squat", weight_kg=110.0, recorded_at=date(2026, 2, 1))
+        assert updated is False


### PR DESCRIPTION
## Summary

Improvements to the 1RM and Benchmark tracking pages, applying the same UX fixes to both where applicable.

### 1RM page
- **Inline edit support** — edit button per history row opens an inline form (new GET/PUT `/one-rep-maxes/{id}/edit` endpoints)
- **PR markers on chart** — gold points highlight personal records, data sorted chronologically
- **Searchable exercise input** — `<select>` replaced with datalist input
- **Contextual delete confirmation** — e.g. "Delete Back Squat 100kg entry?"
- Removed dead `syncSliderFill` code and duplicate Chart.js CDN tag

### Benchmark page
- **Inline edit support** — new GET/PUT `/benchmark-results/{id}/edit` endpoints + labeled edit form
- **PR markers on chart** — gold points mark faster (PR) times
- **Searchable benchmark input**
- **Contextual delete confirmation**

### Bug fixes
- Edit row background fixed for dark theme

### Tests
- Added service tests for `get_by_id`/`update` (1RM) and `update_result` (benchmark)
- Added view tests for edit form rendering, update, validation errors
- Updated 1RM e2e test for datalist input

Coverage: 97%, all 592 tests pass, ruff + mypy clean.