### PR TITLE
refactor: remove avatar upload UI from friends page

### DIFF
--- a/src/wodplanner/app/routers/views.py
+++ b/src/wodplanner/app/routers/views.py
@@ -642,7 +642,6 @@ def friends_page(
     friends = friends_service.get_all(session.user_id)
     friend_user_ids = [f.appuser_id for f in friends]
     avatar_map = user_service.get_avatar_filenames_by_appuser_ids(friend_user_ids)
-    my_avatar = user_service.get_avatar_filename(session.user_id)
 
     friends_data = [
         {
@@ -663,7 +662,6 @@ def friends_page(
             "active_page": "friends",
             "friends": friends_data,
             "friend_count": len(friends_data),
-            "my_avatar": my_avatar,
             **get_user_context(session),
         },
     )

--- a/src/wodplanner/app/static/css/style.css
+++ b/src/wodplanner/app/static/css/style.css
@@ -2526,11 +2526,8 @@ body {
     white-space: nowrap;
 }
 
-/* Friend avatar section (self upload) */
+/* Friend avatar section */
 .friend-avatar-section {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
     margin-bottom: 1.25rem;
     padding: 1rem 1.25rem;
     background: white;
@@ -2568,46 +2565,7 @@ body {
         border-radius: 50%;
     }
 
-    .friend-avatar-self-img,
-    .friend-avatar-img,
-    .person-avatar-img {
-        cursor: pointer;
-    }
-
-    .friend-avatar-upload {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-}
-
-.friend-avatar-label {
-    font-size: 0.8125rem;
-    font-weight: 600;
-    color: var(--gray-700);
-}
-
-.upload-btn {
-    position: relative;
-    cursor: pointer;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.375rem;
-}
-
-.upload-input {
-    position: absolute;
-    inset: 0;
-    opacity: 0;
-    cursor: pointer;
-}
-
-.remove-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.375rem;
-}
-
-/* Empty state with icon */
+    /* Empty state with icon */
 .empty-state-icon {
     color: var(--gray-300);
     margin-bottom: 0.75rem;

--- a/src/wodplanner/app/templates/friends.html
+++ b/src/wodplanner/app/templates/friends.html
@@ -10,33 +10,7 @@
 
 <div class="friend-avatar-section">
     <div class="friend-avatar-self">
-        {% if my_avatar %}
-        <img src="/uploads/avatars/{{ my_avatar }}" alt="Your avatar" class="friend-avatar-self-img">
-        {% else %}
         <span class="friend-avatar-self-initials">{{ user.firstname[:2].upper() }}</span>
-        {% endif %}
-    </div>
-    <div class="friend-avatar-upload">
-        <span class="friend-avatar-label">Your photo</span>
-        <form action="/avatar/upload" method="post" enctype="multipart/form-data" id="avatar-form">
-            <label class="btn btn-sm btn-secondary upload-btn">
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/>
-                </svg>
-                Upload
-                <input type="file" name="avatar" accept="image/jpeg,image/png,image/gif,image/webp" class="upload-input" onchange="document.getElementById('avatar-form').submit()">
-            </label>
-        </form>
-        {% if my_avatar %}
-        <form action="/avatar/remove" method="post" id="avatar-remove-form">
-            <button type="submit" class="btn btn-sm btn-danger remove-btn" onclick="return confirm('Remove your profile photo?')">
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
-                </svg>
-                Remove
-            </button>
-        </form>
-        {% endif %}
     </div>
 </div>
 


### PR DESCRIPTION
Removes the Upload/Remove photo section from the friends page — we no longer support photo uploads. The avatar circle now always shows the user's two-letter initials.