### PR TITLE
fix: prevent iOS Safari from serving stale cached CSS

### DIFF
--- a/src/wodplanner/app/main.py
+++ b/src/wodplanner/app/main.py
@@ -93,6 +93,10 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response.headers["X-Frame-Options"] = "DENY"
         response.headers["X-Content-Type-Options"] = "nosniff"
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        # Never cache static files — iOS Safari aggressively caches broken responses
+        if request.url.path.startswith("/static/"):
+            response.headers["Cache-Control"] = "no-cache, must-revalidate"
+            response.headers["Pragma"] = "no-cache"
         if settings.environment == "production":
             response.headers["Strict-Transport-Security"] = (
                 "max-age=31536000; includeSubDomains"

--- a/src/wodplanner/app/templates/base.html
+++ b/src/wodplanner/app/templates/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="color-scheme" content="light dark">
     <title>{% block title %}WodPlanner{% endblock %}</title>
-    <link rel="stylesheet" href="/static/css/style.css?v={{ css_version }}">
+    <link rel="stylesheet" href="/static/css/style.css?v={{ css_version }}" onerror="this.href='/static/css/style.css?v='+Date.now()">
     <link rel="apple-touch-icon" sizes="180x180" href="/static/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/static/favicon-16x16.png">


### PR DESCRIPTION
iOS Safari aggressively caches static responses — including failed or corrupt ones. With only a content-hash `?v=` cache-buster, a transient network blip that returns a broken CSS response gets cached, and refreshing the page doesn't help because the URL hasn't changed.

**Changes:**
- `main.py`: Set `Cache-Control: no-cache, must-revalidate` on all `/static/` responses — browser must revalidate with the server before using a cached copy. Server returns `304 Not Modified` for unchanged files, so no bandwidth waste.
- `base.html`: Add `onerror` retry on the stylesheet link — if the initial request fails, retry with a fresh timestamp cache-buster.