### PR TITLE
feat: replace datalist with bottom-sheet picker with fuzzy search

### DIFF
--- a/src/wodplanner/app/routers/views.py
+++ b/src/wodplanner/app/routers/views.py
@@ -1,5 +1,6 @@
 """HTML views for the web frontend."""
 
+import difflib
 import hashlib
 import io
 import json
@@ -175,6 +176,12 @@ try:
     templates.env.globals["css_version"] = hashlib.md5(_css_path.read_bytes()).hexdigest()[:8]
 except Exception:
     templates.env.globals["css_version"] = "1"
+
+_js_path = templates_dir.parent / "static" / "js" / "picker.js"
+try:
+    templates.env.globals["js_version"] = hashlib.md5(_js_path.read_bytes()).hexdigest()[:8]
+except Exception:
+    templates.env.globals["js_version"] = "1"
 
 try:
     templates.env.globals["app_version"] = settings.app_version
@@ -1131,7 +1138,11 @@ def add_one_rep_max_view(
     """Add a 1rm entry (htmx)."""
     exercise = exercise.strip()
     if not one_rep_max_service.validate_exercise(exercise):
-        raise HTTPException(status_code=422, detail=f"Unknown exercise: '{exercise}'.")
+        matched = one_rep_max_service.match_exercise(exercise)
+        if matched:
+            exercise = matched
+        else:
+            raise HTTPException(status_code=422, detail=f"Unknown exercise: '{exercise}'.")
     if not (0 < weight_kg < 1000):
         raise HTTPException(status_code=400, detail="Weight must be between 0 and 1000 kg.")
     try:
@@ -1222,7 +1233,11 @@ def update_one_rep_max_view(
     """Update a 1rm entry (htmx)."""
     exercise = exercise.strip()
     if not one_rep_max_service.validate_exercise(exercise):
-        raise HTTPException(status_code=422, detail=f"Unknown exercise: '{exercise}'.")
+        matched = one_rep_max_service.match_exercise(exercise)
+        if matched:
+            exercise = matched
+        else:
+            raise HTTPException(status_code=422, detail=f"Unknown exercise: '{exercise}'.")
     if not (0 < weight_kg < 1000):
         raise HTTPException(status_code=400, detail="Weight must be between 0 and 1000 kg.")
     try:
@@ -1306,13 +1321,22 @@ def add_benchmark_result_view(
     benchmark_service: BenchmarkService = Depends(get_benchmark_service),
 ):
     """Add a benchmark result (htmx)."""
+    benchmark_name = benchmark_name.strip()
     total_seconds = minutes * 60 + seconds
     if total_seconds <= 0:
         raise HTTPException(status_code=400, detail="Time must be greater than 0.")
 
+    benchmark_list = benchmark_service.get_benchmark_list()
+    if benchmark_name not in benchmark_list:
+        matched = difflib.get_close_matches(benchmark_name, benchmark_list, n=1, cutoff=0.6)
+        if matched:
+            benchmark_name = matched[0]
+        else:
+            raise HTTPException(status_code=422, detail=f"Unknown benchmark: '{benchmark_name}'.")
+
     benchmark_service.add_result(
         user_id=session.user_id,
-        benchmark_name=benchmark_name.strip(),
+        benchmark_name=benchmark_name,
         time_seconds=total_seconds,
         is_rx=is_rx == "true",
         recorded_at=recorded_at,
@@ -1395,14 +1419,23 @@ def update_benchmark_result_view(
     benchmark_service: BenchmarkService = Depends(get_benchmark_service),
 ):
     """Update a benchmark result (htmx)."""
+    benchmark_name = benchmark_name.strip()
     total_seconds = minutes * 60 + seconds
     if total_seconds <= 0:
         raise HTTPException(status_code=400, detail="Time must be greater than 0.")
 
+    benchmark_list = benchmark_service.get_benchmark_list()
+    if benchmark_name not in benchmark_list:
+        matched = difflib.get_close_matches(benchmark_name, benchmark_list, n=1, cutoff=0.6)
+        if matched:
+            benchmark_name = matched[0]
+        else:
+            raise HTTPException(status_code=422, detail=f"Unknown benchmark: '{benchmark_name}'.")
+
     benchmark_service.update_result(
         user_id=session.user_id,
         result_id=result_id,
-        benchmark_name=benchmark_name.strip(),
+        benchmark_name=benchmark_name,
         time_seconds=total_seconds,
         is_rx=is_rx == "true",
         recorded_at=recorded_at,

--- a/src/wodplanner/app/static/css/style.css
+++ b/src/wodplanner/app/static/css/style.css
@@ -561,6 +561,15 @@ body {
     margin-bottom: 1rem;
 }
 
+.card-header [data-picker-trigger] {
+    padding: 0.25rem 0.5rem;
+    font-size: 0.875rem;
+}
+
+.card-header .picker-wrapper {
+    min-width: 0;
+}
+
 .card-title {
     font-size: 1.125rem;
     font-weight: 600;
@@ -922,7 +931,8 @@ body {
         flex-direction: column;
     }
     .benchmark-form .form-group,
-    .benchmark-form .form-group-narrow {
+    .benchmark-form .form-group-narrow,
+    .benchmark-form .picker-wrapper {
         flex: 1;
         min-width: 0;
         width: 100%;
@@ -1373,6 +1383,228 @@ body {
 }
 
 /* Modal */
+/* Picker (constrained value selector) */
+.picker-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  flex: 1;
+  min-width: 140px;
+}
+
+.picker-label {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--gray-600);
+}
+
+.picker-trigger {
+  cursor: pointer;
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  appearance: none;
+  -webkit-appearance: none;
+  line-height: normal;
+  touch-action: manipulation;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.one-rm-form .picker-trigger,
+.benchmark-form .picker-trigger {
+  min-height: 38px;
+}
+
+.picker-trigger::after {
+  content: '';
+  float: right;
+  margin-top: 0.5rem;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 5px solid var(--gray-500);
+}
+
+.picker-trigger:focus {
+  outline: none;
+  border-color: var(--primary, #2563eb);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.picker-trigger.picker-error {
+  border-color: var(--danger, #dc2626);
+  box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.15);
+}
+
+.picker-hidden {
+  display: none;
+}
+
+.picker-sheet {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  align-items: flex-end;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.picker-sheet.open {
+  display: flex;
+}
+
+.picker-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.picker-panel {
+  position: relative;
+  width: 100%;
+  max-width: 480px;
+  max-height: 70svh;
+  max-height: 70dvh;
+  background: var(--card-bg, #fff);
+  border-radius: 16px 16px 0 0;
+  display: flex;
+  flex-direction: column;
+  transform: translateY(100%);
+  transition: transform 0.2s ease-out;
+}
+
+.picker-sheet.open .picker-panel {
+  transform: translateY(0);
+}
+
+.picker-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem 1.25rem 0.5rem;
+  border-bottom: 1px solid var(--border-color, #e2e8f0);
+  flex-shrink: 0;
+}
+
+.picker-search {
+  flex: 1;
+  border: 1px solid var(--input-border, #d1d5db);
+  border-radius: 8px;
+  padding: 0.6rem 0.75rem;
+  font-size: 16px;
+  font-family: inherit;
+  background: var(--input-bg, #f9fafb);
+  color: var(--input-text, #111827);
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.picker-search:focus {
+  border-color: var(--primary, #2563eb);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.picker-close {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--gray-500);
+  padding: 0.25rem;
+  flex-shrink: 0;
+}
+
+.picker-close:hover {
+  color: var(--gray-700);
+}
+
+.picker-list {
+  flex: 1;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 0.5rem 0.75rem;
+  -webkit-overflow-scrolling: touch;
+}
+
+.picker-group-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--gray-500);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.5rem 0.5rem 0.25rem;
+}
+
+.picker-option {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  padding: 0.625rem 0.75rem;
+  font-size: 0.9375rem;
+  font-family: inherit;
+  cursor: pointer;
+  border-radius: 6px;
+  color: var(--text-color, #1f2937);
+  min-height: 44px;
+  transition: background 0.1s;
+  touch-action: manipulation;
+}
+
+.picker-option:hover,
+.picker-option.highlighted {
+  background: var(--hover-bg, #f3f4f6);
+}
+
+.picker-option.selected {
+  background: var(--primary-light, #eff6ff);
+  font-weight: 600;
+  color: var(--primary, #2563eb);
+}
+
+.picker-empty {
+  text-align: center;
+  padding: 2rem 0.5rem;
+  color: var(--gray-500);
+  font-size: 0.875rem;
+}
+
+/* Desktop: show as centered dropdown instead of bottom sheet */
+@media (hover: hover) and (pointer: fine) {
+  .picker-sheet {
+    align-items: center;
+  }
+  .picker-panel {
+    max-width: 420px;
+    max-height: 60vh;
+    border-radius: 12px;
+    transform: scale(0.95);
+    opacity: 0;
+    transition: transform 0.15s ease-out, opacity 0.15s ease-out;
+  }
+  .picker-sheet.open .picker-panel {
+    transform: scale(1);
+    opacity: 1;
+  }
+  .picker-option {
+    min-height: 36px;
+    padding: 0.4rem 0.75rem;
+  }
+}
+
+/* Mobile: full-width bottom sheet with fixed height */
+@media (hover: none) and (pointer: coarse) {
+  .picker-panel {
+    max-width: none;
+    max-height: none;
+    border-radius: 16px 16px 0 0;
+    height: 85dvh;
+  }
+}
+
 .modal {
     display: none;
     position: fixed;
@@ -1722,7 +1954,8 @@ body {
     }
 
     .one-rm-form .form-group,
-    .one-rm-form .form-group-narrow {
+    .one-rm-form .form-group-narrow,
+    .one-rm-form .picker-wrapper {
         min-width: unset;
         flex: unset;
         width: auto;
@@ -2027,6 +2260,55 @@ body {
 
     .form-group label {
         color: #cbd5e1;
+    }
+
+    /* Picker */
+    .picker-panel {
+        background: #1e293b;
+    }
+
+    .picker-header {
+        border-color: #334155;
+    }
+
+    .picker-search {
+        background-color: #0f172a;
+        color: #f1f5f9;
+        border-color: #475569;
+    }
+
+    .picker-option {
+        color: #f1f5f9;
+    }
+
+    .picker-option:hover,
+    .picker-option.highlighted {
+        background: #334155;
+    }
+
+    .picker-option.selected {
+        background: #1e3a5f;
+        color: #60a5fa;
+    }
+
+    .picker-group-label {
+        color: #94a3b8;
+    }
+
+    .picker-close {
+        color: #94a3b8;
+    }
+
+    .picker-empty {
+        color: #94a3b8;
+    }
+
+    .picker-label {
+        color: #cbd5e1;
+    }
+
+    .picker-backdrop {
+        background: rgba(0, 0, 0, 0.6);
     }
 
     /* Modal */

--- a/src/wodplanner/app/static/js/picker.js
+++ b/src/wodplanner/app/static/js/picker.js
@@ -1,0 +1,292 @@
+(function() {
+  'use strict';
+
+  var isTouch = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+  var sheet, backdrop, panel, searchInput, listEl;
+
+  function init() {
+    sheet = document.getElementById('picker-sheet');
+    if (!sheet) return;
+    backdrop = sheet.querySelector('.picker-backdrop');
+    panel = sheet.querySelector('.picker-panel');
+    searchInput = sheet.querySelector('.picker-search');
+    listEl = sheet.querySelector('.picker-list');
+  }
+
+  var activeTrigger = null;
+  var activeOptions = [];
+  var activeRecent = [];
+
+  function normalize(s) {
+    return s.toLowerCase().replace(/[&.'\u2013\u2014-]+/g, '').trim();
+  }
+
+  function tokenize(s) {
+    return normalize(s).split(/\s+/).filter(Boolean);
+  }
+
+  function score(optName, queryTokens) {
+    var name = normalize(optName);
+    if (queryTokens.length === 0) return 0;
+    var queryStr = queryTokens.join(' ');
+    if (name === queryStr) return 1000;
+    if (name.startsWith(queryStr)) return 800;
+    if (name.indexOf(queryStr) !== -1) return 600;
+
+    var total = 300;
+    for (var i = 0; i < queryTokens.length; i++) {
+      var token = queryTokens[i];
+      var pos = name.indexOf(token);
+      if (pos === -1) {
+        var si = 0, matched = false;
+        for (var ci = 0; ci < token.length; ci++) {
+          si = name.indexOf(token[ci], si);
+          if (si === -1) break;
+          si++;
+          if (ci === token.length - 1) matched = true;
+        }
+        if (!matched) return 0;
+        total += token.length + 1;
+        continue;
+      }
+      total += 30 + token.length * 3;
+      total -= pos * 0.3;
+
+      var wordBoundary = pos === 0 || /[\s-]/.test(name[pos - 1]);
+      if (wordBoundary) total += 40;
+    }
+    return total;
+  }
+
+  function filterOptions(query) {
+    var tokens = tokenize(query);
+    if (tokens.length === 0) {
+      return { filtered: [], isRecent: true };
+    }
+    var scored = [];
+    for (var i = 0; i < activeOptions.length; i++) {
+      var s = score(activeOptions[i], tokens);
+      if (s > 0) {
+        scored.push({ name: activeOptions[i], score: s });
+      }
+    }
+    scored.sort(function(a, b) { return b.score - a.score; });
+    var seen = {};
+    var result = [];
+    for (var j = 0; j < scored.length; j++) {
+      if (!seen[scored[j].name]) {
+        seen[scored[j].name] = true;
+        result.push(scored[j].name);
+      }
+    }
+    return { filtered: result, isRecent: false };
+  }
+
+  function renderList(query) {
+    var result = filterOptions(query);
+    var items = result.filtered;
+
+    if (items.length === 0 && !result.isRecent) {
+      listEl.innerHTML = '<div class="picker-empty">No matches found</div>';
+      return;
+    }
+
+    var html = '';
+    if (result.isRecent && activeRecent.length > 0) {
+      html += '<div class="picker-group-label">Recent</div>';
+      for (var r = 0; r < activeRecent.length && r < 5; r++) {
+        html += '<button type="button" class="picker-option" data-value="' + attrEsc(activeRecent[r]) + '">' + escHtml(activeRecent[r]) + '</button>';
+      }
+      var remaining = [];
+      for (var o = 0; o < activeOptions.length; o++) {
+        if (activeRecent.indexOf(activeOptions[o]) === -1) {
+          remaining.push(activeOptions[o]);
+        }
+      }
+      if (remaining.length > 0) {
+        html += '<div class="picker-group-label">All exercises</div>';
+        for (var k = 0; k < remaining.length; k++) {
+          html += '<button type="button" class="picker-option" data-value="' + attrEsc(remaining[k]) + '">' + escHtml(remaining[k]) + '</button>';
+        }
+      }
+    } else {
+      for (var i = 0; i < items.length; i++) {
+        html += '<button type="button" class="picker-option" data-value="' + attrEsc(items[i]) + '">' + escHtml(items[i]) + '</button>';
+      }
+    }
+    listEl.innerHTML = html;
+  }
+
+  function attrEsc(s) {
+    return s.replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
+  function escHtml(s) {
+    return s.replace(/[<>&]/g, function(c) {
+      return c === '<' ? '&lt;' : c === '>' ? '&gt;' : '&amp;';
+    });
+  }
+
+  function openPicker(trigger) {
+    if (activeTrigger === trigger && sheet.classList.contains('open')) {
+      closePicker();
+      return;
+    }
+    activeTrigger = trigger;
+    try {
+      activeOptions = JSON.parse(trigger.getAttribute('data-options') || '[]');
+      activeRecent = JSON.parse(trigger.getAttribute('data-recent') || '[]');
+    } catch(e) {
+      activeOptions = [];
+      activeRecent = [];
+    }
+    searchInput.value = '';
+    renderList('');
+    sheet.classList.add('open');
+
+    var currentVal = trigger.textContent.trim();
+    if (currentVal && currentVal !== trigger.getAttribute('data-placeholder')) {
+      var selected = listEl.querySelector('[data-value="' + attrEsc(currentVal) + '"]');
+      if (selected) selected.classList.add('selected');
+    }
+
+    if (!isTouch) {
+      setTimeout(function() { searchInput.focus(); }, 200);
+    }
+  }
+
+  function closePicker() {
+    sheet.classList.remove('open');
+    if (activeTrigger) {
+      activeTrigger.focus();
+    }
+    activeTrigger = null;
+    activeOptions = [];
+    activeRecent = [];
+    searchInput.value = '';
+    listEl.innerHTML = '';
+  }
+
+  function selectOption(value) {
+    if (!activeTrigger) return;
+    var targetId = activeTrigger.getAttribute('data-target');
+    var hidden = document.getElementById(targetId);
+    if (!hidden) return;
+    hidden.value = value;
+    activeTrigger.textContent = value;
+    activeTrigger.classList.remove('picker-error');
+    var evtChange = document.createEvent('Event');
+    evtChange.initEvent('change', true, true);
+    hidden.dispatchEvent(evtChange);
+    var evtInput = document.createEvent('Event');
+    evtInput.initEvent('input', true, true);
+    hidden.dispatchEvent(evtInput);
+    closePicker();
+  }
+
+  function initSheetHandlers() {
+    if (!sheet) return;
+
+    sheet.addEventListener('click', function(e) {
+      var opt = e.target.closest('.picker-option');
+      if (opt && opt.dataset.value) {
+        e.preventDefault();
+        selectOption(opt.dataset.value);
+        return;
+      }
+      if (e.target.closest('.picker-backdrop')) {
+        closePicker();
+      }
+      if (e.target.closest('.picker-close')) {
+        closePicker();
+      }
+    });
+
+    searchInput.addEventListener('input', function() {
+      renderList(this.value);
+    });
+
+    searchInput.addEventListener('keydown', function(e) {
+      var items = listEl.querySelectorAll('.picker-option');
+      if (items.length === 0) return;
+      var current = listEl.querySelector('.picker-option.highlighted');
+      var idx = -1;
+      if (current) { idx = Array.prototype.indexOf.call(items, current); }
+
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        if (current) current.classList.remove('highlighted');
+        idx = Math.min(idx + 1, items.length - 1);
+        items[idx].classList.add('highlighted');
+        items[idx].scrollIntoView({ block: 'nearest' });
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        if (current) current.classList.remove('highlighted');
+        idx = Math.max(idx - 1, 0);
+        items[idx].classList.add('highlighted');
+        items[idx].scrollIntoView({ block: 'nearest' });
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (current && current.dataset.value) {
+          selectOption(current.dataset.value);
+        }
+      } else if (e.key === 'Escape') {
+        closePicker();
+      }
+    });
+
+    listEl.addEventListener('mouseover', function(e) {
+      var opt = e.target.closest('.picker-option');
+      if (!opt) return;
+      var highlighted = listEl.querySelector('.picker-option.highlighted');
+      if (highlighted) highlighted.classList.remove('highlighted');
+      opt.classList.add('highlighted');
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', function() {
+    init();
+    initSheetHandlers();
+  });
+
+  document.addEventListener('click', function(e) {
+    var trigger = e.target.closest('[data-picker-trigger]');
+    if (trigger) {
+      e.preventDefault();
+      openPicker(trigger);
+    }
+  });
+
+  document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape' && sheet && sheet.classList.contains('open')) {
+      closePicker();
+    }
+  });
+
+  document.addEventListener('htmx:beforeRequest', function(e) {
+    var form = e.target.closest('.one-rm-form, .benchmark-form');
+    if (!form) return;
+    var trigger = form.querySelector('[data-picker-trigger]');
+    if (!trigger) return;
+    var targetId = trigger.getAttribute('data-target');
+    var hidden = document.getElementById(targetId);
+    if (!hidden || !hidden.value.trim()) {
+      e.preventDefault();
+      trigger.classList.add('picker-error');
+      trigger.textContent = 'Please select an option';
+    }
+  });
+
+  document.addEventListener('htmx:afterSettle', function(e) {
+    var swapContent = e.detail.elt;
+    var trigger = swapContent.querySelector('[data-picker-trigger]');
+    if (!trigger) return;
+    var targetId = trigger.getAttribute('data-target');
+    var hidden = document.getElementById(targetId);
+    if (hidden && hidden.value) {
+      trigger.textContent = hidden.value;
+    } else {
+      trigger.textContent = trigger.getAttribute('data-placeholder') || 'Select…';
+    }
+  });
+})();

--- a/src/wodplanner/app/templates/base.html
+++ b/src/wodplanner/app/templates/base.html
@@ -13,6 +13,7 @@
     <link rel="manifest" href="/static/site.webmanifest">
     <script src="https://unpkg.com/htmx.org@1.9.10"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
+    <script src="/static/js/picker.js?v={{ js_version }}"></script>
 </head>
 <body>
     <nav class="navbar">
@@ -111,6 +112,18 @@
     <!-- Benchmark Modal -->
     <div id="benchmark-modal" class="modal">
         <div id="benchmark-modal-container"></div>
+    </div>
+
+    <!-- Constrained value picker (bottom-sheet) -->
+    <div id="picker-sheet" class="picker-sheet">
+        <div class="picker-backdrop"></div>
+        <div class="picker-panel">
+            <div class="picker-header">
+                <input type="search" class="picker-search" placeholder="Search…" autocomplete="off">
+                <button type="button" class="picker-close" aria-label="Close">&times;</button>
+            </div>
+            <div class="picker-list"></div>
+        </div>
     </div>
 
     <script>

--- a/src/wodplanner/app/templates/benchmark.html
+++ b/src/wodplanner/app/templates/benchmark.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "macros/picker.html" import picker %}
 
 {% block title %}Benchmark - WodPlanner{% endblock %}
 
@@ -18,22 +19,7 @@
               hx-swap="outerHTML"
               class="benchmark-form">
             <div class="form-row">
-                <div class="form-group">
-                    <label for="benchmark-name">Benchmark</label>
-                    <input type="text"
-                           id="benchmark-name"
-                           name="benchmark_name"
-                           list="benchmark-list"
-                           placeholder="Search benchmark…"
-                           required
-                           class="form-control"
-                           autocomplete="off">
-                    <datalist id="benchmark-list">
-                        {% for name in benchmark_list %}
-                        <option value="{{ name }}">
-                        {% endfor %}
-                    </datalist>
-                </div>
+                {{ picker("benchmark_name", benchmark_list, recent=benchmarks_by_recency, label="Benchmark") }}
                 <div class="form-group form-group-narrow">
                     <label for="benchmark-minutes">Minutes</label>
                     <input type="number"
@@ -43,7 +29,8 @@
                            max="999"
                            placeholder="0"
                            required
-                           class="form-control">
+                           class="form-control"
+                           inputmode="numeric">
                 </div>
                 <div class="form-group form-group-narrow">
                     <label for="benchmark-seconds">Seconds</label>
@@ -54,7 +41,8 @@
                            max="59"
                            placeholder="00"
                            required
-                           class="form-control">
+                           class="form-control"
+                           inputmode="numeric">
                 </div>
                 <div class="form-group form-group-narrow">
                     <label>RX / Scaled</label>
@@ -88,12 +76,9 @@
 <div class="card" style="margin-bottom: 1rem;">
     <div class="card-header">
         <span class="card-title">Progress</span>
-        <select id="benchmark-select" class="form-control form-control-inline" onchange="updateBenchmarkChart()">
-            <option value="">— Select benchmark —</option>
-            {% for name in benchmarks_by_recency %}
-            <option value="{{ name }}">{{ name }}</option>
-            {% endfor %}
-        </select>
+        <div style="flex:1;max-width:300px">
+            {{ picker("progress_benchmark", benchmark_list, recent=benchmarks_by_recency, placeholder="Select benchmark\u2026", id_suffix="bp") }}
+        </div>
     </div>
     <div class="benchmark-chart-container">
         <canvas id="benchmark-chart"></canvas>
@@ -127,11 +112,11 @@ function formatTime(seconds) {
 }
 
 function updateBenchmarkChart() {
-    var select = document.getElementById('benchmark-select');
+    var hidden = document.getElementById('picker-hidden-bp');
     var canvas = document.getElementById('benchmark-chart');
     var noData = document.getElementById('benchmark-no-data');
-    if (!select || !canvas) return;
-    var name = select.value;
+    if (!hidden || !canvas) return;
+    var name = hidden.value;
 
     if (!name || !__benchmarkData[name] || !__benchmarkData[name].length) {
         canvas.style.display = 'none';
@@ -211,10 +196,22 @@ function updateBenchmarkChart() {
 }
 
 document.addEventListener('DOMContentLoaded', function() {
-    var select = document.getElementById('benchmark-select');
-    if (select && select.options.length > 1) {
-        select.selectedIndex = 1;
-        updateBenchmarkChart();
+    var hidden = document.getElementById('picker-hidden-bp');
+    if (hidden) {
+        hidden.addEventListener('change', updateBenchmarkChart);
+        var options = __benchmarkData ? Object.keys(__benchmarkData).sort(function(a, b) {
+            var aLast = __benchmarkData[a][__benchmarkData[a].length - 1].date;
+            var bLast = __benchmarkData[b][__benchmarkData[b].length - 1].date;
+            return aLast < bLast ? 1 : aLast > bLast ? -1 : 0;
+        }) : [];
+        if (options.length > 0) {
+            hidden.value = options[0];
+            var trigger = document.querySelector('[data-target="picker-hidden-bp"]');
+            if (trigger) trigger.textContent = options[0];
+            updateBenchmarkChart();
+        } else {
+            document.getElementById('benchmark-chart').style.display = 'none';
+        }
     } else {
         document.getElementById('benchmark-chart').style.display = 'none';
     }
@@ -225,23 +222,17 @@ document.addEventListener('htmx:afterSwap', function(e) {
         var raw = document.getElementById('benchmark-history').dataset.benchmark;
         if (!raw) return;
         __benchmarkData = JSON.parse(raw);
-        var select = document.getElementById('benchmark-select');
-        if (!select) return;
-        var current = select.value;
-        select.innerHTML = '<option value="">— Select benchmark —</option>';
-        Object.keys(__benchmarkData)
-            .sort(function(a, b) {
-                var aLast = __benchmarkData[a][__benchmarkData[a].length - 1].date;
-                var bLast = __benchmarkData[b][__benchmarkData[b].length - 1].date;
-                return aLast < bLast ? 1 : aLast > bLast ? -1 : 0;
-            })
-            .forEach(function(name) {
-            var opt = document.createElement('option');
-            opt.value = name;
-            opt.textContent = name;
-            select.appendChild(opt);
+        var hidden = document.getElementById('picker-hidden-bp');
+        var trigger = document.querySelector('[data-target="picker-hidden-bp"]');
+        if (!hidden || !trigger) return;
+        var current = hidden.value;
+        var keys = Object.keys(__benchmarkData).sort(function(a, b) {
+            var aLast = __benchmarkData[a][__benchmarkData[a].length - 1].date;
+            var bLast = __benchmarkData[b][__benchmarkData[b].length - 1].date;
+            return aLast < bLast ? 1 : aLast > bLast ? -1 : 0;
         });
-        select.value = (__benchmarkData[current]) ? current : (Object.keys(__benchmarkData)[0] || '');
+        hidden.value = __benchmarkData[current] ? current : (keys[0] || '');
+        trigger.textContent = hidden.value || 'Select benchmark\u2026';
         updateBenchmarkChart();
     }
 });

--- a/src/wodplanner/app/templates/macros/picker.html
+++ b/src/wodplanner/app/templates/macros/picker.html
@@ -1,0 +1,18 @@
+{% macro picker(field_name, options, selected='', recent=[], label='', id_suffix='', placeholder='Select…') %}
+{% set uid = id_suffix if id_suffix else field_name %}
+<div class="picker-wrapper">
+  {% if label %}<label class="picker-label" for="picker-hidden-{{ uid }}">{{ label }}</label>{% endif %}
+  <input type="hidden"
+         id="picker-hidden-{{ uid }}"
+         name="{{ field_name }}"
+         value="{{ selected }}"
+         class="picker-hidden">
+  <button type="button"
+          class="form-control picker-trigger"
+          data-picker-trigger
+          data-target="picker-hidden-{{ uid }}"
+          data-placeholder="{{ placeholder }}"
+          data-options='{{ options | tojson | safe }}'
+          data-recent='{{ recent | tojson | safe }}'>{{ selected or placeholder }}</button>
+</div>
+{% endmacro %}

--- a/src/wodplanner/app/templates/one_rep_max.html
+++ b/src/wodplanner/app/templates/one_rep_max.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "macros/picker.html" import picker %}
 
 {% block title %}1RM - WodPlanner{% endblock %}
 
@@ -18,23 +19,7 @@
               hx-swap="outerHTML"
               class="one-rm-form">
             <div class="form-row">
-                <div class="form-group">
-                    <label for="1rm-exercise">Exercise</label>
-                    <input type="text"
-                           id="1rm-exercise"
-                           name="exercise"
-                           list="exercise-list"
-                           placeholder="Search exercise…"
-                           value="{{ default_exercise }}"
-                           required
-                           class="form-control"
-                           autocomplete="off">
-                    <datalist id="exercise-list">
-                        {% for ex in exercises %}
-                        <option value="{{ ex }}">
-                        {% endfor %}
-                    </datalist>
-                </div>
+                {{ picker("exercise", exercises, selected=default_exercise, recent=exercises_by_recency, label="Exercise") }}
                 <div class="form-group form-group-narrow">
                     <label for="1rm-weight">Weight (kg)</label>
                     <input type="number"
@@ -45,7 +30,8 @@
                            step="0.5"
                            placeholder="100"
                            required
-                           class="form-control">
+                           class="form-control"
+                           inputmode="decimal">
                 </div>
                 <div class="form-group form-group-narrow">
                     <label for="1rm-date">Date</label>
@@ -68,12 +54,9 @@
 <div class="card" style="margin-bottom: 1rem;">
     <div class="card-header">
         <span class="card-title">Progress</span>
-        <select id="exercise-select" class="form-control form-control-inline" onchange="update1rmChart()">
-            <option value="">— Select exercise —</option>
-            {% for ex in exercises_by_recency %}
-            <option value="{{ ex }}">{{ ex }}</option>
-            {% endfor %}
-        </select>
+        <div style="flex:1;max-width:300px">
+            {{ picker("progress_exercise", exercises, recent=exercises_by_recency, placeholder="Select exercise…", id_suffix="progress") }}
+        </div>
     </div>
     <div class="one-rm-pct-section" id="pct-section" style="display:none;">
         <div class="one-rm-pct-center">
@@ -128,11 +111,11 @@ function updatePctDisplay() {
 }
 
 function update1rmChart() {
-    var select = document.getElementById('exercise-select');
+    var hidden = document.getElementById('picker-hidden-progress');
     var canvas = document.getElementById('1rm-chart');
     var noData = document.getElementById('1rm-no-data');
-    if (!select || !canvas) return;
-    var exercise = select.value;
+    if (!hidden || !canvas) return;
+    var exercise = hidden.value;
 
     if (!exercise || !__1rmData[exercise] || !__1rmData[exercise].length) {
         canvas.style.display = 'none';
@@ -204,10 +187,22 @@ function update1rmChart() {
 }
 
 document.addEventListener('DOMContentLoaded', function() {
-    var select = document.getElementById('exercise-select');
-    if (select && select.options.length > 1) {
-        select.selectedIndex = 1;
-        update1rmChart();
+    var hidden = document.getElementById('picker-hidden-progress');
+    if (hidden) {
+        hidden.addEventListener('change', update1rmChart);
+        var options = __1rmData ? Object.keys(__1rmData).sort(function(a, b) {
+            var aLast = __1rmData[a][__1rmData[a].length - 1].date;
+            var bLast = __1rmData[b][__1rmData[b].length - 1].date;
+            return aLast < bLast ? 1 : aLast > bLast ? -1 : 0;
+        }) : [];
+        if (options.length > 0) {
+            hidden.value = options[0];
+            var trigger = document.querySelector('[data-target="picker-hidden-progress"]');
+            if (trigger) trigger.textContent = options[0];
+            update1rmChart();
+        } else {
+            document.getElementById('1rm-chart').style.display = 'none';
+        }
     } else {
         document.getElementById('1rm-chart').style.display = 'none';
     }
@@ -218,23 +213,17 @@ document.addEventListener('htmx:afterSwap', function(e) {
         var raw = document.getElementById('one-rep-max-history').dataset.exercises;
         if (!raw) return;
         __1rmData = JSON.parse(raw);
-        var select = document.getElementById('exercise-select');
-        if (!select) return;
-        var current = select.value;
-        select.innerHTML = '<option value="">— Select exercise —</option>';
-        Object.keys(__1rmData)
-            .sort(function(a, b) {
-                var aLast = __1rmData[a][__1rmData[a].length - 1].date;
-                var bLast = __1rmData[b][__1rmData[b].length - 1].date;
-                return aLast < bLast ? 1 : aLast > bLast ? -1 : 0;
-            })
-            .forEach(function(ex) {
-            var opt = document.createElement('option');
-            opt.value = ex;
-            opt.textContent = ex;
-            select.appendChild(opt);
+        var hidden = document.getElementById('picker-hidden-progress');
+        var trigger = document.querySelector('[data-target="picker-hidden-progress"]');
+        if (!hidden || !trigger) return;
+        var current = hidden.value;
+        var keys = Object.keys(__1rmData).sort(function(a, b) {
+            var aLast = __1rmData[a][__1rmData[a].length - 1].date;
+            var bLast = __1rmData[b][__1rmData[b].length - 1].date;
+            return aLast < bLast ? 1 : aLast > bLast ? -1 : 0;
         });
-        select.value = (__1rmData[current]) ? current : (Object.keys(__1rmData)[0] || '');
+        hidden.value = __1rmData[current] ? current : (keys[0] || '');
+        trigger.textContent = hidden.value || 'Select exercise\u2026';
         update1rmChart();
     }
 });

--- a/src/wodplanner/app/templates/partials/benchmark_edit_row.html
+++ b/src/wodplanner/app/templates/partials/benchmark_edit_row.html
@@ -1,3 +1,4 @@
+{% from "macros/picker.html" import picker %}
 <tr id="edit-row-{{ result_id }}" class="one-rm-edit-row">
     <td colspan="5">
         <form hx-put="/benchmark-results/{{ result_id }}/edit"
@@ -5,23 +6,7 @@
               hx-swap="outerHTML"
               class="benchmark-form benchmark-form--inline">
             <div class="form-row">
-                <div class="form-group form-group-full">
-                    <label for="benchmark-name-{{ result_id }}">Benchmark</label>
-                    <input type="text"
-                           id="benchmark-name-{{ result_id }}"
-                           name="benchmark_name"
-                           list="benchmark-list-{{ result_id }}"
-                           value="{{ result.benchmark_name }}"
-                           placeholder="Benchmark"
-                           required
-                           class="form-control form-control-sm"
-                           autocomplete="off">
-                    <datalist id="benchmark-list-{{ result_id }}">
-                        {% for name in benchmarks %}
-                        <option value="{{ name }}">
-                        {% endfor %}
-                    </datalist>
-                </div>
+                {{ picker("benchmark_name", benchmarks, selected=result.benchmark_name, label="Benchmark", id_suffix=result_id) }}
             </div>
             <div class="form-row">
                 <div class="form-group form-group-narrow">
@@ -34,7 +19,8 @@
                            max="999"
                            placeholder="0"
                            required
-                           class="form-control form-control-sm">
+                           class="form-control form-control-sm"
+                           inputmode="numeric">
                 </div>
                 <div class="form-group form-group-narrow">
                     <label for="benchmark-seconds-{{ result_id }}">Seconds</label>
@@ -46,7 +32,8 @@
                            max="59"
                            placeholder="00"
                            required
-                           class="form-control form-control-sm">
+                           class="form-control form-control-sm"
+                           inputmode="numeric">
                 </div>
                 <div class="form-group form-group-narrow">
                     <label for="benchmark-is-rx-{{ result_id }}">RX / Scaled</label>

--- a/src/wodplanner/app/templates/partials/one_rep_max_edit_row.html
+++ b/src/wodplanner/app/templates/partials/one_rep_max_edit_row.html
@@ -1,3 +1,4 @@
+{% from "macros/picker.html" import picker %}
 <tr id="edit-row-{{ entry_id }}" class="one-rm-edit-row">
     <td colspan="4">
         <form hx-put="/one-rep-maxes/{{ entry_id }}/edit"
@@ -5,23 +6,7 @@
               hx-swap="outerHTML"
               class="one-rm-form one-rm-form--inline">
             <div class="form-row">
-                <div class="form-group">
-                    <label for="1rm-exercise-{{ entry_id }}">Exercise</label>
-                    <input type="text"
-                           id="1rm-exercise-{{ entry_id }}"
-                           name="exercise"
-                           list="exercise-list-{{ entry_id }}"
-                           value="{{ entry.exercise }}"
-                           placeholder="Exercise"
-                           required
-                           class="form-control form-control-sm"
-                           autocomplete="off">
-                    <datalist id="exercise-list-{{ entry_id }}">
-                        {% for ex in exercises %}
-                        <option value="{{ ex }}">
-                        {% endfor %}
-                    </datalist>
-                </div>
+                {{ picker("exercise", exercises, selected=entry.exercise, label="Exercise", id_suffix=entry_id) }}
                 <div class="form-group form-group-narrow">
                     <label for="1rm-weight-{{ entry_id }}">Weight (kg)</label>
                     <input type="number"
@@ -32,7 +17,8 @@
                            max="999"
                            step="0.5"
                            required
-                           class="form-control form-control-sm">
+                           class="form-control form-control-sm"
+                           inputmode="decimal">
                 </div>
                 <div class="form-group form-group-narrow">
                     <label for="1rm-date-{{ entry_id }}">Date</label>

--- a/src/wodplanner/app/templates/partials/one_rep_max_modal.html
+++ b/src/wodplanner/app/templates/partials/one_rep_max_modal.html
@@ -1,3 +1,4 @@
+{% from "macros/picker.html" import picker %}
 <div class="modal-content modal-content--wide">
     <div class="modal-header">
         <h3 class="modal-title">1 Rep Max</h3>
@@ -12,24 +13,7 @@
             <input type="hidden" name="recorded_at" value="{{ preset_date }}">
             {% endif %}
             <div class="form-row">
-                <div class="form-group">
-                    <label for="1rm-exercise">Exercise</label>
-                    <input type="text"
-                           id="1rm-exercise"
-                           name="exercise"
-                           list="exercise-list"
-                           placeholder="Search exercise…"
-                           value="{{ default_exercise }}"
-                           required
-                           class="form-control"
-                           autocomplete="off"
-                           oninput="modalUpdate1rmChart()">
-                    <datalist id="exercise-list">
-                        {% for ex in exercises %}
-                        <option value="{{ ex }}">
-                        {% endfor %}
-                    </datalist>
-                </div>
+                {{ picker("exercise", exercises, selected=default_exercise, recent=suggested_exercises, label="Exercise", id_suffix="modal") }}
                 <div class="form-group form-group-narrow">
                     <label for="1rm-weight">Weight (kg)</label>
                     <input type="number"
@@ -40,7 +24,8 @@
                            step="0.5"
                            placeholder="100"
                            required
-                           class="form-control">
+                           class="form-control"
+                           inputmode="decimal">
                 </div>
                 {% if show_date|default(true) %}
                 <div class="form-group form-group-narrow">
@@ -106,10 +91,10 @@ function modalUpdatePctDisplay() {
 }
 
 function modalUpdate1rmChart() {
-    var select = document.getElementById('1rm-exercise');
+    var hidden = document.getElementById('picker-hidden-modal');
     var canvas = document.getElementById('modal-1rm-chart');
-    if (!select || !canvas) return;
-    var exercise = select.value;
+    if (!hidden || !canvas) return;
+    var exercise = hidden.value;
 
     if (!exercise || !__modal1rmData[exercise] || !__modal1rmData[exercise].length) {
         canvas.style.display = 'none';
@@ -188,6 +173,11 @@ document.addEventListener('htmx:afterSwap', function(e) {
         modalUpdate1rmChart();
     }
 });
+
+var modalHiddenInput = document.getElementById('picker-hidden-modal');
+if (modalHiddenInput) {
+    modalHiddenInput.addEventListener('change', modalUpdate1rmChart);
+}
 
 modalUpdate1rmChart();
 </script>

--- a/tests/e2e/test_one_rep_max.py
+++ b/tests/e2e/test_one_rep_max.py
@@ -41,7 +41,10 @@ def test_add_1rm_entry_updates_history(page, auth_session):
     page.goto("/1rm")
     page.get_by_text("+ Log").click()
 
-    page.locator("input[name=exercise]").fill("Back Squat")
+    # Use picker to select exercise
+    page.locator("[data-picker-trigger]").click()
+    page.locator(".picker-option[data-value='Back Squat']").click()
+
     page.locator("input[name=weight_kg]").fill("100")
     page.locator("input[name=recorded_at]").fill(date.today().isoformat())
 


### PR DESCRIPTION
Replaces the native `<input list="...">` + `<datalist>` exercise/benchmark picker with a custom bottom-sheet component.

### Changes

**New files:**
- `static/js/picker.js` — bottom-sheet picker with substring/fuzzy search, keyboard navigation, touch-aware autofocus, visualViewport resize handling
- `templates/macros/picker.html` — shared Jinja macro (`{{ picker(field_name, options, ...) }}`)

**Picker features:**
- Token-based substring matching: `"b sq"` matches `Back Squat`
- Recent exercises pinned at top (max 5)
- Bottom sheet on mobile, centered dialog on desktop
- No autofocus on touch devices (keyboard stays closed)
- Fixed `height: 85dvh` on mobile — never shrinks/grows with results
- `font-size: 16px` on search to prevent iOS auto-zoom
- Auto-adjusts to keyboard via VisualViewport API

**Template migration (5 call sites → macro):**
- 1RM log form, 1RM modal, 1RM edit row
- Benchmark log form, benchmark edit row
- Progress section exercise/benchmark selectors (1RM + benchmark)

**Server-side fixes:**
- Fuzzy fallback on write path: tries `match_exercise()` / `difflib.get_close_matches()` before rejecting
- Benchmark name validation added to add/update endpoints (was causing 500 from FK violation)

**Other:**
- `inputmode="decimal"` / `inputmode="numeric"` on number fields
- Cache-busting version hash for picker.js