### PR TITLE
fix: extract_1rm_exercises regex terminates at newlines

### DIFF
--- a/src/wodplanner/services/one_rep_max.py
+++ b/src/wodplanner/services/one_rep_max.py
@@ -93,7 +93,7 @@ def extract_1rm_exercises(text: str | None) -> list[str]:
         return []
     results = []
     # Capture everything up to the next exercise letter (e.g. "B.") or end of string
-    for m in re.finditer(r'1rm\s+(.+?)(?=\s+[A-Z]\.\s|\s*\Z)', text, re.IGNORECASE | re.DOTALL):
+    for m in re.finditer(r'1rm\s+(.+?)(?=\s+[A-Z]\.\s|\n(?!\s*[A-Za-z])|\s*\Z)', text, re.IGNORECASE | re.DOTALL):
         preceding = text[max(0, m.start() - 6):m.start()]
         if not re.search(r'\d+%\s*$', preceding):
             # Strip parenthetical annotations, collapse internal whitespace/newlines


### PR DESCRIPTION
## Bug

On Aug 26, 2026, a CrossFit metcon reads `Find 1rm Power Clean\n07:00-09:00 Rest\n...`. The `extract_1rm_exercises` regex `1rm\\s+(.+?)(?=\\s+[A-Z]\\.\\s|\\s*\\Z)` only stopped at uppercase-letter-dot markers (`A.`, `B.`) or end-of-string. With no such marker, it captured the entire rest of the metcon text, which failed fuzzy-matching (cutoff 0.6). `suggested_exercises` stayed empty, and the modal fell back to the user's last-logged 1RM ("Medium Grip Football Bar Bench Press") instead of the correct "Power Clean".

## Fix

Added `\\n(?!\\s*[A-Za-z])` to the lookahead — terminates at newlines when the next non-whitespace character is **not** a letter. This:

- Correctly extracts `Power Clean` from `Find 1rm Power Clean\n07:00...` (stops at newline before digit)
- Preserves multi-line exercise names like `Future Method\nMiniband Small Grip Bench\nPress` (stops at `\nB.` not mid-name)

Verified against all 165 `1rm` occurrences in the deployed database — no regressions.

## Checklist

- [x] All 336 unit tests pass
- [x] Ruff linter clean
- [x] Mypy type check clean