### PR TITLE
feat: redesign user-data schema around central users table

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,223 @@
+# Database Redesign Plan
+
+## Design Principles
+
+1. **Single source of truth for user identity** — new `users` table, FK-referenced by all user-scoped tables
+2. **Referential integrity** — FK constraints with `ON UPDATE CASCADE` / `ON DELETE CASCADE` / `ON DELETE RESTRICT`
+3. **Soft deletes** — `deleted_at TEXT` on user-data and reference tables; queries filter `WHERE deleted_at IS NULL`
+4. **Audit timestamps** — `created_at` (immutable) and `updated_at` (set on every change)
+5. **Indexes** — every table indexed on its primary access path
+6. **CHECK constraints** — guard against impossible values
+7. **Consistent types** — all dates/timestamps as `TEXT` (ISO 8601)
+8. **Lazy population** — `users` table populated on first authenticated request via `require_session` / `require_session_for_view`, not on login
+
+## Target Schema
+
+```
+users (NEW — v800/v801)
+├── id INTEGER PRIMARY KEY              -- WodApp user_id (from session)
+├── appuser_id INTEGER UNIQUE           -- WodApp appuser_id (for member matching)
+├── gym_id INTEGER                      -- user's default gym
+├── display_name TEXT                   -- from WodApp firstname
+├── avatar_filename TEXT                -- moved from preferences
+├── tracking_disabled INTEGER NOT NULL DEFAULT 0  -- moved from preferences
+├── created_at TEXT NOT NULL
+└── updated_at TEXT NOT NULL
+
+preferences (MODIFIED — v802, keeps only UI settings)
+├── user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE
+├── key TEXT NOT NULL                   -- hidden_class_types, dismissed_tooltips
+├── value TEXT NOT NULL                 -- JSON-encoded
+└── PRIMARY KEY (user_id, key)
+[Removed keys: my_appuser_id, tracking_disabled, avatar_filename → moved to users]
+
+schedules (MODIFIED — v807)
+├── gym_id INTEGER NOT NULL DEFAULT 0   -- was nullable, now NOT NULL (fixes NULL UNIQUE bug)
+├── created_at TEXT NOT NULL            -- immutable on upsert
+├── updated_at TEXT NOT NULL            -- new, set on every upsert
+├── UNIQUE(date, class_type, gym_id)
+└── INDEX(date, gym_id)                 -- new
+
+friends (MODIFIED — v803)
+├── owner_user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE
+├── deleted_at TEXT                     -- new, soft delete
+├── INDEX(owner_user_id)               -- new
+└── UNIQUE(owner_user_id, appuser_id)
+
+exercises (MODIFIED — v808)
+├── deleted_at TEXT                     -- new, soft delete
+└── updated_at TEXT                     -- new
+
+one_rep_maxes (MODIFIED — v804)
+├── user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE
+├── exercise TEXT NOT NULL REFERENCES exercises(name) ON UPDATE CASCADE ON DELETE RESTRICT
+├── weight_kg REAL NOT NULL CHECK(weight_kg > 0)
+├── deleted_at TEXT                     -- new, soft delete
+├── updated_at TEXT NOT NULL            -- new
+├── INDEX(user_id, exercise)            -- new
+└── INDEX(user_id, recorded_at)         -- new
+
+benchmark_wods (MODIFIED — v809)
+├── deleted_at TEXT                     -- new, soft delete
+└── updated_at TEXT                     -- new
+
+benchmark_results (MODIFIED — v805)
+├── user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE
+├── benchmark_name TEXT NOT NULL REFERENCES benchmark_wods(name) ON UPDATE CASCADE ON DELETE RESTRICT
+├── time_seconds INTEGER NOT NULL CHECK(time_seconds > 0)
+├── is_rx INTEGER NOT NULL DEFAULT 1 CHECK(is_rx IN (0, 1))
+├── deleted_at TEXT                     -- new, soft delete
+├── updated_at TEXT NOT NULL            -- new
+└── INDEX(user_id, benchmark_name)      -- new
+
+subscription_events (MODIFIED — v806)
+├── user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE
+[No soft-delete — event log; no other changes]
+
+schema_migrations (unchanged)
+```
+
+## Lazy Population Strategy
+
+**Where:** `require_session` (`dependencies.py:78`) and `require_session_for_view` (`dependencies.py:94`)
+
+Both receive `AuthSession` from the cookie, which carries `user_id`, `appuser_id`, `gym_id`, and `firstname`. After session validation, before returning, call:
+
+```python
+user_service.upsert(
+    user_id=session.user_id,
+    appuser_id=session.appuser_id,
+    gym_id=session.gym_id,
+    display_name=session.firstname,
+)
+```
+
+The upsert SQL:
+
+```sql
+INSERT INTO users (id, appuser_id, gym_id, display_name, tracking_disabled, created_at, updated_at)
+VALUES (?, ?, ?, ?, 0, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+    appuser_id = excluded.appuser_id,
+    gym_id = excluded.gym_id,
+    display_name = excluded.display_name,
+    updated_at = excluded.updated_at
+```
+
+This updates `appuser_id`, `gym_id`, and `display_name` from the session on every request (keeping them fresh if the user changes gyms or name in WodApp). It does **not** overwrite `tracking_disabled` or `avatar_filename` — those are user-managed.
+
+**Removal condition:** Once `SELECT COUNT(*) FROM users WHERE display_name IS NULL OR gym_id IS NULL` returns 0, the upsert call can be removed from `require_session`. After removal, `display_name` and `gym_id` become static (won't auto-update from WodApp changes). Acceptable tradeoff for this app.
+
+> **Note (decision, 2026-08-04):** the count will never reach 0 on its own because of legacy rows (e.g. `user 0` from the single-user era and stale rows like `309755`) that no real session will ever populate. Decision: **keep the per-request upsert in `require_session` indefinitely** (negligible cost for this low-traffic app) and leave those rows in place. If the removal condition is ever revisited, it should count only session-created users (e.g. `WHERE id != 0`).
+
+## Migration Plan
+
+All new migrations use version range **800–899**. They run after all existing migrations (100–701).
+
+| Version | Description | Approach |
+|---------|-------------|----------|
+| **v800** | Create `users` table | `CREATE TABLE IF NOT EXISTS` |
+| **v801** | Populate `users` from existing data + clean preferences | Procedural: collect distinct `user_id` from `preferences`, `friends`, `one_rep_maxes`, `benchmark_results`, `subscription_events`. For each, extract `my_appuser_id` / `tracking_disabled` / `avatar_filename` from `preferences` if present. Insert into `users` (`display_name` and `gym_id` left NULL — filled by lazy population). Delete migrated keys from `preferences`. |
+| **v802** | Recreate `preferences` with FK to `users` | Create `preferences_new` with FK, copy remaining keys (`hidden_class_types`, `dismissed_tooltips`), drop old, rename. |
+| **v803** | Recreate `friends` with FK + soft-delete + index | Create `friends_new`, copy data (`deleted_at = NULL`), drop old, rename, create index. |
+| **v804** | Recreate `one_rep_maxes` with FK + CHECK + soft-delete + indexes + updated_at | FK to `users(id)` and `exercises(name) ON UPDATE CASCADE`. |
+| **v805** | Recreate `benchmark_results` with FK + CHECK + soft-delete + index + updated_at | FK to `users(id)` and `benchmark_wods(name) ON UPDATE CASCADE`. |
+| **v806** | Recreate `subscription_events` with FK to `users` | Keep existing indexes. FK to `users(id) ON DELETE CASCADE`. |
+| **v807** | Recreate `schedules` — fix NULL `gym_id`, add `updated_at`, add index | Create `schedules_new` with `gym_id INTEGER NOT NULL DEFAULT 0`, copy data (NULL → 0), drop old, rename, create index. |
+| **v808** | Add `deleted_at` + `updated_at` to `exercises` | `ALTER TABLE exercises ADD COLUMN` (2 statements) |
+| **v809** | Add `deleted_at` + `updated_at` to `benchmark_wods` | `ALTER TABLE benchmark_wods ADD COLUMN` (2 statements) |
+
+All recreate-and-copy migrations must:
+
+- Check whether the table already has the new schema (idempotent for pre-existing prod DBs)
+- Preserve all existing data
+- Be wrapped in a single migration function
+
+## Application Code Changes
+
+### New `UserService` (`services/users.py`)
+
+- `upsert(user_id, appuser_id, gym_id, display_name)` — called from `require_session` / `require_session_for_view`
+- `get(user_id) -> User | None`
+- `get_avatar_filename(user_id) -> str | None`
+- `get_avatar_filenames_by_appuser_ids(appuser_ids) -> dict[int, str | None]` — single query: `SELECT appuser_id, avatar_filename FROM users WHERE appuser_id IN (...)`
+- `is_tracking_disabled(user_id) -> bool`
+- `set_tracking_disabled(user_id, disabled)`
+- `set_avatar_filename(user_id, filename)` / `delete_avatar_filename(user_id)`
+
+### `PreferencesService` changes
+
+- **Remove:** `get_my_appuser_id`, `set_my_appuser_id`, `is_tracking_disabled`, `set_tracking_disabled`, `get_avatar_filename`, `set_avatar_filename`, `delete_avatar_filename`, `get_avatar_filenames`, `get_avatar_filenames_by_appuser_ids` — all moved to `UserService`
+- **Keep:** `get_hidden_class_types`, `set_hidden_class_types`, `toggle_hidden_class_type`, `get_dismissed_tooltips`, `dismiss_tooltip`, `reset_tooltips`
+
+### `dependencies.py` changes
+
+- Add `get_user_service()` singleton (like existing service getters)
+- Add `user_service` upsert call in `require_session` and `require_session_for_view` after session validation
+
+### `views.py` changes
+
+- Replace all `prefs_service.get_avatar_filename` / `is_tracking_disabled` / `get_my_appuser_id` calls with `user_service.*` equivalents
+- `get_avatar_filenames_by_appuser_ids` simplifies from 3 queries to 1
+
+### Service query changes (all user-data tables)
+
+- Add `AND deleted_at IS NULL` to every SELECT in `FriendsService`, `OneRepMaxService`, `BenchmarkService`
+- `get_exercise_list()`: add `WHERE deleted_at IS NULL`
+- `BenchmarkService.get_benchmark_list()`: add `WHERE deleted_at IS NULL`
+- Delete methods: change `DELETE FROM` to `UPDATE SET deleted_at = ?`
+- `ScheduleService` upsert: stop overwriting `created_at` on conflict; set `updated_at` instead
+- `ScheduleService` queries: replace `gym_id IS NULL` checks with `gym_id = 0`
+
+### `backup-db` CLI
+
+- After `src.backup(dst)`, run `PRAGMA integrity_check` and `PRAGMA foreign_key_check` on the destination
+- If either fails, delete the backup file and log an error
+
+### Dead code cleanup
+
+- Remove `ScheduleService.find_for_appointment` (never called)
+- Remove `BenchmarkService.get_benchmark_names_for_user` (never called)
+- Remove `PreferencesService.get_for_user` / `get_all` (only used in tests)
+
+### Documentation
+
+- Update `docs/database.md` with all 10 tables (including `users`)
+- Update migration version range table (add 600–699 benchmark, 700–799 subscription_tracker, 800–899 users)
+- Document soft-delete convention, FK relationships, lazy population strategy, and removal condition
+
+## Risk Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| Migration data loss | Every recreate-and-copy migration checks if new schema is already in place (idempotent). `ALTER TABLE ADD COLUMN` is non-destructive. |
+| FK enforcement breaks existing data | v801 (populate users) runs before any FK migration. Any `user_id` in user-scoped tables without a `preferences` row → insert a placeholder `users` row with `user_id` only. |
+| `exercises(name)` FK blocks renames | `ON UPDATE CASCADE` propagates renames to `one_rep_maxes.exercise`. |
+| `benchmark_wods(name)` FK blocks renames | Same — `ON UPDATE CASCADE`. |
+| Soft-delete changes query behavior | All queries explicitly filter `deleted_at IS NULL`. Existing tests updated. |
+| `schedules` gym_id 0 vs NULL | Migrate NULL → 0 in v807. All queries change from `gym_id IS NULL` to `gym_id = 0`. |
+| Per-request upsert cost | Single-row PK upsert — negligible for low-traffic app. Removable once all rows populated. |
+
+## Testing Strategy
+
+1. **Migration tests**: Create a test DB with old schema + sample data, run all migrations, verify data preserved and new constraints in place
+2. **FK enforcement tests**: Insert `one_rep_maxes` row with non-existent `exercises.name` → expect `IntegrityError`
+3. **Soft-delete tests**: Delete a friend, verify filtered from `get_all` but still in DB; verify `get` returns None
+4. **Upsert test**: Upsert a schedule twice, verify `created_at` unchanged and `updated_at` updated
+5. **Lazy population test**: Simulate `require_session_for_view` with a user not in `users` table, verify row created
+6. **Backup verification test**: Create a backup, verify `PRAGMA integrity_check` passes
+
+## Execution Order
+
+1. Create `UserService` + `User` model
+2. Write migrations v800–v809
+3. Write migration tests
+4. Update `dependencies.py` (add `get_user_service`, lazy upsert in `require_session` / `require_session_for_view`)
+5. Update `PreferencesService` (remove migrated methods)
+6. Update all service queries (soft-delete filters, updated_at, gym_id=0)
+7. Update `views.py` (use `UserService` for avatars/tracking/identity)
+8. Update `backup-db` CLI (integrity check)
+9. Update `docs/database.md`
+10. Clean up dead code
+11. Run full test suite
+

--- a/docs/database.md
+++ b/docs/database.md
@@ -19,6 +19,9 @@ Version ranges per service (keep grouped, avoid collisions):
 | 300–399 | `preferences` |
 | 400–499 | `one_rep_max` |
 | 500–599 | *(reserved — was `google_accounts`)* |
+| 600–699 | `benchmark` |
+| 700–799 | `subscription_tracker` |
+| 800–899 | `users` (single source of truth for user identity) |
 
 ### Applying migrations
 
@@ -62,11 +65,21 @@ WAL mode is persistent (stored in DB file header) — set once on first connecti
 
 ## Tables
 
-- `friends` — scoped per `owner_user_id`; unique on `(owner_user_id, appuser_id)`
-- `preferences` — scoped per `user_id`; primary key `(user_id, key)`; value is JSON-encoded. Known keys: `hidden_class_types` (JSON array of class type strings), `dismissed_tooltips` (JSON array of tooltip ID strings), `my_appuser_id` (stringified int — the user's `id_appuser` in member lists; discovered once via name-match in `people_modal_view`, then used for reliable ID-based self-detection)
-- `schedules` — scoped per `gym_id`; unique on `(date, class_type, gym_id)`; `gym_id` nullable for legacy rows imported before gym scoping was added
-- `exercises` — canonical list of 1RM exercise names; columns: `id`, `name` (UNIQUE), `created_at`; seeded with 28 predefined exercises on first run if table is empty; extended via `add-1rm` CLI
-- `one_rep_maxes` — scoped per `user_id`; columns: `id`, `user_id`, `exercise` (must match a name in `exercises`), `weight_kg`, `recorded_at` (ISO date), `notes`, `created_at`
+- `users` — single source of truth for user identity. PK `id` = WodApp `user_id` (from session); also stores `appuser_id` (for member matching), `gym_id`, `display_name`, `avatar_filename`, `tracking_disabled`. Referenced by every user-scoped table via FK. Rows are populated lazily on first authenticated request.
+- `friends` — scoped per `owner_user_id` (FK → `users`); unique on `(owner_user_id, appuser_id)`; soft-deletable via `deleted_at`
+- `preferences` — scoped per `user_id` (FK → `users`); primary key `(user_id, key)`; value is JSON-encoded. Keeps only UI settings: `hidden_class_types`, `dismissed_tooltips`. Identity/tracking/avatar keys moved to `users`.
+- `schedules` — scoped per `gym_id` (NOT NULL, default 0); unique on `(date, class_type, gym_id)`; index on `(date, gym_id)`; `created_at` is immutable, `updated_at` set on every upsert
+- `exercises` — canonical list of 1RM exercise names; columns: `id`, `name` (UNIQUE), `created_at`, `updated_at`, `deleted_at`; seeded with 28 predefined exercises on first run if table is empty; extended via `add-1rm` CLI
+- `one_rep_maxes` — scoped per `user_id` (FK → `users`); `exercise` FK → `exercises(name)`; columns: `id`, `user_id`, `exercise`, `weight_kg` (>0), `recorded_at`, `notes`, `created_at`, `updated_at`, `deleted_at`; indexes on `(user_id, exercise)` and `(user_id, recorded_at)`
+- `benchmark_wods` — canonical list of benchmark WOD names; columns `id`, `name` (UNIQUE), `category`, `created_at`, `updated_at`, `deleted_at`
+- `benchmark_results` — scoped per `user_id` (FK → `users`); `benchmark_name` FK → `benchmark_wods(name)`; columns `id`, `user_id`, `benchmark_name`, `time_seconds` (>0), `is_rx`, `recorded_at`, `created_at`, `updated_at`, `deleted_at`; index on `(user_id, benchmark_name)`
+- `subscription_events` — event log, scoped per `user_id` (FK → `users`, ON DELETE CASCADE); no soft-delete; indexes on `(user_id, class_date)` and `(user_id, appointment_id)`
+
+### Conventions
+
+- **Soft deletes**: user-data and reference tables (`friends`, `one_rep_maxes`, `benchmark_results`, `exercises`, `benchmark_wods`) expose `deleted_at TEXT`. All SELECT queries filter `WHERE deleted_at IS NULL`; delete methods set `deleted_at` instead of issuing `DELETE`.
+- **Audit timestamps**: all tables carry `created_at` (immutable) and `updated_at` (set on every change), stored as ISO-8601 `TEXT`.
+- **Lazy population**: `users` rows are created/refreshed on every authenticated request via `dependencies.require_session` / `require_session_for_view` (`UserService.upsert`). This keeps `appuser_id`, `gym_id`, and `display_name` in sync with the session while never overwriting `tracking_disabled` or `avatar_filename`.
 
 
 ## Auth

--- a/src/wodplanner/app/dependencies.py
+++ b/src/wodplanner/app/dependencies.py
@@ -19,10 +19,17 @@ from wodplanner.services.preferences import PreferencesService
 from wodplanner.services.schedule import ScheduleService
 from wodplanner.services.subscription import SubscriptionService
 from wodplanner.services.subscription_tracker import SubscriptionTrackerService
+from wodplanner.services.users import UserService
 
 
 def _get_db_path() -> Path:
     return Path(os.environ.get("DB_PATH", "/data/wodplanner.db"))
+
+
+@lru_cache
+def get_user_service() -> UserService:
+    """Get the singleton user service."""
+    return UserService(_get_db_path())
 
 
 @lru_cache
@@ -88,7 +95,18 @@ def require_session(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Not authenticated",
         )
+    _upsert_user(session)
     return session
+
+
+def _upsert_user(session: AuthSession) -> None:
+    """Lazily persist the user's identity from the session."""
+    get_user_service().upsert(
+        user_id=session.user_id,
+        appuser_id=session.appuser_id,
+        gym_id=session.gym_id,
+        display_name=session.firstname,
+    )
 
 
 def require_session_for_view(
@@ -116,6 +134,7 @@ def require_session_for_view(
             status_code=status.HTTP_303_SEE_OTHER,
             headers={"Location": "/login"},
         )
+    _upsert_user(session)
     return session
 
 

--- a/src/wodplanner/app/routers/views.py
+++ b/src/wodplanner/app/routers/views.py
@@ -27,6 +27,7 @@ from wodplanner.app.dependencies import (
     get_session_from_cookie,
     get_subscription_service,
     get_subscription_tracker_service,
+    get_user_service,
     require_session_for_view,
 )
 from wodplanner.models.auth import AuthSession
@@ -43,6 +44,7 @@ from wodplanner.services.schedule import ScheduleService
 from wodplanner.services.schedule_lookup import match_schedule, match_schedules_for_date
 from wodplanner.services.subscription import SubscribeAction, SubscriptionService
 from wodplanner.services.subscription_tracker import SubscriptionTrackerService
+from wodplanner.services.users import UserService
 from wodplanner.utils.dates import parse_api_datetime, parse_iso_date
 
 logger = logging.getLogger(__name__)
@@ -234,7 +236,7 @@ def home_page(
     session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
     client: WodAppClient = Depends(get_client_from_session_for_view),
     tracker: SubscriptionTrackerService = Depends(get_subscription_tracker_service),
-    prefs_service: PreferencesService = Depends(get_preferences_service),
+    user_service: UserService = Depends(get_user_service),
     schedule_service: ScheduleService = Depends(get_schedule_service),
     benchmark_service: BenchmarkService = Depends(get_benchmark_service),
 ):
@@ -283,7 +285,7 @@ def home_page(
     average = 0.0
     weeks_tracked = 0
 
-    if not prefs_service.is_tracking_disabled(user_id):
+    if not user_service.is_tracking_disabled(user_id):
         has_data = tracker.has_any_events(user_id)
         if has_data:
             weekly = tracker.get_weekly_counts(user_id)
@@ -500,11 +502,12 @@ def settings_page(
     request: Request,
     session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
     prefs_service: PreferencesService = Depends(get_preferences_service),
+    user_service: UserService = Depends(get_user_service),
 ):
     """Settings page."""
     hidden_types = prefs_service.get_hidden_class_types(session.user_id)
     filters = [{"name": t, "hidden": t in hidden_types} for t in FILTERABLE_CLASS_TYPES]
-    tracking_disabled = prefs_service.is_tracking_disabled(session.user_id)
+    tracking_disabled = user_service.is_tracking_disabled(session.user_id)
     return render(
         request,
         "settings.html",
@@ -547,12 +550,12 @@ def toggle_tracking(
     enable: str = Form("true"),
     delete_data: str = Form("false"),
     session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
-    prefs_service: PreferencesService = Depends(get_preferences_service),
+    user_service: UserService = Depends(get_user_service),
     tracker: SubscriptionTrackerService = Depends(get_subscription_tracker_service),
 ):
     """Enable or disable session tracking."""
     disabled = enable != "true"
-    prefs_service.set_tracking_disabled(session.user_id, disabled)
+    user_service.set_tracking_disabled(session.user_id, disabled)
 
     if delete_data == "true":
         tracker.delete_all_for_user(session.user_id)
@@ -633,13 +636,13 @@ def friends_page(
     request: Request,
     session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
     friends_service: FriendsService = Depends(get_friends_service),
-    prefs_service: PreferencesService = Depends(get_preferences_service),
+    user_service: UserService = Depends(get_user_service),
 ):
     """Friends management page."""
     friends = friends_service.get_all(session.user_id)
     friend_user_ids = [f.appuser_id for f in friends]
-    avatar_map = prefs_service.get_avatar_filenames_by_appuser_ids(friend_user_ids)
-    my_avatar = prefs_service.get_avatar_filename(session.user_id)
+    avatar_map = user_service.get_avatar_filenames_by_appuser_ids(friend_user_ids)
+    my_avatar = user_service.get_avatar_filename(session.user_id)
 
     friends_data = [
         {
@@ -673,13 +676,13 @@ def add_friend_view(
     name: str = Form(...),
     session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
     friends_service: FriendsService = Depends(get_friends_service),
-    prefs_service: PreferencesService = Depends(get_preferences_service),
+    user_service: UserService = Depends(get_user_service),
 ):
     """Add a friend (htmx form submission)."""
     friends_service.add(session.user_id, appuser_id, name)
     friends = friends_service.get_all(session.user_id)
     friend_user_ids = [f.appuser_id for f in friends]
-    avatar_map = prefs_service.get_avatar_filenames_by_appuser_ids(friend_user_ids)
+    avatar_map = user_service.get_avatar_filenames_by_appuser_ids(friend_user_ids)
 
     friends_data = [
         {
@@ -702,13 +705,13 @@ def delete_friend_view(
     friend_id: int,
     session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
     friends_service: FriendsService = Depends(get_friends_service),
-    prefs_service: PreferencesService = Depends(get_preferences_service),
+    user_service: UserService = Depends(get_user_service),
 ):
     """Delete a friend (htmx)."""
     friends_service.delete(session.user_id, friend_id)
     friends = friends_service.get_all(session.user_id)
     friend_user_ids = [f.appuser_id for f in friends]
-    avatar_map = prefs_service.get_avatar_filenames_by_appuser_ids(friend_user_ids)
+    avatar_map = user_service.get_avatar_filenames_by_appuser_ids(friend_user_ids)
 
     friends_data = [
         {
@@ -730,7 +733,7 @@ def upload_avatar(
     request: Request,
     avatar: UploadFile = FastAPIFile(...),
     session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
-    prefs_service: PreferencesService = Depends(get_preferences_service),
+    user_service: UserService = Depends(get_user_service),
 ):
     ext = Path(avatar.filename or "").suffix.lower()
     if ext not in _ALLOWED_EXTENSIONS:
@@ -777,9 +780,7 @@ def upload_avatar(
     img = Image.open(io.BytesIO(contents))
     img.save(filepath, format=fmt)
 
-    prefs_service.set_avatar_filename(session.user_id, filename)
-    if session.appuser_id:
-        prefs_service.set_avatar_filename(session.appuser_id, filename)
+    user_service.set_avatar_filename(session.user_id, filename)
     return RedirectResponse(url="/friends", status_code=303)
 
 
@@ -787,21 +788,17 @@ def upload_avatar(
 def remove_avatar(
     request: Request,
     session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
-    prefs_service: PreferencesService = Depends(get_preferences_service),
+    user_service: UserService = Depends(get_user_service),
 ):
     """Remove the current user's avatar photo."""
     def _remove_file(user_id: int) -> None:
-        filename = prefs_service.get_avatar_filename(user_id)
+        filename = user_service.get_avatar_filename(user_id)
         if filename:
             filepath = _UPLOAD_DIR / filename
             if filepath.exists():
                 filepath.unlink()
     _remove_file(session.user_id)
-    if session.appuser_id:
-        _remove_file(session.appuser_id)
-    prefs_service.delete_avatar_filename(session.user_id)
-    if session.appuser_id:
-        prefs_service.delete_avatar_filename(session.appuser_id)
+    user_service.delete_avatar_filename(session.user_id)
     return RedirectResponse(url="/friends", status_code=303)
 
 
@@ -816,6 +813,7 @@ def subscribe_view(
     client: WodAppClient = Depends(get_client_from_session_for_view),
     friends_service: FriendsService = Depends(get_friends_service),
     prefs_service: PreferencesService = Depends(get_preferences_service),
+    user_service: UserService = Depends(get_user_service),
     schedule_service: ScheduleService = Depends(get_schedule_service),
     subscription_service: SubscriptionService = Depends(get_subscription_service),
     benchmark_service: BenchmarkService = Depends(get_benchmark_service),
@@ -832,7 +830,7 @@ def subscribe_view(
         action=SubscribeAction.SUBSCRIBE,
     )
 
-    if result.subscribedWithSuccess and not prefs_service.is_tracking_disabled(session.user_id):
+    if result.subscribedWithSuccess and not user_service.is_tracking_disabled(session.user_id):
         tracker.record_subscribe(
             user_id=session.user_id,
             appointment_id=appointment_id,
@@ -904,6 +902,7 @@ def unsubscribe_view(
     client: WodAppClient = Depends(get_client_from_session_for_view),
     friends_service: FriendsService = Depends(get_friends_service),
     prefs_service: PreferencesService = Depends(get_preferences_service),
+    user_service: UserService = Depends(get_user_service),
     schedule_service: ScheduleService = Depends(get_schedule_service),
     subscription_service: SubscriptionService = Depends(get_subscription_service),
     benchmark_service: BenchmarkService = Depends(get_benchmark_service),
@@ -926,7 +925,7 @@ def unsubscribe_view(
         action=action,
     )
 
-    if result.subscribedWithSuccess and is_waitinglist != "true" and not prefs_service.is_tracking_disabled(session.user_id):
+    if result.subscribedWithSuccess and is_waitinglist != "true" and not user_service.is_tracking_disabled(session.user_id):
         tracker.record_unsubscribe(
             user_id=session.user_id,
             appointment_id=appointment_id,
@@ -957,7 +956,7 @@ def people_modal_view(
     session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
     client: WodAppClient = Depends(get_client_from_session_for_view),
     friends_service: FriendsService = Depends(get_friends_service),
-    prefs_service: PreferencesService = Depends(get_preferences_service),
+    user_service: UserService = Depends(get_user_service),
 ):
     """Get participants for an appointment (htmx modal)."""
     start = parse_api_datetime(date_start)
@@ -967,22 +966,28 @@ def people_modal_view(
     friend_ids = friends_service.get_appuser_ids(session.user_id)
     members = details.subscriptions.members
 
-    # Resolve current user's id_appuser: prefer session, then stored pref, then
-    # one-time name-match discovery (only when exactly one member matches, to
-    # avoid wrong self-assignment on name collision).
-    current_appuser_id = session.appuser_id or prefs_service.get_my_appuser_id(session.user_id)
+    # Resolve current user's id_appuser: prefer session, then stored (users
+    # table), then one-time name-match discovery (only when exactly one member
+    # matches, to avoid wrong self-assignment on name collision).
+    current_user = user_service.get(session.user_id)
+    current_appuser_id = session.appuser_id or (current_user.appuser_id if current_user else None)
     if not current_appuser_id:
         name_matches = [m for m in members if m.name == session.firstname]
         if len(name_matches) == 1:
             current_appuser_id = name_matches[0].id_appuser
-            prefs_service.set_my_appuser_id(session.user_id, current_appuser_id)
+            user_service.upsert(
+                user_id=session.user_id,
+                appuser_id=current_appuser_id,
+                gym_id=session.gym_id,
+                display_name=session.firstname,
+            )
 
     participants = []
     all_user_ids = [m.id_appuser for m in members]
-    avatar_map = prefs_service.get_avatar_filenames(all_user_ids)
+    avatar_map = user_service.get_avatar_filenames_by_appuser_ids(all_user_ids)
     # Current user's avatar is stored under session.user_id, not appuser_id
     if current_appuser_id and current_appuser_id not in avatar_map:
-        my_avatar = prefs_service.get_avatar_filename(session.user_id)
+        my_avatar = user_service.get_avatar_filename(session.user_id)
         if my_avatar:
             avatar_map[current_appuser_id] = my_avatar
     for member in members:
@@ -1023,7 +1028,7 @@ def add_friend_from_people(
     session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
     client: WodAppClient = Depends(get_client_from_session_for_view),
     friends_service: FriendsService = Depends(get_friends_service),
-    prefs_service: PreferencesService = Depends(get_preferences_service),
+    user_service: UserService = Depends(get_user_service),
 ):
     """Add a friend from the people modal."""
     friends_service.add(session.user_id, appuser_id, name)
@@ -1037,7 +1042,7 @@ def add_friend_from_people(
         session=session,
         client=client,
         friends_service=friends_service,
-        prefs_service=prefs_service,
+        user_service=user_service,
     )
 
 

--- a/src/wodplanner/cli/backup_db.py
+++ b/src/wodplanner/cli/backup_db.py
@@ -1,11 +1,14 @@
 """CLI tool for backing up the SQLite database."""
 
 import argparse
+import logging
 import sqlite3
 from datetime import datetime
 from pathlib import Path
 
 MAX_BACKUPS = 7
+
+logger = logging.getLogger(__name__)
 
 
 def backup(db_path: Path, backup_dir: Path) -> Path:
@@ -21,7 +24,30 @@ def backup(db_path: Path, backup_dir: Path) -> Path:
         dst.close()
         src.close()
 
+    _verify_backup(dest)
     return dest
+
+
+def _verify_backup(dest: Path) -> None:
+    """Run integrity + FK checks on the backup; delete it if either fails."""
+    conn = sqlite3.connect(dest)
+    try:
+        integrity = conn.execute("PRAGMA integrity_check").fetchone()[0]
+        if integrity != "ok":
+            logger.error("Backup %s failed integrity_check: %s", dest, integrity)
+            _discard(dest)
+            return
+        fk_violations = conn.execute("PRAGMA foreign_key_check").fetchall()
+        if fk_violations:
+            logger.error("Backup %s has %d FK violations", dest, len(fk_violations))
+            _discard(dest)
+            return
+    finally:
+        conn.close()
+
+
+def _discard(dest: Path) -> None:
+    dest.unlink(missing_ok=True)
 
 
 def rotate(backup_dir: Path, keep: int = MAX_BACKUPS) -> list[Path]:

--- a/src/wodplanner/models/user.py
+++ b/src/wodplanner/models/user.py
@@ -1,0 +1,16 @@
+"""User model."""
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class User(BaseModel):
+    id: int
+    appuser_id: int | None = None
+    gym_id: int | None = None
+    display_name: str | None = None
+    avatar_filename: str | None = None
+    tracking_disabled: bool = False
+    created_at: datetime | None = None
+    updated_at: datetime | None = None

--- a/src/wodplanner/services/benchmark.py
+++ b/src/wodplanner/services/benchmark.py
@@ -107,6 +107,57 @@ migrations.register(601, "seed default benchmark WODs", _migrate_v601)
 migrations.register(602, "create benchmark_results table", _migrate_v602)
 
 
+def _migrate_v805(conn: sqlite3.Connection) -> None:
+    """Recreate benchmark_results with FK to users/wods, CHECK, soft-delete, index."""
+    if migrations.has_fk_to(conn, "benchmark_results", "users") and migrations.has_column(
+        conn, "benchmark_results", "updated_at"
+    ):
+        return
+    with migrations.fk_disabled(conn):
+        conn.execute("ALTER TABLE benchmark_results RENAME TO benchmark_results_old")
+        conn.execute(
+            """
+            CREATE TABLE benchmark_results (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                benchmark_name TEXT NOT NULL REFERENCES benchmark_wods(name) ON UPDATE CASCADE ON DELETE RESTRICT,
+                time_seconds INTEGER NOT NULL CHECK(time_seconds > 0),
+                is_rx INTEGER NOT NULL DEFAULT 1 CHECK(is_rx IN (0, 1)),
+                recorded_at TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                deleted_at TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO benchmark_results
+                (id, user_id, benchmark_name, time_seconds, is_rx, recorded_at, created_at, updated_at, deleted_at)
+            SELECT id, user_id, benchmark_name, time_seconds, is_rx, recorded_at, created_at, created_at, NULL
+            FROM benchmark_results_old
+            """
+        )
+        conn.execute("DROP TABLE benchmark_results_old")
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_bmr_user_name ON benchmark_results(user_id, benchmark_name)"
+        )
+
+
+migrations.register(805, "recreate benchmark_results with FK + soft-delete", _migrate_v805)
+
+
+def _migrate_v809(conn: sqlite3.Connection) -> None:
+    """Add deleted_at + updated_at to benchmark_wods."""
+    if not migrations.has_column(conn, "benchmark_wods", "deleted_at"):
+        conn.execute("ALTER TABLE benchmark_wods ADD COLUMN deleted_at TEXT")
+    if not migrations.has_column(conn, "benchmark_wods", "updated_at"):
+        conn.execute("ALTER TABLE benchmark_wods ADD COLUMN updated_at TEXT")
+
+
+migrations.register(809, "add soft-delete + updated_at to benchmark_wods", _migrate_v809)
+
+
 class BenchmarkService(BaseService):
     def _row_to_model(self, row: sqlite3.Row) -> BenchmarkWod:
         return BenchmarkWod(
@@ -119,16 +170,17 @@ class BenchmarkService(BaseService):
     def get_benchmark_list(self) -> list[str]:
         with self._get_connection() as conn:
             rows = conn.execute(
-                "SELECT name FROM benchmark_wods ORDER BY name"
+                "SELECT name FROM benchmark_wods WHERE deleted_at IS NULL ORDER BY name"
             ).fetchall()
             return [row["name"] for row in rows]
 
     def add_benchmark_wod(self, name: str, category: str) -> bool:
         try:
+            now = datetime.now().isoformat()
             with self._get_connection() as conn:
                 conn.execute(
-                    "INSERT INTO benchmark_wods (name, category, created_at) VALUES (?, ?, ?)",
-                    (name.strip(), category.strip(), datetime.now().isoformat()),
+                    "INSERT INTO benchmark_wods (name, category, created_at, updated_at) VALUES (?, ?, ?, ?)",
+                    (name.strip(), category.strip(), now, now),
                 )
                 conn.commit()
                 return True
@@ -149,10 +201,11 @@ class BenchmarkService(BaseService):
     def add_result(
         self, user_id: int, benchmark_name: str, time_seconds: int, is_rx: bool, recorded_at: str
     ) -> BenchmarkResult:
+        now = datetime.now().isoformat()
         with self._get_connection() as conn:
             row = conn.execute(
-                "INSERT INTO benchmark_results (user_id, benchmark_name, time_seconds, is_rx, recorded_at, created_at) VALUES (?, ?, ?, ?, ?, ?) RETURNING *",
-                (user_id, benchmark_name.strip(), time_seconds, int(is_rx), recorded_at, datetime.now().isoformat()),
+                "INSERT INTO benchmark_results (user_id, benchmark_name, time_seconds, is_rx, recorded_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING *",
+                (user_id, benchmark_name.strip(), time_seconds, int(is_rx), recorded_at, now, now),
             ).fetchone()
             conn.commit()
             return self._row_to_result(row)
@@ -160,7 +213,7 @@ class BenchmarkService(BaseService):
     def get_results_for_benchmark(self, user_id: int, benchmark_name: str) -> list[BenchmarkResult]:
         with self._get_connection() as conn:
             rows = conn.execute(
-                "SELECT * FROM benchmark_results WHERE user_id = ? AND benchmark_name = ? ORDER BY recorded_at DESC",
+                "SELECT * FROM benchmark_results WHERE user_id = ? AND benchmark_name = ? AND deleted_at IS NULL ORDER BY recorded_at DESC",
                 (user_id, benchmark_name),
             ).fetchall()
             return [self._row_to_result(row) for row in rows]
@@ -168,23 +221,15 @@ class BenchmarkService(BaseService):
     def get_all_results(self, user_id: int) -> list[BenchmarkResult]:
         with self._get_connection() as conn:
             rows = conn.execute(
-                "SELECT * FROM benchmark_results WHERE user_id = ? ORDER BY recorded_at DESC",
+                "SELECT * FROM benchmark_results WHERE user_id = ? AND deleted_at IS NULL ORDER BY recorded_at DESC",
                 (user_id,),
             ).fetchall()
             return [self._row_to_result(row) for row in rows]
 
-    def get_benchmark_names_for_user(self, user_id: int) -> list[str]:
-        with self._get_connection() as conn:
-            rows = conn.execute(
-                "SELECT DISTINCT benchmark_name FROM benchmark_results WHERE user_id = ? ORDER BY benchmark_name",
-                (user_id,),
-            ).fetchall()
-            return [row["benchmark_name"] for row in rows]
-
     def get_result(self, user_id: int, result_id: int) -> BenchmarkResult | None:
         with self._get_connection() as conn:
             row = conn.execute(
-                "SELECT * FROM benchmark_results WHERE id = ? AND user_id = ?",
+                "SELECT * FROM benchmark_results WHERE id = ? AND user_id = ? AND deleted_at IS NULL",
                 (result_id, user_id),
             ).fetchone()
             return self._row_to_result(row) if row else None
@@ -192,8 +237,8 @@ class BenchmarkService(BaseService):
     def delete_result(self, user_id: int, result_id: int) -> bool:
         with self._get_connection() as conn:
             cursor = conn.execute(
-                "DELETE FROM benchmark_results WHERE id = ? AND user_id = ?",
-                (result_id, user_id),
+                "UPDATE benchmark_results SET deleted_at = ? WHERE id = ? AND user_id = ? AND deleted_at IS NULL",
+                (datetime.now().isoformat(), result_id, user_id),
             )
             conn.commit()
             return cursor.rowcount > 0
@@ -201,8 +246,8 @@ class BenchmarkService(BaseService):
     def update_result(self, user_id: int, result_id: int, benchmark_name: str, time_seconds: int, is_rx: bool, recorded_at: str) -> bool:
         with self._get_connection() as conn:
             cursor = conn.execute(
-                "UPDATE benchmark_results SET benchmark_name = ?, time_seconds = ?, is_rx = ?, recorded_at = ? WHERE id = ? AND user_id = ?",
-                (benchmark_name, time_seconds, int(is_rx), recorded_at, result_id, user_id),
+                "UPDATE benchmark_results SET benchmark_name = ?, time_seconds = ?, is_rx = ?, recorded_at = ?, updated_at = ? WHERE id = ? AND user_id = ? AND deleted_at IS NULL",
+                (benchmark_name, time_seconds, int(is_rx), recorded_at, datetime.now().isoformat(), result_id, user_id),
             )
             conn.commit()
             return cursor.rowcount > 0

--- a/src/wodplanner/services/friends.py
+++ b/src/wodplanner/services/friends.py
@@ -55,6 +55,40 @@ def _migrate_v200(conn: sqlite3.Connection) -> None:
 migrations.register(200, "create friends table (owner-scoped)", _migrate_v200)
 
 
+def _migrate_v803(conn: sqlite3.Connection) -> None:
+    """Recreate friends with FK to users + soft-delete + index."""
+    if migrations.has_fk_to(conn, "friends", "users") and migrations.has_column(
+        conn, "friends", "deleted_at"
+    ):
+        return
+    with migrations.fk_disabled(conn):
+        conn.execute("ALTER TABLE friends RENAME TO friends_old")
+        conn.execute(
+            """
+            CREATE TABLE friends (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                owner_user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                appuser_id INTEGER NOT NULL,
+                name TEXT NOT NULL,
+                added_at TEXT NOT NULL,
+                deleted_at TEXT,
+                UNIQUE(owner_user_id, appuser_id)
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO friends (id, owner_user_id, appuser_id, name, added_at, deleted_at)
+            SELECT id, owner_user_id, appuser_id, name, added_at, NULL FROM friends_old
+            """
+        )
+        conn.execute("DROP TABLE friends_old")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_friends_owner ON friends(owner_user_id)")
+
+
+migrations.register(803, "recreate friends with FK users + soft-delete", _migrate_v803)
+
+
 class FriendsService(BaseService):
     """Service for managing friends with SQLite storage."""
 
@@ -86,7 +120,7 @@ class FriendsService(BaseService):
         """Get a friend by ID, scoped to owner."""
         with self._get_connection() as conn:
             row = conn.execute(
-                "SELECT * FROM friends WHERE id = ? AND owner_user_id = ?",
+                "SELECT * FROM friends WHERE id = ? AND owner_user_id = ? AND deleted_at IS NULL",
                 (friend_id, owner_user_id),
             ).fetchone()
             return self._row_to_model(row) if row else None
@@ -95,7 +129,7 @@ class FriendsService(BaseService):
         """Get a friend by WodApp user ID, scoped to owner."""
         with self._get_connection() as conn:
             row = conn.execute(
-                "SELECT * FROM friends WHERE owner_user_id = ? AND appuser_id = ?",
+                "SELECT * FROM friends WHERE owner_user_id = ? AND appuser_id = ? AND deleted_at IS NULL",
                 (owner_user_id, appuser_id),
             ).fetchone()
             return self._row_to_model(row) if row else None
@@ -104,7 +138,7 @@ class FriendsService(BaseService):
         """Get all friends for owner."""
         with self._get_connection() as conn:
             rows = conn.execute(
-                "SELECT * FROM friends WHERE owner_user_id = ? ORDER BY name",
+                "SELECT * FROM friends WHERE owner_user_id = ? AND deleted_at IS NULL ORDER BY name",
                 (owner_user_id,),
             ).fetchall()
             return [self._row_to_model(row) for row in rows]
@@ -113,27 +147,27 @@ class FriendsService(BaseService):
         """Get set of friend appuser IDs for quick lookup, scoped to owner."""
         with self._get_connection() as conn:
             rows = conn.execute(
-                "SELECT appuser_id FROM friends WHERE owner_user_id = ?",
+                "SELECT appuser_id FROM friends WHERE owner_user_id = ? AND deleted_at IS NULL",
                 (owner_user_id,),
             ).fetchall()
             return {row["appuser_id"] for row in rows}
 
     def delete(self, owner_user_id: int, friend_id: int) -> bool:
-        """Delete a friend by ID, scoped to owner."""
+        """Soft-delete a friend by ID, scoped to owner."""
         with self._get_connection() as conn:
             cursor = conn.execute(
-                "DELETE FROM friends WHERE id = ? AND owner_user_id = ?",
-                (friend_id, owner_user_id),
+                "UPDATE friends SET deleted_at = ? WHERE id = ? AND owner_user_id = ? AND deleted_at IS NULL",
+                (datetime.now().isoformat(), friend_id, owner_user_id),
             )
             conn.commit()
             return cursor.rowcount > 0
 
     def delete_by_appuser_id(self, owner_user_id: int, appuser_id: int) -> bool:
-        """Delete a friend by WodApp user ID, scoped to owner."""
+        """Soft-delete a friend by WodApp user ID, scoped to owner."""
         with self._get_connection() as conn:
             cursor = conn.execute(
-                "DELETE FROM friends WHERE owner_user_id = ? AND appuser_id = ?",
-                (owner_user_id, appuser_id),
+                "UPDATE friends SET deleted_at = ? WHERE owner_user_id = ? AND appuser_id = ? AND deleted_at IS NULL",
+                (datetime.now().isoformat(), owner_user_id, appuser_id),
             )
             conn.commit()
             return cursor.rowcount > 0

--- a/src/wodplanner/services/migrations.py
+++ b/src/wodplanner/services/migrations.py
@@ -13,17 +13,21 @@ Version ranges per service (keep migrations grouped and avoid collisions):
     200-299  friends
     300-399  preferences
     400-499  one_rep_max
+    600-699  benchmark
+    700-799  subscription_tracker
+    800-899  users (single source of truth for user identity)
 """
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import sqlite3
 import threading
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Callable, Union
+from typing import Callable, Iterator, Union
 
 from wodplanner.services.db import get_connection
 
@@ -43,6 +47,37 @@ class _Entry:
 _registry: list[_Entry] = []
 _applied_paths: set[Path] = set()
 _lock = threading.Lock()
+
+
+@contextlib.contextmanager
+def fk_disabled(conn: sqlite3.Connection) -> Iterator[None]:
+    """Temporarily disable FK enforcement so recreate-and-copy migrations can
+    preserve otherwise-orphaned rows. FK is re-enabled and committed on exit."""
+    conn.execute("PRAGMA foreign_keys=OFF")
+    try:
+        yield
+    finally:
+        conn.commit()
+        conn.execute("PRAGMA foreign_keys=ON")
+        conn.commit()
+
+
+def table_exists(conn: sqlite3.Connection, name: str) -> bool:
+    return (
+        conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)
+        ).fetchone()
+        is not None
+    )
+
+
+def has_column(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    cols = [r[1] for r in conn.execute(f"PRAGMA table_info({table})")]
+    return column in cols
+
+
+def has_fk_to(conn: sqlite3.Connection, table: str, parent: str) -> bool:
+    return any(r["table"] == parent for r in conn.execute(f"PRAGMA foreign_key_list({table})"))
 
 
 def register(version: int, description: str, sql: MigrationSql) -> None:
@@ -99,6 +134,7 @@ def _import_services_for_registration() -> None:
         preferences,
         schedule,
         subscription_tracker,
+        users,
     )
 
 

--- a/src/wodplanner/services/one_rep_max.py
+++ b/src/wodplanner/services/one_rep_max.py
@@ -143,6 +143,56 @@ migrations.register(400, "create exercises and one_rep_maxes tables", _migrate_v
 migrations.register(401, "seed default exercises", _migrate_v401)
 
 
+def _migrate_v804(conn: sqlite3.Connection) -> None:
+    """Recreate one_rep_maxes with FK to users/exercises, CHECK, soft-delete, indexes."""
+    if migrations.has_fk_to(conn, "one_rep_maxes", "users") and migrations.has_column(
+        conn, "one_rep_maxes", "updated_at"
+    ):
+        return
+    with migrations.fk_disabled(conn):
+        conn.execute("ALTER TABLE one_rep_maxes RENAME TO one_rep_maxes_old")
+        conn.execute(
+            """
+            CREATE TABLE one_rep_maxes (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                exercise TEXT NOT NULL REFERENCES exercises(name) ON UPDATE CASCADE ON DELETE RESTRICT,
+                weight_kg REAL NOT NULL CHECK(weight_kg > 0),
+                recorded_at TEXT NOT NULL,
+                notes TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                deleted_at TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO one_rep_maxes
+                (id, user_id, exercise, weight_kg, recorded_at, notes, created_at, updated_at, deleted_at)
+            SELECT id, user_id, exercise, weight_kg, recorded_at, notes, created_at, created_at, NULL
+            FROM one_rep_maxes_old
+            """
+        )
+        conn.execute("DROP TABLE one_rep_maxes_old")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_orm_user_exercise ON one_rep_maxes(user_id, exercise)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_orm_user_recorded ON one_rep_maxes(user_id, recorded_at)")
+
+
+migrations.register(804, "recreate one_rep_maxes with FK + soft-delete", _migrate_v804)
+
+
+def _migrate_v808(conn: sqlite3.Connection) -> None:
+    """Add deleted_at + updated_at to exercises."""
+    if not migrations.has_column(conn, "exercises", "deleted_at"):
+        conn.execute("ALTER TABLE exercises ADD COLUMN deleted_at TEXT")
+    if not migrations.has_column(conn, "exercises", "updated_at"):
+        conn.execute("ALTER TABLE exercises ADD COLUMN updated_at TEXT")
+
+
+migrations.register(808, "add soft-delete + updated_at to exercises", _migrate_v808)
+
+
 class OneRepMaxService(BaseService):
     def _row_to_model(self, row: sqlite3.Row) -> OneRepMax:
         return OneRepMax(
@@ -156,10 +206,11 @@ class OneRepMaxService(BaseService):
         )
 
     def add(self, user_id: int, exercise: str, weight_kg: float, recorded_at: date, notes: str | None = None) -> OneRepMax:
+        now = datetime.now().isoformat()
         with self._get_connection() as conn:
             row = conn.execute(
-                "INSERT INTO one_rep_maxes (user_id, exercise, weight_kg, recorded_at, notes, created_at) VALUES (?, ?, ?, ?, ?, ?) RETURNING *",
-                (user_id, exercise.strip(), weight_kg, recorded_at.isoformat(), notes, datetime.now().isoformat()),
+                "INSERT INTO one_rep_maxes (user_id, exercise, weight_kg, recorded_at, notes, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING *",
+                (user_id, exercise.strip(), weight_kg, recorded_at.isoformat(), notes, now, now),
             ).fetchone()
             conn.commit()
             return self._row_to_model(row)
@@ -167,7 +218,7 @@ class OneRepMaxService(BaseService):
     def get_all(self, user_id: int) -> list[OneRepMax]:
         with self._get_connection() as conn:
             rows = conn.execute(
-                "SELECT * FROM one_rep_maxes WHERE user_id = ? ORDER BY recorded_at DESC, created_at DESC",
+                "SELECT * FROM one_rep_maxes WHERE user_id = ? AND deleted_at IS NULL ORDER BY recorded_at DESC, created_at DESC",
                 (user_id,),
             ).fetchall()
             return [self._row_to_model(row) for row in rows]
@@ -175,7 +226,7 @@ class OneRepMaxService(BaseService):
     def get_for_exercise(self, user_id: int, exercise: str) -> list[OneRepMax]:
         with self._get_connection() as conn:
             rows = conn.execute(
-                "SELECT * FROM one_rep_maxes WHERE user_id = ? AND exercise = ? ORDER BY recorded_at DESC",
+                "SELECT * FROM one_rep_maxes WHERE user_id = ? AND exercise = ? AND deleted_at IS NULL ORDER BY recorded_at DESC",
                 (user_id, exercise),
             ).fetchall()
             return [self._row_to_model(row) for row in rows]
@@ -183,7 +234,7 @@ class OneRepMaxService(BaseService):
     def get_exercises(self, user_id: int) -> list[str]:
         with self._get_connection() as conn:
             rows = conn.execute(
-                "SELECT DISTINCT exercise FROM one_rep_maxes WHERE user_id = ? ORDER BY exercise",
+                "SELECT DISTINCT exercise FROM one_rep_maxes WHERE user_id = ? AND deleted_at IS NULL ORDER BY exercise",
                 (user_id,),
             ).fetchall()
             return [row["exercise"] for row in rows]
@@ -191,15 +242,17 @@ class OneRepMaxService(BaseService):
     def delete(self, user_id: int, entry_id: int) -> bool:
         with self._get_connection() as conn:
             cursor = conn.execute(
-                "DELETE FROM one_rep_maxes WHERE id = ? AND user_id = ?",
-                (entry_id, user_id),
+                "UPDATE one_rep_maxes SET deleted_at = ? WHERE id = ? AND user_id = ? AND deleted_at IS NULL",
+                (datetime.now().isoformat(), entry_id, user_id),
             )
             conn.commit()
             return cursor.rowcount > 0
 
     def get_exercise_list(self) -> list[str]:
         with self._get_connection() as conn:
-            rows = conn.execute("SELECT name FROM exercises ORDER BY name").fetchall()
+            rows = conn.execute(
+                "SELECT name FROM exercises WHERE deleted_at IS NULL ORDER BY name"
+            ).fetchall()
             return [row["name"] for row in rows]
 
     def add_exercise(self, name: str) -> bool:
@@ -207,8 +260,8 @@ class OneRepMaxService(BaseService):
         try:
             with self._get_connection() as conn:
                 conn.execute(
-                    "INSERT INTO exercises (name, created_at) VALUES (?, ?)",
-                    (name.strip(), datetime.now().isoformat()),
+                    "INSERT INTO exercises (name, created_at, updated_at) VALUES (?, ?, ?)",
+                    (name.strip(), datetime.now().isoformat(), datetime.now().isoformat()),
                 )
                 conn.commit()
                 return True
@@ -218,7 +271,7 @@ class OneRepMaxService(BaseService):
     def validate_exercise(self, name: str) -> bool:
         with self._get_connection() as conn:
             row = conn.execute(
-                "SELECT 1 FROM exercises WHERE name = ?", (name,)
+                "SELECT 1 FROM exercises WHERE name = ? AND deleted_at IS NULL", (name,)
             ).fetchone()
             return row is not None
 
@@ -230,7 +283,7 @@ class OneRepMaxService(BaseService):
     def get_max_for_exercise(self, user_id: int, exercise: str) -> float | None:
         with self._get_connection() as conn:
             row = conn.execute(
-                "SELECT MAX(weight_kg) FROM one_rep_maxes WHERE user_id = ? AND exercise = ?",
+                "SELECT MAX(weight_kg) FROM one_rep_maxes WHERE user_id = ? AND exercise = ? AND deleted_at IS NULL",
                 (user_id, exercise),
             ).fetchone()
             return row[0] if row and row[0] is not None else None
@@ -238,7 +291,7 @@ class OneRepMaxService(BaseService):
     def get_by_id(self, user_id: int, entry_id: int) -> OneRepMax | None:
         with self._get_connection() as conn:
             row = conn.execute(
-                "SELECT * FROM one_rep_maxes WHERE id = ? AND user_id = ?",
+                "SELECT * FROM one_rep_maxes WHERE id = ? AND user_id = ? AND deleted_at IS NULL",
                 (entry_id, user_id),
             ).fetchone()
             return self._row_to_model(row) if row else None
@@ -246,8 +299,8 @@ class OneRepMaxService(BaseService):
     def update(self, user_id: int, entry_id: int, exercise: str, weight_kg: float, recorded_at: date) -> bool:
         with self._get_connection() as conn:
             cursor = conn.execute(
-                "UPDATE one_rep_maxes SET exercise = ?, weight_kg = ?, recorded_at = ? WHERE id = ? AND user_id = ?",
-                (exercise, weight_kg, recorded_at.isoformat(), entry_id, user_id),
+                "UPDATE one_rep_maxes SET exercise = ?, weight_kg = ?, recorded_at = ?, updated_at = ? WHERE id = ? AND user_id = ? AND deleted_at IS NULL",
+                (exercise, weight_kg, recorded_at.isoformat(), datetime.now().isoformat(), entry_id, user_id),
             )
             conn.commit()
             return cursor.rowcount > 0

--- a/src/wodplanner/services/preferences.py
+++ b/src/wodplanner/services/preferences.py
@@ -1,20 +1,15 @@
-"""User preferences storage service."""
+"""User preferences storage service (UI-only settings).
+
+User identity, tracking, and avatar settings moved to the `users` table /
+`UserService`; this service keeps only UI preferences.
+"""
 
 import json
 import sqlite3
-from dataclasses import dataclass, field
 from typing import cast
 
 from wodplanner.services import migrations
 from wodplanner.services.base import BaseService
-
-
-@dataclass
-class UserPreferences:
-    """User preferences."""
-    hidden_class_types: list[str] = field(default_factory=list)
-    dismissed_tooltips: list[str] = field(default_factory=list)
-    tracking_disabled: bool = False
 
 
 def _migrate_v300(conn: sqlite3.Connection) -> None:
@@ -91,13 +86,6 @@ class PreferencesService(BaseService):
         self.set_hidden_class_types(user_id, hidden)
         return hidden
 
-    def get_my_appuser_id(self, user_id: int) -> int | None:
-        value = self._get(user_id, "my_appuser_id", "")
-        return int(value) if value else None
-
-    def set_my_appuser_id(self, user_id: int, appuser_id: int) -> None:
-        self._set(user_id, "my_appuser_id", str(appuser_id))
-
     def get_dismissed_tooltips(self, user_id: int) -> list[str]:
         value = self._get(user_id, "dismissed_tooltips", "[]")
         return cast("list[str]", json.loads(value))
@@ -110,105 +98,3 @@ class PreferencesService(BaseService):
 
     def reset_tooltips(self, user_id: int) -> None:
         self._set(user_id, "dismissed_tooltips", "[]")
-
-    def is_tracking_disabled(self, user_id: int) -> bool:
-        value = self._get(user_id, "tracking_disabled", "false")
-        return cast("bool", json.loads(value))
-
-    def set_tracking_disabled(self, user_id: int, disabled: bool) -> None:
-        self._set(user_id, "tracking_disabled", json.dumps(disabled))
-
-    def get_for_user(self, user_id: int) -> UserPreferences:
-        """Get all preferences for a user in a single query."""
-        with self._get_connection() as conn:
-            rows = conn.execute(
-                "SELECT key, value FROM preferences WHERE user_id = ?",
-                (user_id,),
-            ).fetchall()
-        prefs = UserPreferences()
-        for row in rows:
-            key, value = row["key"], row["value"]
-            if key == "hidden_class_types":
-                prefs.hidden_class_types = json.loads(value)
-            elif key == "dismissed_tooltips":
-                prefs.dismissed_tooltips = json.loads(value)
-            elif key == "tracking_disabled":
-                prefs.tracking_disabled = json.loads(value)
-        return prefs
-
-    def get_all(self, user_id: int) -> UserPreferences:
-        return self.get_for_user(user_id)
-
-    def get_avatar_filename(self, user_id: int) -> str | None:
-        value = self._get(user_id, "avatar_filename", "")
-        return value if value else None
-
-    def set_avatar_filename(self, user_id: int, filename: str) -> None:
-        self._set(user_id, "avatar_filename", filename)
-
-    def delete_avatar_filename(self, user_id: int) -> None:
-        """Remove the avatar filename preference for a user."""
-        with self._get_connection() as conn:
-            conn.execute(
-                "DELETE FROM preferences WHERE user_id = ? AND key = 'avatar_filename'",
-                (user_id,),
-            )
-            conn.commit()
-
-    def get_avatar_filenames(self, user_ids: list[int]) -> dict[int, str]:
-        if not user_ids:
-            return {}
-        with self._get_connection() as conn:
-            placeholders = ",".join("?" * len(user_ids))
-            rows = conn.execute(
-                f"SELECT user_id, value FROM preferences WHERE user_id IN ({placeholders}) AND key = 'avatar_filename'",
-                user_ids,
-            ).fetchall()
-        return {row["user_id"]: row["value"] for row in rows}
-
-    def get_avatar_filenames_by_appuser_ids(self, appuser_ids: list[int]) -> dict[int, str | None]:
-        """Get avatar filenames keyed by WodApp appuser_id.
-
-        First tries direct lookup by appuser_id. For unfound IDs, falls back
-        to reverse-mapping via my_appuser_id preferences (user_id → appuser_id)
-        to find avatars stored only under the session user_id.
-        """
-        if not appuser_ids:
-            return {}
-
-        result: dict[int, str | None] = {uid: None for uid in appuser_ids}
-
-        with self._get_connection() as conn:
-            # 1. Direct lookup by appuser_id
-            placeholders = ",".join("?" * len(appuser_ids))
-            rows = conn.execute(
-                f"SELECT user_id, value FROM preferences WHERE user_id IN ({placeholders}) AND key = 'avatar_filename'",
-                appuser_ids,
-            ).fetchall()
-            for row in rows:
-                result[row["user_id"]] = row["value"]
-
-            # 2. For unfound IDs, reverse-map through my_appuser_id
-            unfound = [uid for uid in appuser_ids if result[uid] is None]
-            if unfound:
-                placeholders = ",".join("?" * len(unfound))
-                rows = conn.execute(
-                    f"SELECT user_id, value FROM preferences WHERE key = 'my_appuser_id' AND value IN ({placeholders})",
-                    unfound,
-                ).fetchall()
-                mapped_session_ids = [int(row["value"]) for row in rows]
-                if mapped_session_ids:
-                    placeholders = ",".join("?" * len(mapped_session_ids))
-                    avatar_rows = conn.execute(
-                        f"SELECT user_id, value FROM preferences WHERE user_id IN ({placeholders}) AND key = 'avatar_filename'",
-                        mapped_session_ids,
-                    ).fetchall()
-                    session_to_avatar = {row["user_id"]: row["value"] for row in avatar_rows}
-                    for row in rows:
-                        session_id = int(row["value"])
-                        avatar = session_to_avatar.get(session_id)
-                        if avatar:
-                            appuser_id = row["user_id"]
-                            result[int(appuser_id)] = avatar
-
-        return result

--- a/src/wodplanner/services/schedule.py
+++ b/src/wodplanner/services/schedule.py
@@ -114,6 +114,47 @@ def _migrate_v100(conn: sqlite3.Connection) -> None:
 migrations.register(100, "create schedules table (with gym_id)", _migrate_v100)
 
 
+def _migrate_v807(conn: sqlite3.Connection) -> None:
+    """Recreate schedules — fix NULL gym_id (-> 0), add updated_at + index."""
+    if migrations.has_column(conn, "schedules", "updated_at"):
+        return
+    with migrations.fk_disabled(conn):
+        conn.execute("ALTER TABLE schedules RENAME TO schedules_old")
+        conn.execute(
+            """
+            CREATE TABLE schedules (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                gym_id INTEGER NOT NULL DEFAULT 0,
+                date DATE NOT NULL,
+                class_type TEXT NOT NULL,
+                warmup_mobility TEXT,
+                strength_specialty TEXT,
+                metcon TEXT,
+                raw_content TEXT,
+                source_file TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                UNIQUE(date, class_type, gym_id)
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO schedules
+                (id, gym_id, date, class_type, warmup_mobility, strength_specialty,
+                 metcon, raw_content, source_file, created_at, updated_at)
+            SELECT id, COALESCE(gym_id, 0), date, class_type, warmup_mobility, strength_specialty,
+                   metcon, raw_content, source_file, created_at, created_at
+            FROM schedules_old
+            """
+        )
+        conn.execute("DROP TABLE schedules_old")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_schedules_date_gym ON schedules(date, gym_id)")
+
+
+migrations.register(807, "recreate schedules (gym_id NOT NULL, updated_at)", _migrate_v807)
+
+
 class ScheduleService(BaseService):
     """Service for managing workout schedules with SQLite storage."""
 
@@ -133,21 +174,23 @@ class ScheduleService(BaseService):
         )
 
     def _execute_add(self, conn: sqlite3.Connection, schedule: Schedule) -> int | None:
+        now = datetime.now().isoformat()
+        gym_id = schedule.gym_id if schedule.gym_id is not None else 0
         cursor = conn.execute(
             """
             INSERT INTO schedules
-            (gym_id, date, class_type, warmup_mobility, strength_specialty, metcon, raw_content, source_file, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            (gym_id, date, class_type, warmup_mobility, strength_specialty, metcon, raw_content, source_file, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(date, class_type, gym_id) DO UPDATE SET
                 warmup_mobility = excluded.warmup_mobility,
                 strength_specialty = excluded.strength_specialty,
                 metcon = excluded.metcon,
                 raw_content = excluded.raw_content,
                 source_file = excluded.source_file,
-                created_at = excluded.created_at
+                updated_at = excluded.updated_at
             """,
             (
-                schedule.gym_id,
+                gym_id,
                 schedule.date.isoformat(),
                 schedule.class_type,
                 schedule.warmup_mobility,
@@ -155,7 +198,8 @@ class ScheduleService(BaseService):
                 schedule.metcon,
                 schedule.raw_content,
                 schedule.source_file,
-                datetime.now().isoformat(),
+                now,
+                now,
             ),
         )
         return cursor.lastrowid
@@ -184,7 +228,7 @@ class ScheduleService(BaseService):
             placeholders = ",".join("?" * len(aliases))
             if gym_id is not None:
                 row = conn.execute(
-                    f"SELECT * FROM schedules WHERE date = ? AND class_type IN ({placeholders}) AND (gym_id = ? OR gym_id IS NULL)",
+                    f"SELECT * FROM schedules WHERE date = ? AND class_type IN ({placeholders}) AND (gym_id = ? OR gym_id = 0)",
                     (schedule_date.isoformat(), *aliases, gym_id),
                 ).fetchone()
             else:
@@ -202,7 +246,7 @@ class ScheduleService(BaseService):
         with self._get_connection() as conn:
             if gym_id is not None:
                 rows = conn.execute(
-                    "SELECT * FROM schedules WHERE date = ? AND (gym_id = ? OR gym_id IS NULL) ORDER BY class_type",
+                    "SELECT * FROM schedules WHERE date = ? AND (gym_id = ? OR gym_id = 0) ORDER BY class_type",
                     (schedule_date.isoformat(), gym_id),
                 ).fetchall()
             else:
@@ -211,10 +255,6 @@ class ScheduleService(BaseService):
                     (schedule_date.isoformat(),),
                 ).fetchall()
             return [self._row_to_model(row) for row in rows]
-
-    def find_for_appointment(self, appointment_name: str, appointment_date: date, gym_id: int | None = None) -> Schedule | None:
-        """Find a schedule that matches an appointment name and date."""
-        return self.get_by_date_and_class(appointment_date, appointment_name, gym_id=gym_id)
 
     def get_all_for_date(self, schedule_date: date, gym_id: int | None = None) -> dict[str, Schedule]:
         """All schedules for a date, keyed by every known alias — O(1) lookup by API class name."""

--- a/src/wodplanner/services/subscription_tracker.py
+++ b/src/wodplanner/services/subscription_tracker.py
@@ -53,6 +53,46 @@ migrations.register(
     _migrate_v701,
 )
 
+
+def _migrate_v806(conn: sqlite3.Connection) -> None:
+    """Recreate subscription_events with FK to users (keeps indexes, no soft-delete)."""
+    if migrations.has_fk_to(conn, "subscription_events", "users"):
+        return
+    with migrations.fk_disabled(conn):
+        conn.execute("ALTER TABLE subscription_events RENAME TO subscription_events_old")
+        conn.execute(
+            """
+            CREATE TABLE subscription_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                appointment_id INTEGER NOT NULL,
+                class_name TEXT NOT NULL,
+                event_type TEXT NOT NULL CHECK(event_type IN ('subscribe', 'unsubscribe')),
+                class_date TEXT NOT NULL,
+                class_end TEXT,
+                created_at TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO subscription_events
+                (id, user_id, appointment_id, class_name, event_type, class_date, class_end, created_at)
+            SELECT id, user_id, appointment_id, class_name, event_type, class_date, class_end, created_at
+            FROM subscription_events_old
+            """
+        )
+        conn.execute("DROP TABLE subscription_events_old")
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_sub_events_user_date ON subscription_events(user_id, class_date)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_sub_events_user_appt ON subscription_events(user_id, appointment_id)"
+        )
+
+
+migrations.register(806, "recreate subscription_events with FK to users", _migrate_v806)
+
 class SubscriptionTrackerService(BaseService):
     def record_subscribe(
         self, user_id: int, appointment_id: int, class_name: str, class_date: date,

--- a/src/wodplanner/services/users.py
+++ b/src/wodplanner/services/users.py
@@ -1,0 +1,218 @@
+"""User service — single source of truth for user identity.
+
+The `users` table replaces the user-scoped columns previously stored in the
+`preferences` table (my_appuser_id, tracking_disabled, avatar_filename) and is
+referenced by every user-scoped table. Rows are created lazily on the first
+authenticated request (see `dependencies.require_session`), then kept fresh by
+the upsert that runs on every request.
+"""
+
+import json
+import sqlite3
+from datetime import datetime
+
+from wodplanner.models.user import User
+from wodplanner.services import migrations
+from wodplanner.services.base import BaseService
+from wodplanner.utils.dates import parse_iso_datetime
+
+
+def _user_scoped_tables() -> list[tuple[str, str]]:
+    return [
+        ("preferences", "user_id"),
+        ("one_rep_maxes", "user_id"),
+        ("benchmark_results", "user_id"),
+        ("subscription_events", "user_id"),
+        ("friends", "owner_user_id"),
+    ]
+
+
+def _migrate_v800(conn: sqlite3.Connection) -> None:
+    """Create users table."""
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY,
+            appuser_id INTEGER UNIQUE,
+            gym_id INTEGER,
+            display_name TEXT,
+            avatar_filename TEXT,
+            tracking_disabled INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+
+
+def _user_pref(conn: sqlite3.Connection, user_id: int, key: str) -> str | None:
+    row = conn.execute(
+        "SELECT value FROM preferences WHERE user_id = ? AND key = ?", (user_id, key)
+    ).fetchone()
+    return row[0] if row else None
+
+
+def _migrate_v801(conn: sqlite3.Connection) -> None:
+    """Populate users from existing user-scoped tables; clean migrated prefs."""
+    user_ids: set[int] = set()
+    for table, column in _user_scoped_tables():
+        if migrations.table_exists(conn, table):
+            rows = conn.execute(
+                f"SELECT DISTINCT {column} FROM {table} WHERE {column} IS NOT NULL"
+            ).fetchall()
+            user_ids.update(int(row[0]) for row in rows if row[0] is not None)
+
+    now = datetime.now().isoformat()
+    for user_id in user_ids:
+        appuser_id_raw = _user_pref(conn, user_id, "my_appuser_id")
+        appuser_id = int(appuser_id_raw) if appuser_id_raw else None
+        tracking_raw = _user_pref(conn, user_id, "tracking_disabled")
+        tracking_disabled = 1 if tracking_raw and json.loads(tracking_raw) else 0
+        avatar = _user_pref(conn, user_id, "avatar_filename")
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO users
+                (id, appuser_id, gym_id, display_name, avatar_filename,
+                 tracking_disabled, created_at, updated_at)
+            VALUES (?, ?, NULL, NULL, ?, ?, ?, ?)
+            """,
+            (user_id, appuser_id, avatar, tracking_disabled, now, now),
+        )
+
+    conn.execute(
+        "DELETE FROM preferences WHERE key IN ('my_appuser_id', 'tracking_disabled', 'avatar_filename')"
+    )
+
+
+def _migrate_v802(conn: sqlite3.Connection) -> None:
+    """Recreate preferences with FK to users (keeps only UI settings)."""
+    if migrations.has_fk_to(conn, "preferences", "users") and migrations.has_column(
+        conn, "preferences", "value"
+    ):
+        return
+    with migrations.fk_disabled(conn):
+        conn.execute("ALTER TABLE preferences RENAME TO preferences_old")
+        conn.execute(
+            """
+            CREATE TABLE preferences (
+                user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                key TEXT NOT NULL,
+                value TEXT NOT NULL,
+                PRIMARY KEY (user_id, key)
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO preferences (user_id, key, value)
+            SELECT user_id, key, value FROM preferences_old
+            """
+        )
+        conn.execute("DROP TABLE preferences_old")
+
+
+migrations.register(800, "create users table", _migrate_v800)
+migrations.register(801, "populate users from existing data", _migrate_v801)
+migrations.register(802, "recreate preferences with FK to users", _migrate_v802)
+
+
+class UserService(BaseService):
+    """SQLite-backed user identity storage."""
+
+    def _row_to_model(self, row: sqlite3.Row) -> User:
+        return User(
+            id=row["id"],
+            appuser_id=row["appuser_id"],
+            gym_id=row["gym_id"],
+            display_name=row["display_name"],
+            avatar_filename=row["avatar_filename"],
+            tracking_disabled=bool(row["tracking_disabled"]),
+            created_at=parse_iso_datetime(row["created_at"]),
+            updated_at=parse_iso_datetime(row["updated_at"]),
+        )
+
+    def upsert(
+        self, user_id: int, appuser_id: int | None, gym_id: int | None, display_name: str | None
+    ) -> None:
+        """Insert or refresh a user from session data.
+
+        Updates appuser_id, gym_id, and display_name on every call, but never
+        overwrites the user-managed tracking_disabled or avatar_filename.
+        """
+        now = datetime.now().isoformat()
+        with self._get_connection() as conn:
+            conn.execute(
+                """
+                INSERT INTO users
+                    (id, appuser_id, gym_id, display_name, tracking_disabled,
+                     created_at, updated_at)
+                VALUES (?, ?, ?, ?, 0, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    appuser_id = excluded.appuser_id,
+                    gym_id = excluded.gym_id,
+                    display_name = excluded.display_name,
+                    updated_at = excluded.updated_at
+                """,
+                (user_id, appuser_id, gym_id, display_name, now, now),
+            )
+            conn.commit()
+
+    def get(self, user_id: int) -> User | None:
+        with self._get_connection() as conn:
+            row = conn.execute("SELECT * FROM users WHERE id = ?", (user_id,)).fetchone()
+        return self._row_to_model(row) if row else None
+
+    def get_avatar_filename(self, user_id: int) -> str | None:
+        with self._get_connection() as conn:
+            row = conn.execute(
+                "SELECT avatar_filename FROM users WHERE id = ?", (user_id,)
+            ).fetchone()
+        return row[0] if row else None
+
+    def get_avatar_filenames_by_appuser_ids(
+        self, appuser_ids: list[int]
+    ) -> dict[int, str | None]:
+        if not appuser_ids:
+            return {}
+        with self._get_connection() as conn:
+            placeholders = ",".join("?" * len(appuser_ids))
+            rows = conn.execute(
+                f"SELECT appuser_id, avatar_filename FROM users WHERE appuser_id IN ({placeholders})",
+                appuser_ids,
+            ).fetchall()
+        result: dict[int, str | None] = {}
+        for row in rows:
+            if row["avatar_filename"]:
+                result[row["appuser_id"]] = row["avatar_filename"]
+        return result
+
+    def is_tracking_disabled(self, user_id: int) -> bool:
+        with self._get_connection() as conn:
+            row = conn.execute(
+                "SELECT tracking_disabled FROM users WHERE id = ?", (user_id,)
+            ).fetchone()
+        return bool(row[0]) if row else False
+
+    def set_tracking_disabled(self, user_id: int, disabled: bool) -> None:
+        with self._get_connection() as conn:
+            conn.execute(
+                "UPDATE users SET tracking_disabled = ?, updated_at = ? WHERE id = ?",
+                (int(disabled), datetime.now().isoformat(), user_id),
+            )
+            conn.commit()
+
+    def set_avatar_filename(self, user_id: int, filename: str) -> None:
+        with self._get_connection() as conn:
+            conn.execute(
+                "UPDATE users SET avatar_filename = ?, updated_at = ? WHERE id = ?",
+                (filename, datetime.now().isoformat(), user_id),
+            )
+            conn.commit()
+
+    def delete_avatar_filename(self, user_id: int) -> None:
+        with self._get_connection() as conn:
+            conn.execute(
+                "UPDATE users SET avatar_filename = NULL, updated_at = ? WHERE id = ?",
+                (datetime.now().isoformat(), user_id),
+            )
+            conn.commit()

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -14,6 +14,7 @@ from wodplanner.app.dependencies import (
     get_one_rep_max_service,
     get_preferences_service,
     get_schedule_service,
+    get_user_service,
 )
 from wodplanner.models.auth import AuthSession
 from wodplanner.services import session as cookie_session
@@ -23,6 +24,7 @@ from wodplanner.services.login_limiter import limiter
 from wodplanner.services.one_rep_max import OneRepMaxService
 from wodplanner.services.preferences import PreferencesService
 from wodplanner.services.schedule import ScheduleService
+from wodplanner.services.users import UserService
 
 
 def _clear_dep_caches() -> None:
@@ -33,6 +35,7 @@ def _clear_dep_caches() -> None:
         get_one_rep_max_service,
         get_benchmark_service,
         get_api_cache_service,
+        get_user_service,
     ):
         fn.cache_clear()
 
@@ -46,6 +49,17 @@ def _isolate_dependency_caches(monkeypatch, db_path):
     yield
     _clear_dep_caches()
     limiter._state.clear()
+
+
+@pytest.fixture(autouse=True)
+def _create_auth_user(db_path, auth_session):
+    """Ensure the authenticated user (id 42) exists as an FK parent."""
+    UserService(db_path).upsert(
+        user_id=auth_session.user_id,
+        appuser_id=auth_session.appuser_id,
+        gym_id=auth_session.gym_id,
+        display_name=auth_session.firstname,
+    )
 
 
 @pytest.fixture
@@ -120,6 +134,11 @@ def schedule_service(db_path) -> ScheduleService:
 @pytest.fixture
 def preferences_service(db_path) -> PreferencesService:
     return PreferencesService(db_path)
+
+
+@pytest.fixture
+def user_service(db_path) -> UserService:
+    return UserService(db_path)
 
 
 @pytest.fixture

--- a/tests/app/routers/test_views.py
+++ b/tests/app/routers/test_views.py
@@ -295,8 +295,8 @@ class TestPeopleModal:
         assert response.status_code == 200
         assert "Alice" in response.text
 
-    def test_self_discovery_via_name_match(self, app_client, mock_wodapp_client, preferences_service):
-        # session firstname "User" matches one member exactly → should set my_appuser_id
+    def test_self_discovery_via_name_match(self, app_client, mock_wodapp_client, user_service):
+        # session firstname "User" matches one member exactly → should set appuser_id
         from wodplanner.app.config import settings
         from wodplanner.models.auth import AuthSession
         from wodplanner.services import session as cookie_session
@@ -322,7 +322,7 @@ class TestPeopleModal:
             params={"date_start": "2026-04-25 10:00", "date_end": "2026-04-25 11:00"},
         )
         assert response.status_code == 200
-        assert preferences_service.get_my_appuser_id(77) == 8888
+        assert user_service.get(77).appuser_id == 8888
 
 
 class TestAddFriendFromPeople:
@@ -748,8 +748,8 @@ class TestSettingsPage:
         response = app_client.get("/settings")
         assert response.status_code == 200
 
-    def test_shows_tracking_state(self, app_client, session_cookie, preferences_service):
-        preferences_service.set_tracking_disabled(42, True)
+    def test_shows_tracking_state(self, app_client, session_cookie, user_service):
+        user_service.set_tracking_disabled(42, True)
         app_client.cookies.set("session", session_cookie)
         response = app_client.get("/settings")
         assert response.status_code == 200
@@ -771,24 +771,24 @@ class TestSettingsToggleFilter:
 
 
 class TestToggleTracking:
-    def test_disable_tracking(self, app_client, session_cookie, preferences_service):
+    def test_disable_tracking(self, app_client, session_cookie, user_service):
         app_client.cookies.set("session", session_cookie)
         response = app_client.post("/settings/toggle-tracking", data={"enable": "false", "delete_data": "false"})
         assert response.status_code == 200
-        assert preferences_service.is_tracking_disabled(42) is True
+        assert user_service.is_tracking_disabled(42) is True
 
-    def test_enable_tracking(self, app_client, session_cookie, preferences_service):
-        preferences_service.set_tracking_disabled(42, True)
+    def test_enable_tracking(self, app_client, session_cookie, user_service):
+        user_service.set_tracking_disabled(42, True)
         app_client.cookies.set("session", session_cookie)
         response = app_client.post("/settings/toggle-tracking", data={"enable": "true", "delete_data": "false"})
         assert response.status_code == 200
-        assert preferences_service.is_tracking_disabled(42) is False
+        assert user_service.is_tracking_disabled(42) is False
 
-    def test_disable_with_delete(self, app_client, session_cookie, preferences_service):
+    def test_disable_with_delete(self, app_client, session_cookie, user_service):
         app_client.cookies.set("session", session_cookie)
         response = app_client.post("/settings/toggle-tracking", data={"enable": "false", "delete_data": "true"})
         assert response.status_code == 200
-        assert preferences_service.is_tracking_disabled(42) is True
+        assert user_service.is_tracking_disabled(42) is True
 
 
 class TestDeleteTrackingData:
@@ -823,7 +823,7 @@ class TestBenchmarkPage:
 
 
 class TestUploadAvatar:
-    def test_upload_success(self, app_client, session_cookie, monkeypatch, tmp_path, preferences_service):
+    def test_upload_success(self, app_client, session_cookie, monkeypatch, tmp_path, user_service):
         upload_path = tmp_path / "avatars"
         monkeypatch.setattr("wodplanner.app.routers.views._UPLOAD_DIR", upload_path)
 
@@ -839,7 +839,7 @@ class TestUploadAvatar:
             )
         assert response.status_code == 303
         assert response.headers["location"] == "/friends"
-        assert preferences_service.get_avatar_filename(42) == "avatar_42.png"
+        assert user_service.get_avatar_filename(42) == "avatar_42.png"
 
     def test_upload_invalid_extension(self, app_client, session_cookie):
         app_client.cookies.set("session", session_cookie)
@@ -907,8 +907,8 @@ class TestBenchmarkModalNotFound:
 
 
 class TestPeopleModalAvatar:
-    def test_my_avatar_included(self, app_client, session_cookie, mock_wodapp_client, preferences_service):
-        preferences_service.set_avatar_filename(42, "avatar_42.jpg")
+    def test_my_avatar_included(self, app_client, session_cookie, mock_wodapp_client, user_service):
+        user_service.set_avatar_filename(42, "avatar_42.jpg")
         details = _details()
         details.subscriptions.members = [
             Member(id_appuser=1, name="Alice", imageURL=""),

--- a/tests/cli/test_backup_db.py
+++ b/tests/cli/test_backup_db.py
@@ -54,6 +54,24 @@ class TestBackup:
         assert result.exists()
         assert backup_dir.exists()
 
+    def test_backup_with_fk_violation_is_discarded(self, tmp_path):
+        db_path = tmp_path / "broken.db"
+        backup_dir = tmp_path / "backups"
+
+        conn = sqlite3.connect(db_path)
+        conn.execute("CREATE TABLE parent (id INTEGER PRIMARY KEY)")
+        conn.execute(
+            "CREATE TABLE child (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id))"
+        )
+        conn.execute("INSERT INTO child VALUES (1, 99)")  # orphan parent_id
+        conn.commit()
+        conn.close()
+
+        result = backup(db_path, backup_dir)
+
+        assert not result.exists()
+        assert len(list(backup_dir.glob("wodplanner_*.db"))) == 0
+
 
 class TestRotate:
     def test_rotate_keeps_all_when_under_limit(self, tmp_path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,21 @@ def db_path(tmp_path):
 
 
 @pytest.fixture
+def make_user(db_path):
+    """Create users in the `users` table (FK parents for user-scoped inserts)."""
+    from wodplanner.services.users import UserService
+
+    svc = UserService(db_path)
+
+    def _make(*user_ids: int):
+        for uid in user_ids:
+            svc.upsert(user_id=uid, appuser_id=None, gym_id=uid, display_name=str(uid))
+        return svc
+
+    return _make
+
+
+@pytest.fixture
 def clean_registry():
     """Save and restore the migration registry so test-only registrations don't leak."""
     original = list(migrations._registry)

--- a/tests/services/test_benchmark.py
+++ b/tests/services/test_benchmark.py
@@ -249,7 +249,8 @@ class TestBenchmarkResultModel:
 
 
 class TestBenchmarkResultService:
-    def test_add_and_get_results(self, db_path):
+    def test_add_and_get_results(self, db_path, make_user):
+        make_user(1)
         svc = BenchmarkService(db_path)
         svc.add_result(user_id=1, benchmark_name="Fran", time_seconds=180, is_rx=True, recorded_at="2026-05-05")
         results = svc.get_results_for_benchmark(user_id=1, benchmark_name="Fran")
@@ -257,7 +258,8 @@ class TestBenchmarkResultService:
         assert results[0].time_seconds == 180
         assert results[0].is_rx is True
 
-    def test_results_ordered_by_date_desc(self, db_path):
+    def test_results_ordered_by_date_desc(self, db_path, make_user):
+        make_user(1)
         svc = BenchmarkService(db_path)
         svc.add_result(user_id=1, benchmark_name="Fran", time_seconds=300, is_rx=True, recorded_at="2026-05-04")
         svc.add_result(user_id=1, benchmark_name="Fran", time_seconds=180, is_rx=True, recorded_at="2026-05-05")
@@ -265,13 +267,15 @@ class TestBenchmarkResultService:
         assert results[0].recorded_at == "2026-05-05"
         assert results[1].recorded_at == "2026-05-04"
 
-    def test_scoped_by_user(self, db_path):
+    def test_scoped_by_user(self, db_path, make_user):
+        make_user(1, 2)
         svc = BenchmarkService(db_path)
         svc.add_result(user_id=1, benchmark_name="Fran", time_seconds=180, is_rx=True, recorded_at="2026-05-05")
         results = svc.get_results_for_benchmark(user_id=2, benchmark_name="Fran")
         assert len(results) == 0
 
-    def test_scoped_by_benchmark_name(self, db_path):
+    def test_scoped_by_benchmark_name(self, db_path, make_user):
+        make_user(1)
         svc = BenchmarkService(db_path)
         svc.add_result(user_id=1, benchmark_name="Fran", time_seconds=180, is_rx=True, recorded_at="2026-05-05")
         svc.add_result(user_id=1, benchmark_name="Helen", time_seconds=600, is_rx=True, recorded_at="2026-05-05")
@@ -279,27 +283,31 @@ class TestBenchmarkResultService:
         assert len(results) == 1
         assert results[0].benchmark_name == "Fran"
 
-    def test_delete_result(self, db_path):
+    def test_delete_result(self, db_path, make_user):
+        make_user(1)
         svc = BenchmarkService(db_path)
         r = svc.add_result(user_id=1, benchmark_name="Fran", time_seconds=180, is_rx=True, recorded_at="2026-05-05")
         svc.delete_result(user_id=1, result_id=r.id)
         results = svc.get_results_for_benchmark(user_id=1, benchmark_name="Fran")
         assert len(results) == 0
 
-    def test_delete_scoped_by_user(self, db_path):
+    def test_delete_scoped_by_user(self, db_path, make_user):
+        make_user(1, 2)
         svc = BenchmarkService(db_path)
         r = svc.add_result(user_id=1, benchmark_name="Fran", time_seconds=180, is_rx=True, recorded_at="2026-05-05")
         svc.delete_result(user_id=2, result_id=r.id)
         results = svc.get_results_for_benchmark(user_id=1, benchmark_name="Fran")
         assert len(results) == 1
 
-    def test_add_result_returns_model_with_id(self, db_path):
+    def test_add_result_returns_model_with_id(self, db_path, make_user):
+        make_user(1)
         svc = BenchmarkService(db_path)
         r = svc.add_result(user_id=1, benchmark_name="Fran", time_seconds=180, is_rx=True, recorded_at="2026-05-05")
         assert r.id is not None
         assert r.user_id == 1
 
-    def test_update_result(self, db_path):
+    def test_update_result(self, db_path, make_user):
+        make_user(1)
         svc = BenchmarkService(db_path)
         r = svc.add_result(user_id=1, benchmark_name="Fran", time_seconds=180, is_rx=True, recorded_at="2026-05-05")
         updated = svc.update_result(user_id=1, result_id=r.id, benchmark_name="Helen", time_seconds=240, is_rx=False, recorded_at="2026-06-01")
@@ -312,7 +320,8 @@ class TestBenchmarkResultService:
         assert result.is_rx is False
         assert result.recorded_at == "2026-06-01"
 
-    def test_update_result_scoped_by_user(self, db_path):
+    def test_update_result_scoped_by_user(self, db_path, make_user):
+        make_user(1, 2)
         svc = BenchmarkService(db_path)
         r = svc.add_result(user_id=1, benchmark_name="Fran", time_seconds=180, is_rx=True, recorded_at="2026-05-05")
         updated = svc.update_result(user_id=2, result_id=r.id, benchmark_name="Helen", time_seconds=240, is_rx=False, recorded_at="2026-06-01")

--- a/tests/services/test_friends.py
+++ b/tests/services/test_friends.py
@@ -2,7 +2,8 @@ from wodplanner.services.friends import FriendsService
 
 
 class TestFriendsService:
-    def test_add_and_get(self, db_path):
+    def test_add_and_get(self, db_path, make_user):
+        make_user(1)
         svc = FriendsService(db_path)
         f = svc.add(owner_user_id=1, appuser_id=100, name="Alice")
         assert f.id is not None
@@ -12,24 +13,28 @@ class TestFriendsService:
         assert fetched is not None
         assert fetched.name == "Alice"
 
-    def test_get_scoped_to_owner(self, db_path):
+    def test_get_scoped_to_owner(self, db_path, make_user):
+        make_user(1, 2)
         svc = FriendsService(db_path)
         f = svc.add(owner_user_id=1, appuser_id=200, name="Bob")
         assert svc.get(owner_user_id=2, friend_id=f.id) is None
 
-    def test_get_by_appuser_id(self, db_path):
+    def test_get_by_appuser_id(self, db_path, make_user):
+        make_user(1)
         svc = FriendsService(db_path)
         svc.add(owner_user_id=1, appuser_id=300, name="Carol")
         fetched = svc.get_by_appuser_id(owner_user_id=1, appuser_id=300)
         assert fetched is not None
         assert fetched.name == "Carol"
 
-    def test_get_by_appuser_id_wrong_owner(self, db_path):
+    def test_get_by_appuser_id_wrong_owner(self, db_path, make_user):
+        make_user(1, 2)
         svc = FriendsService(db_path)
         svc.add(owner_user_id=1, appuser_id=400, name="Dave")
         assert svc.get_by_appuser_id(owner_user_id=2, appuser_id=400) is None
 
-    def test_get_all_scoped(self, db_path):
+    def test_get_all_scoped(self, db_path, make_user):
+        make_user(10, 20)
         svc = FriendsService(db_path)
         svc.add(owner_user_id=10, appuser_id=1, name="Alice")
         svc.add(owner_user_id=10, appuser_id=2, name="Bob")
@@ -38,43 +43,50 @@ class TestFriendsService:
         results = svc.get_all(owner_user_id=10)
         assert {f.name for f in results} == {"Alice", "Bob"}
 
-    def test_upsert_updates_name(self, db_path):
+    def test_upsert_updates_name(self, db_path, make_user):
+        make_user(1)
         svc = FriendsService(db_path)
         svc.add(owner_user_id=1, appuser_id=500, name="Old Name")
         svc.add(owner_user_id=1, appuser_id=500, name="New Name")
         fetched = svc.get_by_appuser_id(owner_user_id=1, appuser_id=500)
         assert fetched.name == "New Name"
 
-    def test_get_appuser_ids(self, db_path):
+    def test_get_appuser_ids(self, db_path, make_user):
+        make_user(1, 2)
         svc = FriendsService(db_path)
         svc.add(owner_user_id=1, appuser_id=601, name="Alice")
         svc.add(owner_user_id=1, appuser_id=602, name="Bob")
         svc.add(owner_user_id=2, appuser_id=603, name="Carol")
         assert svc.get_appuser_ids(owner_user_id=1) == {601, 602}
 
-    def test_delete(self, db_path):
+    def test_delete(self, db_path, make_user):
+        make_user(1)
         svc = FriendsService(db_path)
         f = svc.add(owner_user_id=1, appuser_id=700, name="Eve")
         assert svc.delete(owner_user_id=1, friend_id=f.id) is True
         assert svc.get(owner_user_id=1, friend_id=f.id) is None
 
-    def test_delete_wrong_owner_returns_false(self, db_path):
+    def test_delete_wrong_owner_returns_false(self, db_path, make_user):
+        make_user(1, 2)
         svc = FriendsService(db_path)
         f = svc.add(owner_user_id=1, appuser_id=800, name="Frank")
         assert svc.delete(owner_user_id=2, friend_id=f.id) is False
 
-    def test_delete_by_appuser_id(self, db_path):
+    def test_delete_by_appuser_id(self, db_path, make_user):
+        make_user(1)
         svc = FriendsService(db_path)
         svc.add(owner_user_id=1, appuser_id=900, name="Grace")
         assert svc.delete_by_appuser_id(owner_user_id=1, appuser_id=900) is True
         assert svc.get_by_appuser_id(owner_user_id=1, appuser_id=900) is None
 
-    def test_delete_by_appuser_id_wrong_owner(self, db_path):
+    def test_delete_by_appuser_id_wrong_owner(self, db_path, make_user):
+        make_user(1, 2)
         svc = FriendsService(db_path)
         svc.add(owner_user_id=1, appuser_id=1000, name="Heidi")
         assert svc.delete_by_appuser_id(owner_user_id=2, appuser_id=1000) is False
 
-    def test_cross_user_isolation_get_all(self, db_path):
+    def test_cross_user_isolation_get_all(self, db_path, make_user):
+        make_user(1, 99)
         svc = FriendsService(db_path)
         svc.add(owner_user_id=1, appuser_id=50, name="User50")
         assert svc.get_all(owner_user_id=99) == []

--- a/tests/services/test_friends_migration.py
+++ b/tests/services/test_friends_migration.py
@@ -1,9 +1,9 @@
-"""Tests for friends._migrate_v200 ALTER branch (legacy schema migration)."""
+"""Tests for friends legacy-schema migration (v200 ALTER + full v800+ cascade)."""
 
 import sqlite3
 
 from wodplanner.services import migrations
-from wodplanner.services.friends import FriendsService, _migrate_v200
+from wodplanner.services.friends import FriendsService
 
 
 class TestFriendsMigrationAlter:
@@ -27,14 +27,12 @@ class TestFriendsMigrationAlter:
             (123, "OldFriend", "2026-04-25T10:00:00"),
         )
         conn.commit()
-
-        # Run migration
-        _migrate_v200(conn)
-        conn.commit()
         conn.close()
 
-        # Confirm new schema + row preserved with owner_user_id=0
+        # Run the full migration set (v200 ALTER + v800-v809 migrate-and-recreate).
         migrations._reset_for_tests()
+        migrations.ensure_migrations(db)
+
         svc = FriendsService(db)
         rows = svc.get_all(owner_user_id=0)
         assert len(rows) == 1

--- a/tests/services/test_one_rep_max.py
+++ b/tests/services/test_one_rep_max.py
@@ -141,7 +141,8 @@ class TestOneRepMaxService:
         result = svc.match_exercise("xyznonexistent")
         assert result is None
 
-    def test_add_and_get_1rm(self, db_path):
+    def test_add_and_get_1rm(self, db_path, make_user):
+        make_user(1)
         from datetime import date
 
         svc = OneRepMaxService(db_path)
@@ -152,7 +153,8 @@ class TestOneRepMaxService:
         results = svc.get_all(user_id=1)
         assert len(results) == 1
 
-    def test_get_for_exercise(self, db_path):
+    def test_get_for_exercise(self, db_path, make_user):
+        make_user(1)
         from datetime import date
 
         svc = OneRepMaxService(db_path)
@@ -163,7 +165,8 @@ class TestOneRepMaxService:
         results = svc.get_for_exercise(user_id=1, exercise="Back Squat")
         assert len(results) == 2
 
-    def test_get_max_for_exercise(self, db_path):
+    def test_get_max_for_exercise(self, db_path, make_user):
+        make_user(1)
         from datetime import date
 
         svc = OneRepMaxService(db_path)
@@ -178,7 +181,8 @@ class TestOneRepMaxService:
         max_weight = svc.get_max_for_exercise(user_id=1, exercise="Nonexistent")
         assert max_weight is None
 
-    def test_delete(self, db_path):
+    def test_delete(self, db_path, make_user):
+        make_user(1)
         from datetime import date
 
         svc = OneRepMaxService(db_path)
@@ -189,7 +193,8 @@ class TestOneRepMaxService:
         results = svc.get_all(user_id=1)
         assert len(results) == 0
 
-    def test_delete_wrong_user_returns_false(self, db_path):
+    def test_delete_wrong_user_returns_false(self, db_path, make_user):
+        make_user(1)
         from datetime import date
 
         svc = OneRepMaxService(db_path)
@@ -197,7 +202,8 @@ class TestOneRepMaxService:
         deleted = svc.delete(user_id=999, entry_id=entry.id)
         assert deleted is False
 
-    def test_get_by_id(self, db_path):
+    def test_get_by_id(self, db_path, make_user):
+        make_user(1)
         from datetime import date
 
         svc = OneRepMaxService(db_path)
@@ -212,7 +218,8 @@ class TestOneRepMaxService:
         found = svc.get_by_id(user_id=1, entry_id=99999)
         assert found is None
 
-    def test_get_by_id_wrong_user(self, db_path):
+    def test_get_by_id_wrong_user(self, db_path, make_user):
+        make_user(1)
         from datetime import date
 
         svc = OneRepMaxService(db_path)
@@ -220,7 +227,8 @@ class TestOneRepMaxService:
         found = svc.get_by_id(user_id=999, entry_id=entry.id)
         assert found is None
 
-    def test_update(self, db_path):
+    def test_update(self, db_path, make_user):
+        make_user(1)
         from datetime import date
 
         svc = OneRepMaxService(db_path)
@@ -234,7 +242,8 @@ class TestOneRepMaxService:
         assert updated_entry.weight_kg == 110.0
         assert updated_entry.recorded_at == date(2026, 2, 1)
 
-    def test_update_wrong_user_returns_false(self, db_path):
+    def test_update_wrong_user_returns_false(self, db_path, make_user):
+        make_user(1)
         from datetime import date
 
         svc = OneRepMaxService(db_path)

--- a/tests/services/test_preferences.py
+++ b/tests/services/test_preferences.py
@@ -3,85 +3,71 @@ from wodplanner.services.preferences import PreferencesService
 
 
 class TestPreferencesService:
-    def test_get_hidden_class_types_empty_by_default(self, db_path):
+    def test_get_hidden_class_types_empty_by_default(self, db_path, make_user):
+        make_user(1)
         svc = PreferencesService(db_path)
         assert svc.get_hidden_class_types(user_id=1) == []
 
-    def test_set_hidden_class_types(self, db_path):
+    def test_set_hidden_class_types(self, db_path, make_user):
+        make_user(1)
         svc = PreferencesService(db_path)
         svc.set_hidden_class_types(user_id=1, types=["CrossFit", "Olympic Lifting"])
         assert svc.get_hidden_class_types(user_id=1) == ["CrossFit", "Olympic Lifting"]
 
-    def test_toggle_hidden_class_type_add(self, db_path):
+    def test_toggle_hidden_class_type_add(self, db_path, make_user):
+        make_user(1)
         svc = PreferencesService(db_path)
         result = svc.toggle_hidden_class_type(user_id=1, class_type="CrossFit")
         assert "CrossFit" in result
         assert svc.get_hidden_class_types(user_id=1) == ["CrossFit"]
 
-    def test_toggle_hidden_class_type_remove(self, db_path):
+    def test_toggle_hidden_class_type_remove(self, db_path, make_user):
+        make_user(1)
         svc = PreferencesService(db_path)
         svc.set_hidden_class_types(user_id=1, types=["CrossFit", "Gymnastics"])
         result = svc.toggle_hidden_class_type(user_id=1, class_type="CrossFit")
         assert "CrossFit" not in result
         assert result == ["Gymnastics"]
 
-    def test_toggle_hidden_class_type_empty_to_non_empty(self, db_path):
+    def test_toggle_hidden_class_type_empty_to_non_empty(self, db_path, make_user):
+        make_user(1)
         svc = PreferencesService(db_path)
         svc.toggle_hidden_class_type(user_id=1, class_type="Oly")
         svc.toggle_hidden_class_type(user_id=1, class_type="CrossFit")
         assert svc.get_hidden_class_types(user_id=1) == ["Oly", "CrossFit"]
 
-    def test_get_dismissed_tooltips_empty_by_default(self, db_path):
+    def test_get_dismissed_tooltips_empty_by_default(self, db_path, make_user):
+        make_user(1)
         svc = PreferencesService(db_path)
         assert svc.get_dismissed_tooltips(user_id=1) == []
 
-    def test_dismiss_tooltip_adds(self, db_path):
+    def test_dismiss_tooltip_adds(self, db_path, make_user):
+        make_user(1)
         svc = PreferencesService(db_path)
         svc.dismiss_tooltip(user_id=1, tooltip_id="welcome_banner")
         assert "welcome_banner" in svc.get_dismissed_tooltips(user_id=1)
 
-    def test_dismiss_tooltip_no_duplicates(self, db_path):
+    def test_dismiss_tooltip_no_duplicates(self, db_path, make_user):
+        make_user(1)
         svc = PreferencesService(db_path)
         svc.dismiss_tooltip(user_id=1, tooltip_id="welcome_banner")
         svc.dismiss_tooltip(user_id=1, tooltip_id="welcome_banner")
         assert svc.get_dismissed_tooltips(user_id=1).count("welcome_banner") == 1
 
-    def test_get_all_returns_complete_preferences(self, db_path):
-        svc = PreferencesService(db_path)
-        svc.set_hidden_class_types(user_id=1, types=["CrossFit"])
-        svc.dismiss_tooltip(user_id=1, tooltip_id="tip1")
-        prefs = svc.get_all(user_id=1)
-        assert prefs.hidden_class_types == ["CrossFit"]
-
-    def test_user_isolation(self, db_path):
+    def test_user_isolation(self, db_path, make_user):
+        make_user(1, 2)
         svc = PreferencesService(db_path)
         svc.set_hidden_class_types(user_id=1, types=["CrossFit"])
         svc.set_hidden_class_types(user_id=2, types=["Gymnastics"])
         assert svc.get_hidden_class_types(user_id=1) == ["CrossFit"]
         assert svc.get_hidden_class_types(user_id=2) == ["Gymnastics"]
 
-    def test_tracking_disabled_default_false(self, db_path):
+    def test_reset_tooltips(self, db_path, make_user):
+        make_user(1)
         svc = PreferencesService(db_path)
-        assert svc.is_tracking_disabled(user_id=1) is False
-
-    def test_set_tracking_disabled(self, db_path):
-        svc = PreferencesService(db_path)
-        svc.set_tracking_disabled(user_id=1, disabled=True)
-        assert svc.is_tracking_disabled(user_id=1) is True
-        svc.set_tracking_disabled(user_id=1, disabled=False)
-        assert svc.is_tracking_disabled(user_id=1) is False
-
-    def test_tracking_disabled_in_get_all(self, db_path):
-        svc = PreferencesService(db_path)
-        svc.set_tracking_disabled(user_id=1, disabled=True)
-        prefs = svc.get_all(user_id=1)
-        assert prefs.tracking_disabled is True
-
-    def test_tracking_disabled_user_isolation(self, db_path):
-        svc = PreferencesService(db_path)
-        svc.set_tracking_disabled(user_id=1, disabled=True)
-        assert svc.is_tracking_disabled(user_id=1) is True
-        assert svc.is_tracking_disabled(user_id=2) is False
+        svc.dismiss_tooltip(user_id=1, tooltip_id="tip1")
+        svc.reset_tooltips(user_id=1)
+        assert svc.get_dismissed_tooltips(user_id=1) == []
 
     def test_migration_from_old_schema(self, tmp_path, clean_registry):
         import sqlite3

--- a/tests/services/test_subscription_tracker.py
+++ b/tests/services/test_subscription_tracker.py
@@ -6,31 +6,36 @@ from wodplanner.services.subscription_tracker import SubscriptionTrackerService
 
 
 class TestRecordSubscribe:
-    def test_records_subscribe(self, db_path):
+    def test_records_subscribe(self, db_path, make_user):
+        make_user(1)
         svc = SubscriptionTrackerService(db_path)
         svc.record_subscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=date(2026, 6, 1))
         assert svc.has_any_events(1)
         assert not svc.has_any_events(2)
 
-    def test_records_any_class_type(self, db_path):
+    def test_records_any_class_type(self, db_path, make_user):
+        make_user(1)
         svc = SubscriptionTrackerService(db_path)
         svc.record_subscribe(user_id=1, appointment_id=10, class_name="Yoga", class_date=date(2026, 6, 1))
         assert svc.has_any_events(1)
 
 
 class TestRecordUnsubscribe:
-    def test_records_unsubscribe(self, db_path):
+    def test_records_unsubscribe(self, db_path, make_user):
+        make_user(1)
         svc = SubscriptionTrackerService(db_path)
         svc.record_subscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=date(2026, 6, 1))
         svc.record_unsubscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=date(2026, 6, 1))
         assert svc.has_any_events(1)
 
-    def test_ignores_unsubscribe_without_prior_subscribe(self, db_path):
+    def test_ignores_unsubscribe_without_prior_subscribe(self, db_path, make_user):
+        make_user(1)
         svc = SubscriptionTrackerService(db_path)
         svc.record_unsubscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=date(2026, 6, 1))
         assert not svc.has_any_events(1)
 
-    def test_sub_then_unsub_net_zero_for_week(self, db_path):
+    def test_sub_then_unsub_net_zero_for_week(self, db_path, make_user):
+        make_user(1)
         svc = SubscriptionTrackerService(db_path)
         svc.record_subscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=date(2026, 6, 1))
         svc.record_unsubscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=date(2026, 6, 1))
@@ -43,7 +48,8 @@ class TestRecordUnsubscribe:
 
 
 class TestWeeklyCounts:
-    def test_single_past_session(self, db_path):
+    def test_single_past_session(self, db_path, make_user):
+        make_user(1)
         svc = SubscriptionTrackerService(db_path)
         svc.record_subscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=date(2026, 5, 1))
         weekly = svc.get_weekly_counts(user_id=1, weeks=52)
@@ -54,7 +60,8 @@ class TestWeeklyCounts:
                 assert w["future"] == 0
                 break
 
-    def test_multiple_sessions_same_week(self, db_path):
+    def test_multiple_sessions_same_week(self, db_path, make_user):
+        make_user(1)
         svc = SubscriptionTrackerService(db_path)
         svc.record_subscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=date(2026, 5, 4))
         svc.record_subscribe(user_id=1, appointment_id=11, class_name="CrossFit", class_date=date(2026, 5, 6))
@@ -65,13 +72,15 @@ class TestWeeklyCounts:
                 assert w["past"] == 2
                 break
 
-    def test_returns_52_weeks(self, db_path):
+    def test_returns_52_weeks(self, db_path, make_user):
+        make_user(1)
         svc = SubscriptionTrackerService(db_path)
         svc.record_subscribe(user_id=1, appointment_id=1, class_name="CrossFit", class_date=date(2026, 1, 1))
         weekly = svc.get_weekly_counts(user_id=1, weeks=52)
         assert len(weekly) == 52
 
-    def test_user_scoping(self, db_path):
+    def test_user_scoping(self, db_path, make_user):
+        make_user(1, 2)
         svc = SubscriptionTrackerService(db_path)
         svc.record_subscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=date(2026, 5, 1))
         svc.record_subscribe(user_id=2, appointment_id=11, class_name="CrossFit", class_date=date(2026, 5, 2))
@@ -88,7 +97,8 @@ class TestWeeklyCounts:
                 assert w["past"] == 1
                 break
 
-    def test_pre_existing_unsubscribe_ignored(self, db_path):
+    def test_pre_existing_unsubscribe_ignored(self, db_path, make_user):
+        make_user(1)
         svc = SubscriptionTrackerService(db_path)
         svc.record_unsubscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=date(2026, 7, 12))
         svc.record_subscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=date(2026, 7, 12))
@@ -102,7 +112,8 @@ class TestWeeklyCounts:
 
 
 class TestCurrentWeekStats:
-    def test_returns_counts(self, db_path):
+    def test_returns_counts(self, db_path, make_user):
+        make_user(1)
         svc = SubscriptionTrackerService(db_path)
         today = date.today()
         svc.record_subscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=today)
@@ -115,7 +126,8 @@ class TestAveragePerWeek:
         svc = SubscriptionTrackerService(db_path)
         assert svc.get_average_per_week(1) == 0.0
 
-    def test_one_week_one_session(self, db_path):
+    def test_one_week_one_session(self, db_path, make_user):
+        make_user(1)
         svc = SubscriptionTrackerService(db_path)
         past_date = date.today() - timedelta(days=10)
         svc.record_subscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=past_date)
@@ -128,7 +140,8 @@ class TestWeeksTracked:
         svc = SubscriptionTrackerService(db_path)
         assert svc.get_weeks_tracked(1) == 0
 
-    def test_counts_distinct_weeks(self, db_path):
+    def test_counts_distinct_weeks(self, db_path, make_user):
+        make_user(1)
         svc = SubscriptionTrackerService(db_path)
         past = date.today() - timedelta(days=30)
         svc.record_subscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=past)
@@ -137,7 +150,8 @@ class TestWeeksTracked:
 
 
 class TestDeleteAllForUser:
-    def test_deletes_all_events_for_user(self, db_path):
+    def test_deletes_all_events_for_user(self, db_path, make_user):
+        make_user(1, 2)
         svc = SubscriptionTrackerService(db_path)
         svc.record_subscribe(user_id=1, appointment_id=10, class_name="CrossFit", class_date=date(2026, 6, 1))
         svc.record_subscribe(user_id=1, appointment_id=11, class_name="CrossFit", class_date=date(2026, 6, 2))
@@ -146,7 +160,8 @@ class TestDeleteAllForUser:
         assert not svc.has_any_events(1)
         assert svc.has_any_events(2)
 
-    def test_noop_when_no_data(self, db_path):
+    def test_noop_when_no_data(self, db_path, make_user):
+        make_user(1)
         svc = SubscriptionTrackerService(db_path)
         svc.delete_all_for_user(user_id=1)
         assert not svc.has_any_events(1)

--- a/tests/services/test_users_migration.py
+++ b/tests/services/test_users_migration.py
@@ -1,0 +1,323 @@
+"""End-to-end migration tests for the v800-v809 database redesign.
+
+Simulates a production DB with the pre-redesign schema (all tables + data from
+the 100-701 migrations) and verifies that applying v800-v809 preserves data and
+installs the new constraints.
+"""
+
+import sqlite3
+
+import pytest
+
+from wodplanner.services import migrations
+from wodplanner.services.users import UserService
+
+_OLD_VERSIONS = [100, 200, 300, 400, 401, 600, 601, 602, 700, 701]
+
+
+def _build_old_schema(path) -> None:
+    """Create the pre-redesign schema with representative data and mark the old
+    migrations as already applied so only v800+ run."""
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE preferences (
+            user_id INTEGER NOT NULL DEFAULT 0,
+            key TEXT NOT NULL,
+            value TEXT NOT NULL,
+            PRIMARY KEY (user_id, key)
+        );
+        CREATE TABLE friends (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            owner_user_id INTEGER NOT NULL DEFAULT 0,
+            appuser_id INTEGER NOT NULL,
+            name TEXT NOT NULL,
+            added_at TEXT NOT NULL,
+            UNIQUE(owner_user_id, appuser_id)
+        );
+        CREATE TABLE exercises (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL UNIQUE,
+            created_at TEXT NOT NULL
+        );
+        CREATE TABLE one_rep_maxes (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            exercise TEXT NOT NULL,
+            weight_kg REAL NOT NULL,
+            recorded_at TEXT NOT NULL,
+            notes TEXT,
+            created_at TEXT NOT NULL
+        );
+        CREATE TABLE benchmark_wods (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL UNIQUE,
+            category TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        );
+        CREATE TABLE benchmark_results (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            benchmark_name TEXT NOT NULL,
+            time_seconds INTEGER NOT NULL,
+            is_rx INTEGER NOT NULL DEFAULT 1,
+            recorded_at TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        );
+        CREATE TABLE subscription_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            appointment_id INTEGER NOT NULL,
+            class_name TEXT NOT NULL,
+            event_type TEXT NOT NULL CHECK(event_type IN ('subscribe', 'unsubscribe')),
+            class_date TEXT NOT NULL,
+            class_end TEXT,
+            created_at TEXT NOT NULL
+        );
+        CREATE INDEX idx_sub_events_user_date ON subscription_events(user_id, class_date);
+        CREATE INDEX idx_sub_events_user_appt ON subscription_events(user_id, appointment_id);
+        CREATE TABLE schedules (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            gym_id INTEGER,
+            date DATE NOT NULL,
+            class_type TEXT NOT NULL,
+            warmup_mobility TEXT,
+            strength_specialty TEXT,
+            metcon TEXT,
+            raw_content TEXT,
+            source_file TEXT,
+            created_at TEXT NOT NULL,
+            UNIQUE(date, class_type, gym_id)
+        );
+        CREATE TABLE schema_migrations (
+            version INTEGER PRIMARY KEY,
+            description TEXT NOT NULL,
+            applied_at TEXT NOT NULL
+        );
+        """
+    )
+    conn.executemany(
+        "INSERT INTO schema_migrations (version, description, applied_at) VALUES (?, 'old', '2026-01-01T00:00:00')",
+        [(v,) for v in _OLD_VERSIONS],
+    )
+    conn.executemany(
+        "INSERT INTO preferences (user_id, key, value) VALUES (?, ?, ?)",
+        [
+            (77, "hidden_class_types", '["CrossFit"]'),
+            (77, "dismissed_tooltips", '["welcome"]'),
+            (77, "my_appuser_id", "8888"),
+            (77, "tracking_disabled", "true"),
+            (77, "avatar_filename", "ava_77.png"),
+        ],
+    )
+    conn.execute(
+        "INSERT INTO friends (owner_user_id, appuser_id, name, added_at) VALUES (77, 111, 'Alice', '2026-01-01T00:00:00')"
+    )
+    conn.execute(
+        "INSERT INTO exercises (name, created_at) VALUES ('Back Squat', '2026-01-01T00:00:00')"
+    )
+    conn.execute(
+        """
+        INSERT INTO one_rep_maxes (user_id, exercise, weight_kg, recorded_at, notes, created_at)
+        VALUES (77, 'Back Squat', 120.5, '2026-01-02', 'pr', '2026-01-02T00:00:00')
+        """
+    )
+    conn.execute(
+        "INSERT INTO benchmark_wods (name, category, created_at) VALUES ('Fran', 'The Girls', '2026-01-01T00:00:00')"
+    )
+    conn.execute(
+        """
+        INSERT INTO benchmark_results (user_id, benchmark_name, time_seconds, is_rx, recorded_at, created_at)
+        VALUES (77, 'Fran', 360, 1, '2026-01-02', '2026-01-02T00:00:00')
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO subscription_events (user_id, appointment_id, class_name, event_type, class_date, class_end, created_at)
+        VALUES (77, 501, 'CrossFit', 'subscribe', '2026-01-05', NULL, '2026-01-05T00:00:00')
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO schedules (gym_id, date, class_type, warmup_mobility, strength_specialty, metcon, raw_content, source_file, created_at)
+        VALUES (NULL, '2026-01-01', 'CrossFit', NULL, NULL, 'AMRAP', NULL, 'Bull_202601.pdf', '2026-01-01T00:00:00')
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def migrated_db(tmp_path):
+    migrations._reset_for_tests()
+    path = tmp_path / "old.db"
+    _build_old_schema(path)
+    ran = migrations.ensure_migrations(path)
+    assert set(ran) == set(range(800, 810))
+    return path
+
+
+def _open(path):
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys=ON")
+    return conn
+
+
+def test_users_populated_from_existing_data(migrated_db):
+    with _open(migrated_db) as conn:
+        row = conn.execute("SELECT * FROM users WHERE id = 77").fetchone()
+    assert row is not None
+    assert row["appuser_id"] == 8888
+    assert row["tracking_disabled"] == 1
+    assert row["avatar_filename"] == "ava_77.png"
+    assert row["display_name"] is None
+    assert row["gym_id"] is None
+
+
+def test_migrated_keys_removed_from_preferences(migrated_db):
+    with _open(migrated_db) as conn:
+        keys = {r["key"] for r in conn.execute("SELECT key FROM preferences WHERE user_id = 77")}
+    assert keys == {"hidden_class_types", "dismissed_tooltips"}
+
+
+def test_user_scoped_tables_preserved_and_fk_installed(migrated_db):
+    with _open(migrated_db) as conn:
+        friends = conn.execute("SELECT * FROM friends").fetchone()
+        orm = conn.execute("SELECT * FROM one_rep_maxes").fetchone()
+        bmr = conn.execute("SELECT * FROM benchmark_results").fetchone()
+        evts = conn.execute("SELECT * FROM subscription_events").fetchone()
+        assert friends["owner_user_id"] == 77
+        assert orm["weight_kg"] == 120.5
+        assert bmr["time_seconds"] == 360
+        assert evts["appointment_id"] == 501
+
+
+def test_fk_to_users_present(migrated_db):
+    with _open(migrated_db) as conn:
+        for table in (
+            "preferences",
+            "friends",
+            "one_rep_maxes",
+            "benchmark_results",
+            "subscription_events",
+        ):
+            parents = [r["table"] for r in conn.execute(f"PRAGMA foreign_key_list({table})")]
+            assert "users" in parents, f"{table} should reference users"
+
+
+def test_soft_delete_columns_present(migrated_db):
+    with _open(migrated_db) as conn:
+        for table in ("friends", "one_rep_maxes", "benchmark_results", "exercises", "benchmark_wods"):
+            cols = [r[1] for r in conn.execute(f"PRAGMA table_info({table})")]
+            assert "deleted_at" in cols, f"{table} missing deleted_at"
+        for table in ("one_rep_maxes", "benchmark_results", "exercises", "benchmark_wods", "schedules"):
+            cols = [r[1] for r in conn.execute(f"PRAGMA table_info({table})")]
+            assert "updated_at" in cols, f"{table} missing updated_at"
+
+
+def test_schedules_gym_id_null_migrated_to_zero(migrated_db):
+    with _open(migrated_db) as conn:
+        row = conn.execute("SELECT * FROM schedules").fetchone()
+    assert row["gym_id"] == 0
+    assert row["updated_at"] is not None
+
+
+def test_fk_enforcement_unknown_user(migrated_db):
+    with _open(migrated_db) as conn:
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO one_rep_maxes (user_id, exercise, weight_kg, recorded_at, created_at, updated_at) VALUES (999, 'Back Squat', 1.0, '2026-01-01', 'x', 'x')"
+            )
+
+
+def test_fk_enforcement_unknown_exercise(migrated_db):
+    with _open(migrated_db) as conn:
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO one_rep_maxes (user_id, exercise, weight_kg, recorded_at, created_at, updated_at) VALUES (77, 'Does Not Exist', 1.0, '2026-01-01', 'x', 'x')"
+            )
+
+
+def test_check_constraint_negative_weight(migrated_db):
+    with _open(migrated_db) as conn:
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO one_rep_maxes (user_id, exercise, weight_kg, recorded_at, created_at, updated_at) VALUES (77, 'Back Squat', -5.0, '2026-01-01', 'x', 'x')"
+            )
+
+
+def test_on_delete_cascade_removes_user_data(migrated_db):
+    with _open(migrated_db) as conn:
+        conn.execute("DELETE FROM users WHERE id = 77")
+        conn.commit()
+        for table, col in (
+            ("preferences", "user_id"),
+            ("friends", "owner_user_id"),
+            ("one_rep_maxes", "user_id"),
+            ("benchmark_results", "user_id"),
+            ("subscription_events", "user_id"),
+        ):
+            count = conn.execute(
+                f"SELECT COUNT(*) AS c FROM {table} WHERE {col} = 77"
+            ).fetchone()["c"]
+            assert count == 0, f"{table} rows not cascaded"
+
+
+def test_on_update_cascade_renames_exercise(migrated_db):
+    with _open(migrated_db) as conn:
+        conn.execute("UPDATE exercises SET name = 'Back Squat 2.0' WHERE name = 'Back Squat'")
+        conn.commit()
+        orm = conn.execute("SELECT * FROM one_rep_maxes").fetchone()
+        assert orm["exercise"] == "Back Squat 2.0"
+
+
+class TestUserService:
+    def test_upsert_creates_row(self, db_path):
+        svc = UserService(db_path)
+        svc.upsert(user_id=1, appuser_id=42, gym_id=7, display_name="Bob")
+        u = svc.get(1)
+        assert u is not None
+        assert u.appuser_id == 42
+        assert u.gym_id == 7
+        assert u.display_name == "Bob"
+
+    def test_upsert_does_not_overwrite_tracking_or_avatar(self, db_path):
+        svc = UserService(db_path)
+        svc.upsert(user_id=1, appuser_id=42, gym_id=7, display_name="Bob")
+        svc.set_tracking_disabled(1, True)
+        svc.set_avatar_filename(1, "a.png")
+        created_after_first = svc.get(1).created_at
+        svc.upsert(user_id=1, appuser_id=99, gym_id=8, display_name="Robert")
+        u = svc.get(1)
+        assert u.tracking_disabled is True
+        assert u.avatar_filename == "a.png"
+        assert u.appuser_id == 99
+        assert u.gym_id == 8
+        assert u.created_at == created_after_first
+
+    def test_get_avatar_filenames_by_appuser_ids(self, db_path):
+        svc = UserService(db_path)
+        svc.upsert(user_id=5, appuser_id=100, gym_id=1, display_name="x")
+        svc.upsert(user_id=6, appuser_id=200, gym_id=1, display_name="y")
+        svc.set_avatar_filename(5, "five.png")
+        result = svc.get_avatar_filenames_by_appuser_ids([100, 200, 300])
+        assert result[100] == "five.png"
+        assert 200 not in result
+        assert 300 not in result
+
+    def test_tracking_disabled_roundtrip(self, db_path):
+        svc = UserService(db_path)
+        assert svc.is_tracking_disabled(1) is False
+        svc.upsert(user_id=1, appuser_id=42, gym_id=7, display_name="Bob")
+        svc.set_tracking_disabled(1, True)
+        assert svc.is_tracking_disabled(1) is True
+
+    def test_avatar_roundtrip(self, db_path):
+        svc = UserService(db_path)
+        svc.upsert(user_id=1, appuser_id=42, gym_id=7, display_name="Bob")
+        assert svc.get_avatar_filename(1) is None
+        svc.set_avatar_filename(1, "b.png")
+        assert svc.get_avatar_filename(1) == "b.png"
+        svc.delete_avatar_filename(1)
+        assert svc.get_avatar_filename(1) is None


### PR DESCRIPTION
## What
Introduces a `users` table as the single source of truth for user identity and migrates every user-scoped table to reference it.

## Changes
- **Migrations v800–v809**: create/populate `users`; recreate-and-copy `preferences`, `friends`, `one_rep_maxes`, `benchmark_results`, `subscription_events`, and `schedules` with FK → users, soft-delete (`deleted_at`), `updated_at`, CHECK constraints, and indexes. FK disabled during copy to preserve orphaned rows. Fixes `schedules.gym_id` NULL → 0.
- **New `UserService` + `User` model**; lazy upsert in `require_session` / `require_session_for_view`.
- **`PreferencesService`** reduced to UI settings; identity/tracking/avatar moved to `users`.
- Services filter `deleted_at IS NULL` and soft-delete instead of `DELETE`; `ScheduleService` keeps immutable `created_at` with `updated_at` on upsert.
- **`backup-db`** runs `integrity_check` + `foreign_key_check` and discards bad backups.
- Dead code removed; `docs/database.md` updated; migration tests added.

## Testing
- `pytest`: 605 passed, 33 deselected (e2e excluded by default)
- `ruff check .`: clean
- `mypy src`: clean

## Notes
- Web writes are covered by the lazy `users` upsert. CLI tools that write user-scoped rows (`seed-subscriptions`) now require the target user to exist in `users` (FK enforcement).
