### PR TITLE
fix: unsubscribe tracking silently dropped since v0.20.2

### DIFF
--- a/src/wodplanner/app/routers/views.py
+++ b/src/wodplanner/app/routers/views.py
@@ -932,7 +932,7 @@ def unsubscribe_view(
         action=action,
     )
 
-    if result.subscribedWithSuccess and is_waitinglist != "true" and not user_service.is_tracking_disabled(session.user_id):
+    if result.status == "OK" and is_waitinglist != "true" and not user_service.is_tracking_disabled(session.user_id):
         tracker.record_unsubscribe(
             user_id=session.user_id,
             appointment_id=appointment_id,

--- a/src/wodplanner/services/subscription_tracker.py
+++ b/src/wodplanner/services/subscription_tracker.py
@@ -162,7 +162,7 @@ class SubscriptionTrackerService(BaseService):
     def _is_past(self, class_end_raw: str | None, class_date_raw: str, now: datetime) -> bool:
         if class_end_raw:
             return self._parse_end(class_end_raw) < now
-        return date.fromisoformat(class_date_raw) < date.today()
+        return date.fromisoformat(class_date_raw) < now.date()
 
     def get_weekly_counts(
         self, user_id: int, weeks: int = 52


### PR DESCRIPTION
## Bug

Unsubscribe events have not been recorded in the `subscription_events` table since commit e42615a (PR #171) was deployed in v0.20.2.

## Root cause

The condition at `views.py:935` used `result.subscribedWithSuccess` to gate `record_unsubscribe`, but the WodApp API only returns `subscribedWithSuccess: 1` for successful **subscribes** — for unsubscribes it returns `status: "OK"` without that field, so the guard was always falsy.

## Changes

1. **`views.py:935`** — Changed the unsubscribe guard from `result.subscribedWithSuccess` to `result.status == "OK"`
2. **`subscription_tracker.py:165`** — Fixed `_is_past` fallback to use `now.date()` (Amsterdam timezone) instead of `date.today()` (server UTC) to prevent midnight misclassification

Closes #226