### PR TITLE
fix: preserve appuser_id when upsert called with NULL

### DIFF
--- a/src/wodplanner/app/routers/views.py
+++ b/src/wodplanner/app/routers/views.py
@@ -985,11 +985,6 @@ def people_modal_view(
     participants = []
     all_user_ids = [m.id_appuser for m in members]
     avatar_map = user_service.get_avatar_filenames_by_appuser_ids(all_user_ids)
-    # Current user's avatar is stored under session.user_id, not appuser_id
-    if current_appuser_id and current_appuser_id not in avatar_map:
-        my_avatar = user_service.get_avatar_filename(session.user_id)
-        if my_avatar:
-            avatar_map[current_appuser_id] = my_avatar
     for member in members:
         participants.append({
             "id": member.id_appuser,

--- a/src/wodplanner/services/users.py
+++ b/src/wodplanner/services/users.py
@@ -136,8 +136,10 @@ class UserService(BaseService):
     ) -> None:
         """Insert or refresh a user from session data.
 
-        Updates appuser_id, gym_id, and display_name on every call, but never
-        overwrites the user-managed tracking_disabled or avatar_filename.
+        Updates gym_id and display_name on every call.  appuser_id is only
+        updated when a non-NULL value is provided, so a later request with a
+        NULL session appuser_id won't clobber a previously discovered Member ID.
+        Never overwrites the user-managed tracking_disabled or avatar_filename.
         """
         now = datetime.now().isoformat()
         with self._get_connection() as conn:
@@ -148,7 +150,7 @@ class UserService(BaseService):
                      created_at, updated_at)
                 VALUES (?, ?, ?, ?, 0, ?, ?)
                 ON CONFLICT(id) DO UPDATE SET
-                    appuser_id = excluded.appuser_id,
+                    appuser_id = COALESCE(excluded.appuser_id, users.appuser_id),
                     gym_id = excluded.gym_id,
                     display_name = excluded.display_name,
                     updated_at = excluded.updated_at

--- a/tests/app/routers/test_views.py
+++ b/tests/app/routers/test_views.py
@@ -324,6 +324,24 @@ class TestPeopleModal:
         assert response.status_code == 200
         assert user_service.get(77).appuser_id == 8888
 
+    def test_self_avatar_visible_via_appuser_id(self, app_client, session_cookie, mock_wodapp_client, user_service):
+        """Current user's avatar must appear in the modal without a workaround."""
+        user_service.set_avatar_filename(42, "avatar_42.png")
+        details = _details()
+        details.subscriptions.members = [
+            Member(id_appuser=4242, name="User", imageURL=""),
+            Member(id_appuser=1, name="Alice", imageURL=""),
+        ]
+        mock_wodapp_client.get_appointment_details.return_value = details
+
+        app_client.cookies.set("session", session_cookie)
+        response = app_client.get(
+            "/appointments/1/people",
+            params={"date_start": "2026-04-25 10:00", "date_end": "2026-04-25 11:00"},
+        )
+        assert response.status_code == 200
+        assert "avatar_42.png" in response.text
+
 
 class TestAddFriendFromPeople:
     def test_adds_and_returns_modal(self, app_client, session_cookie, mock_wodapp_client, friends_service):

--- a/tests/services/test_users_migration.py
+++ b/tests/services/test_users_migration.py
@@ -296,6 +296,14 @@ class TestUserService:
         assert u.gym_id == 8
         assert u.created_at == created_after_first
 
+    def test_upsert_preserves_appuser_id_when_null(self, db_path):
+        """appuser_id must not be overwritten with NULL (breaks friend avatar lookup)."""
+        svc = UserService(db_path)
+        svc.upsert(user_id=1, appuser_id=42, gym_id=7, display_name="Bob")
+        svc.upsert(user_id=1, appuser_id=None, gym_id=7, display_name="Bob")
+        u = svc.get(1)
+        assert u.appuser_id == 42
+
     def test_get_avatar_filenames_by_appuser_ids(self, db_path):
         svc = UserService(db_path)
         svc.upsert(user_id=5, appuser_id=100, gym_id=1, display_name="x")


### PR DESCRIPTION
UserService.upsert ran on every authenticated request with session.appuser_id, which is often None (WodApp login doesn't reliably return the Member ID). This clobbered the Member ID previously discovered via name-matching, making avatars invisible to friends (friend lookup uses WHERE appuser_id IN (...), and NULL never matches). Use COALESCE to keep the existing appuser_id when the new value is NULL.