### PR TITLE
refactor: move user upsert from per-request deps to login-only

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -79,7 +79,7 @@ WAL mode is persistent (stored in DB file header) — set once on first connecti
 
 - **Soft deletes**: user-data and reference tables (`friends`, `one_rep_maxes`, `benchmark_results`, `exercises`, `benchmark_wods`) expose `deleted_at TEXT`. All SELECT queries filter `WHERE deleted_at IS NULL`; delete methods set `deleted_at` instead of issuing `DELETE`.
 - **Audit timestamps**: all tables carry `created_at` (immutable) and `updated_at` (set on every change), stored as ISO-8601 `TEXT`.
-- **Lazy population**: `users` rows are created/refreshed on every authenticated request via `dependencies.require_session` / `require_session_for_view` (`UserService.upsert`). This keeps `appuser_id`, `gym_id`, and `display_name` in sync with the session while never overwriting `tracking_disabled` or `avatar_filename`.
+- **Login-time creation**: `users` rows are created/updated at login time via `auth.login` (`UserService.upsert`). The `appuser_id` is later refined when the user's people modal discovers their ID via name-match. Never overwrites `tracking_disabled` or `avatar_filename`.
 
 
 ## Auth

--- a/src/wodplanner/app/dependencies.py
+++ b/src/wodplanner/app/dependencies.py
@@ -95,18 +95,7 @@ def require_session(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Not authenticated",
         )
-    _upsert_user(session)
     return session
-
-
-def _upsert_user(session: AuthSession) -> None:
-    """Lazily persist the user's identity from the session."""
-    get_user_service().upsert(
-        user_id=session.user_id,
-        appuser_id=session.appuser_id,
-        gym_id=session.gym_id,
-        display_name=session.firstname,
-    )
 
 
 def require_session_for_view(
@@ -134,7 +123,6 @@ def require_session_for_view(
             status_code=status.HTTP_303_SEE_OTHER,
             headers={"Location": "/login"},
         )
-    _upsert_user(session)
     return session
 
 

--- a/src/wodplanner/app/routers/auth.py
+++ b/src/wodplanner/app/routers/auth.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 
 from wodplanner.api.client import AuthenticationError, WodAppClient, WodAppError
 from wodplanner.app.config import settings
-from wodplanner.app.dependencies import require_session
+from wodplanner.app.dependencies import get_user_service, require_session
 from wodplanner.models.auth import AuthSession
 from wodplanner.services import session as cookie_session
 from wodplanner.services.login_limiter import limiter
@@ -71,6 +71,12 @@ def login(
         client.close()
 
         limiter.record_success(ip)
+        get_user_service().upsert(
+            user_id=auth_session.user_id,
+            appuser_id=auth_session.appuser_id,
+            gym_id=auth_session.gym_id,
+            display_name=auth_session.firstname,
+        )
         session_value = cookie_session.encode(auth_session, settings.secret_key)
 
         redirect = RedirectResponse(url="/", status_code=303)

--- a/src/wodplanner/services/users.py
+++ b/src/wodplanner/services/users.py
@@ -2,9 +2,9 @@
 
 The `users` table replaces the user-scoped columns previously stored in the
 `preferences` table (my_appuser_id, tracking_disabled, avatar_filename) and is
-referenced by every user-scoped table. Rows are created lazily on the first
-authenticated request (see `dependencies.require_session`), then kept fresh by
-the upsert that runs on every request.
+referenced by every user-scoped table. Rows are created at login time (see
+`auth.login`) and updated lazily when the user's `appuser_id` is discovered via
+the people modal.
 """
 
 import json
@@ -136,11 +136,23 @@ class UserService(BaseService):
     ) -> None:
         """Insert or refresh a user from session data.
 
+        Skips the write when no values have changed, avoiding unnecessary
+        SQLite write-lock contention on every request.
+
         Updates gym_id and display_name on every call.  appuser_id is only
         updated when a non-NULL value is provided, so a later request with a
         NULL session appuser_id won't clobber a previously discovered Member ID.
         Never overwrites the user-managed tracking_disabled or avatar_filename.
         """
+        existing = self.get(user_id)
+        if existing is not None:
+            resolved_appuser_id = appuser_id if appuser_id is not None else existing.appuser_id
+            if (
+                existing.display_name == display_name
+                and existing.gym_id == gym_id
+                and existing.appuser_id == resolved_appuser_id
+            ):
+                return
         now = datetime.now().isoformat()
         with self._get_connection() as conn:
             conn.execute(


### PR DESCRIPTION
Removes the per-request `_upsert_user` call from `require_session` and `require_session_for_view` (was hitting the DB on every authenticated request — ~40+ endpoints). The upsert now runs once at login time in `auth.login` instead.

Also adds a no-op check in `UserService.upsert` to skip writes when no values have changed, reducing SQLite write-lock contention when upsert IS called.

Closes out the optimization discussed in the session: from ~40 DB writes per page view to zero.