### PR TITLE
fix: tolerate stray backtick before day number in Dutch date parsing

### DIFF
--- a/src/wodplanner/cli/import_schedule.py
+++ b/src/wodplanner/cli/import_schedule.py
@@ -39,7 +39,8 @@ DUTCH_MONTHS = {
 def parse_dutch_date(date_str: str, year: int) -> date | None:
     """Parse a Dutch date string like 'Maandag 13 April' to a date object."""
     # Pattern: Day name + day number + month name
-    pattern = r"(?:Maandag|Dinsdag|Woensdag|Donderdag|Vrijdag|Zaterdag|Zondag)\s+(\d+)\s+(\w+)"
+    # Allow stray punctuation (e.g. backtick) between day name and number — PDF artifact
+    pattern = r"(?:Maandag|Dinsdag|Woensdag|Donderdag|Vrijdag|Zaterdag|Zondag)\s+\W*(\d+)\s+(\w+)"
     match = re.match(pattern, date_str, re.IGNORECASE)
     if not match:
         return None
@@ -61,7 +62,7 @@ def is_date_row(text: str) -> bool:
     """Check if the text looks like a date row (e.g., 'Maandag 13 April')."""
     if not text:
         return False
-    pattern = r"^(Maandag|Dinsdag|Woensdag|Donderdag|Vrijdag|Zaterdag|Zondag)\s+\d+\s+\w+"
+    pattern = r"^(Maandag|Dinsdag|Woensdag|Donderdag|Vrijdag|Zaterdag|Zondag)\s+\W*\d+\s+\w+"
     return bool(re.match(pattern, text.strip(), re.IGNORECASE))
 
 


### PR DESCRIPTION
The Bull_202605.pdf has a backtick before 14 in 'Vrijdag `14 Augustus', which broke the date regex. Added `\W*` between day name and day number to handle stray punctuation PDF artifacts. Reimporting Bull_202605.pdf will now pick up the missing 14 August schedule.