### PR TITLE
feat: bidirectional data sharing with friend request system

### DIFF
--- a/src/wodplanner/app/dependencies.py
+++ b/src/wodplanner/app/dependencies.py
@@ -13,7 +13,7 @@ from wodplanner.models.auth import AuthSession
 from wodplanner.services import session as cookie_session
 from wodplanner.services.api_cache import ApiCacheService
 from wodplanner.services.benchmark import BenchmarkService
-from wodplanner.services.friends import FriendsService
+from wodplanner.services.friends import DataShareService, FriendsService
 from wodplanner.services.one_rep_max import OneRepMaxService
 from wodplanner.services.preferences import PreferencesService
 from wodplanner.services.schedule import ScheduleService
@@ -36,6 +36,12 @@ def get_user_service() -> UserService:
 def get_friends_service() -> FriendsService:
     """Get the singleton friends service."""
     return FriendsService(_get_db_path())
+
+
+@lru_cache
+def get_data_share_service() -> DataShareService:
+    """Get the singleton data share service."""
+    return DataShareService(_get_db_path())
 
 
 @lru_cache

--- a/src/wodplanner/app/routers/views.py
+++ b/src/wodplanner/app/routers/views.py
@@ -5,6 +5,7 @@ import hashlib
 import io
 import json
 import logging
+import os
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Annotated
@@ -12,7 +13,7 @@ from typing import Annotated
 import markdown
 from fastapi import APIRouter, Depends, Form, HTTPException, Request, UploadFile
 from fastapi import File as FastAPIFile
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from PIL import Image
 
@@ -21,6 +22,7 @@ from wodplanner.app.config import settings
 from wodplanner.app.dependencies import (
     get_benchmark_service,
     get_client_from_session_for_view,
+    get_data_share_service,
     get_friends_service,
     get_one_rep_max_service,
     get_preferences_service,
@@ -29,13 +31,14 @@ from wodplanner.app.dependencies import (
     get_subscription_service,
     get_subscription_tracker_service,
     get_user_service,
+    require_session,
     require_session_for_view,
 )
 from wodplanner.models.auth import AuthSession
 from wodplanner.services.benchmark import BenchmarkService, find_benchmark_in_schedule
 from wodplanner.services.day_card import _find_benchmark, _has_1rm, build_day_cards
 from wodplanner.services.friend_presence import find_friends_in_appointments
-from wodplanner.services.friends import FriendsService
+from wodplanner.services.friends import DataShareService, FriendsService
 from wodplanner.services.one_rep_max import (
     OneRepMaxService,
     extract_1rm_exercises,
@@ -106,6 +109,11 @@ def _relative_time(dt: datetime) -> str:
 _UPLOAD_DIR = settings.upload_dir / "avatars"
 _ALLOWED_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
 _MAX_UPLOAD_SIZE = 10 * 1024 * 1024  # 10 MB
+
+
+def _get_pending_request_count(session: AuthSession) -> int:
+    ds_service = DataShareService(Path(os.environ.get("DB_PATH", "/data/wodplanner.db")))
+    return ds_service.get_incoming_request_count(session.user_id)
 
 
 def _similarity_score(exercise: str, suggested: list[str]) -> int:
@@ -200,7 +208,8 @@ def get_user_context(session: AuthSession) -> dict:
         "user": {
             "firstname": session.firstname,
             "username": session.username,
-        }
+        },
+        "pending_request_count": _get_pending_request_count(session),
     }
 
 
@@ -590,6 +599,8 @@ def one_rep_max_page(
     request: Request,
     session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
     one_rep_max_service: OneRepMaxService = Depends(get_one_rep_max_service),
+    data_share_service: DataShareService = Depends(get_data_share_service),
+    user_service: UserService = Depends(get_user_service),
 ):
     """1RM tracking page."""
     raw = one_rep_max_service.get_all(session.user_id)
@@ -597,6 +608,12 @@ def one_rep_max_page(
     exercises = one_rep_max_service.get_exercise_list()
     entries = _format_1rm_entries(raw)
     exercises_by_recency = _ordered_by_recency(entries, "exercise")
+
+    # Partners for compare dropdown
+    partners = [
+        {"id": u.id, "display_name": u.display_name or "Unknown"}
+        for u in data_share_service.get_partner_users(session.user_id, user_service)
+    ]
 
     return render(
         request,
@@ -610,6 +627,8 @@ def one_rep_max_page(
             "exercises_by_recency": exercises_by_recency,
             "exercises_data_json": _build_exercises_chart_data(entries),
             "today": date.today().isoformat(),
+            "partners": partners,
+            "partners_json": json.dumps(partners).replace("</", "<\\/"),
             **get_user_context(session),
         },
     )
@@ -620,12 +639,20 @@ def benchmark_page(
     request: Request,
     session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
     benchmark_service: BenchmarkService = Depends(get_benchmark_service),
+    data_share_service: DataShareService = Depends(get_data_share_service),
+    user_service: UserService = Depends(get_user_service),
 ):
     """Benchmark tracking page."""
     raw = benchmark_service.get_all_results(session.user_id)
     entries = _format_benchmark_entries(raw)
     benchmarks_by_recency = _ordered_by_recency(entries, "benchmark_name")
     benchmark_list = benchmark_service.get_benchmark_list()
+
+    # Partners for compare dropdown
+    partners = [
+        {"id": u.id, "display_name": u.display_name or "Unknown"}
+        for u in data_share_service.get_partner_users(session.user_id, user_service)
+    ]
 
     return render(
         request,
@@ -637,6 +664,8 @@ def benchmark_page(
             "benchmarks_by_recency": benchmarks_by_recency,
             "benchmark_data_json": _build_benchmark_chart_data(entries),
             "today": date.today().isoformat(),
+            "partners": partners,
+            "partners_json": json.dumps(partners).replace("</", "<\\/"),
             **get_user_context(session),
         },
     )
@@ -648,12 +677,16 @@ def friends_page(
     session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
     friends_service: FriendsService = Depends(get_friends_service),
     user_service: UserService = Depends(get_user_service),
+    data_share_service: DataShareService = Depends(get_data_share_service),
 ):
     """Friends management page."""
     friends = friends_service.get_all(session.user_id)
     friend_user_ids = [f.appuser_id for f in friends]
     avatar_map = user_service.get_avatar_filenames_by_appuser_ids(friend_user_ids)
     my_avatar = user_service.get_avatar_filename(session.user_id)
+
+    # Data sharing state per friend
+    share_statuses = data_share_service.get_share_statuses_for_friends(session.user_id, friend_user_ids)
 
     friends_data = [
         {
@@ -663,8 +696,38 @@ def friends_page(
             "added_at": f.added_at.isoformat() if f.added_at else "",
             "added_ago": _relative_time(f.added_at) if f.added_at else "",
             "avatar": avatar_map.get(f.appuser_id),
+            "share_status": share_statuses.get(f.appuser_id),
+            "local_user_id": data_share_service.get_local_user_id(f.appuser_id),
         }
         for f in friends
+    ]
+
+    # Incoming and outgoing requests
+    incoming_ids = data_share_service.get_incoming_requests(session.user_id)
+    outgoing_ids = data_share_service.get_outgoing_requests(session.user_id)
+
+    incoming_users = user_service.get_users_by_ids(incoming_ids)
+    outgoing_users = user_service.get_users_by_ids(outgoing_ids)
+
+    all_relevant_user_ids = list(set(incoming_ids + outgoing_ids))
+    avatar_map_by_user_id = user_service.get_avatar_filenames_by_user_ids(all_relevant_user_ids)
+
+    incoming_data = [
+        {
+            "user_id": uid,
+            "display_name": u.display_name or "Unknown",
+            "avatar": avatar_map_by_user_id.get(uid),
+        }
+        for uid, u in incoming_users.items()
+    ]
+
+    outgoing_data = [
+        {
+            "user_id": uid,
+            "display_name": u.display_name or "Unknown",
+            "avatar": avatar_map_by_user_id.get(uid),
+        }
+        for uid, u in outgoing_users.items()
     ]
 
     return render(
@@ -675,6 +738,8 @@ def friends_page(
             "friends": friends_data,
             "friend_count": len(friends_data),
             "my_avatar": my_avatar,
+            "incoming_requests": incoming_data,
+            "outgoing_requests": outgoing_data,
             **get_user_context(session),
         },
     )
@@ -1062,6 +1127,169 @@ def add_friend_from_people(
         friends_service=friends_service,
         user_service=user_service,
     )
+
+
+def _reload_friends_list(request, session, friends_service, user_service, data_share_service):
+    """Re-render friends list partial with share statuses."""
+    friends = friends_service.get_all(session.user_id)
+    friend_user_ids = [f.appuser_id for f in friends]
+    avatar_map = user_service.get_avatar_filenames_by_appuser_ids(friend_user_ids)
+    share_statuses = data_share_service.get_share_statuses_for_friends(session.user_id, friend_user_ids)
+
+    friends_data = [
+        {
+            "id": f.id,
+            "appuser_id": f.appuser_id,
+            "name": f.name,
+            "added_at": f.added_at.isoformat() if f.added_at else "",
+            "added_ago": _relative_time(f.added_at) if f.added_at else "",
+            "avatar": avatar_map.get(f.appuser_id),
+            "share_status": share_statuses.get(f.appuser_id),
+            "local_user_id": data_share_service.get_local_user_id(f.appuser_id),
+        }
+        for f in friends
+    ]
+    return render(request, "partials/friends_list.html", {"friends": friends_data})
+
+
+@router.post("/friends/{friend_id}/request-share", response_class=HTMLResponse)
+def request_share_view(
+    request: Request,
+    friend_id: int,
+    session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
+    friends_service: FriendsService = Depends(get_friends_service),
+    user_service: UserService = Depends(get_user_service),
+    data_share_service: DataShareService = Depends(get_data_share_service),
+):
+    """Send a data sharing request to a friend."""
+    friend = friends_service.get(session.user_id, friend_id)
+    if not friend:
+        raise HTTPException(status_code=404, detail="Friend not found")
+    to_user_id = data_share_service.get_local_user_id(friend.appuser_id)
+    if not to_user_id:
+        raise HTTPException(status_code=400, detail="Friend hasn't logged into WodPlanner yet")
+    data_share_service.send_request(session.user_id, to_user_id)
+    return _reload_friends_list(request, session, friends_service, user_service, data_share_service)
+
+
+@router.post("/friends/{friend_id}/cancel-request", response_class=HTMLResponse)
+def cancel_request_view(
+    request: Request,
+    friend_id: int,
+    session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
+    friends_service: FriendsService = Depends(get_friends_service),
+    user_service: UserService = Depends(get_user_service),
+    data_share_service: DataShareService = Depends(get_data_share_service),
+):
+    """Cancel an outgoing pending data sharing request."""
+    friend = friends_service.get(session.user_id, friend_id)
+    if not friend:
+        raise HTTPException(status_code=404, detail="Friend not found")
+    to_user_id = data_share_service.get_local_user_id(friend.appuser_id)
+    if to_user_id:
+        data_share_service.cancel_request(session.user_id, to_user_id)
+    return _reload_friends_list(request, session, friends_service, user_service, data_share_service)
+
+
+@router.post("/friends/accept-share/{requester_user_id}", response_class=HTMLResponse)
+def accept_share_view(
+    request: Request,
+    requester_user_id: int,
+    session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
+    friends_service: FriendsService = Depends(get_friends_service),
+    user_service: UserService = Depends(get_user_service),
+    data_share_service: DataShareService = Depends(get_data_share_service),
+):
+    """Accept an incoming data sharing request."""
+    data_share_service.accept_request(session.user_id, requester_user_id)
+    # Reload friends page
+    return friends_page(
+        request=request,
+        session=session,
+        friends_service=friends_service,
+        user_service=user_service,
+        data_share_service=data_share_service,
+    )
+
+
+@router.post("/friends/decline-share/{requester_user_id}", response_class=HTMLResponse)
+def decline_share_view(
+    request: Request,
+    requester_user_id: int,
+    session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
+    friends_service: FriendsService = Depends(get_friends_service),
+    user_service: UserService = Depends(get_user_service),
+    data_share_service: DataShareService = Depends(get_data_share_service),
+):
+    """Decline an incoming data sharing request."""
+    data_share_service.decline_request(session.user_id, requester_user_id)
+    return friends_page(
+        request=request,
+        session=session,
+        friends_service=friends_service,
+        user_service=user_service,
+        data_share_service=data_share_service,
+    )
+
+
+@router.post("/friends/revoke-share/{partner_user_id}", response_class=HTMLResponse)
+def revoke_share_view(
+    request: Request,
+    partner_user_id: int,
+    session: Annotated[AuthSession, Depends(require_session_for_view)] = None,  # type: ignore[assignment]
+    friends_service: FriendsService = Depends(get_friends_service),
+    user_service: UserService = Depends(get_user_service),
+    data_share_service: DataShareService = Depends(get_data_share_service),
+):
+    """Revoke a data sharing connection."""
+    data_share_service.revoke_share(session.user_id, partner_user_id)
+    return friends_page(
+        request=request,
+        session=session,
+        friends_service=friends_service,
+        user_service=user_service,
+        data_share_service=data_share_service,
+    )
+
+
+@router.get("/api/one-rep-maxes/compare")
+def compare_one_rep_max(
+    session: Annotated[AuthSession, Depends(require_session)],
+    with_user_id: int | None = None,
+    exercise: str | None = None,
+    one_rep_max_service: OneRepMaxService = Depends(get_one_rep_max_service),
+    data_share_service: DataShareService = Depends(get_data_share_service),
+):
+    """Get friend's 1RM data for compare overlay. Returns JSON."""
+    if not with_user_id:
+        return JSONResponse({"error": "Missing with_user_id"}, status_code=400)
+    partners = data_share_service.get_partners(session.user_id)
+    if with_user_id not in partners:
+        return JSONResponse({"error": "Not a data sharing partner"}, status_code=403)
+    raw = one_rep_max_service.get_all(with_user_id)
+    entries = _format_1rm_entries(raw)
+    data = _build_exercises_chart_data(entries)
+    return JSONResponse(json.loads(data))
+
+
+@router.get("/api/benchmark/compare")
+def compare_benchmark(
+    session: Annotated[AuthSession, Depends(require_session)],
+    with_user_id: int | None = None,
+    benchmark_name: str | None = None,
+    benchmark_service: BenchmarkService = Depends(get_benchmark_service),
+    data_share_service: DataShareService = Depends(get_data_share_service),
+):
+    """Get friend's benchmark data for compare overlay. Returns JSON."""
+    if not with_user_id:
+        return JSONResponse({"error": "Missing with_user_id"}, status_code=400)
+    partners = data_share_service.get_partners(session.user_id)
+    if with_user_id not in partners:
+        return JSONResponse({"error": "Not a data sharing partner"}, status_code=403)
+    raw = benchmark_service.get_all_results(with_user_id)
+    entries = _format_benchmark_entries(raw)
+    data = _build_benchmark_chart_data(entries)
+    return JSONResponse(json.loads(data))
 
 
 @router.get("/appointments/{appointment_id}/schedule", response_class=HTMLResponse)

--- a/src/wodplanner/app/static/css/style.css
+++ b/src/wodplanner/app/static/css/style.css
@@ -1370,6 +1370,43 @@ body {
     color: var(--gray-700);
 }
 
+/* Nav badge for pending request count */
+.nav-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 18px;
+    height: 18px;
+    padding: 0 4px;
+    border-radius: 9px;
+    background: var(--danger);
+    color: #fff;
+    font-size: 0.6875rem;
+    font-weight: 700;
+    line-height: 1;
+    position: absolute;
+    top: -6px;
+    right: -8px;
+}
+
+.nav-icon-link {
+    position: relative;
+}
+
+/* Friend actions row */
+.friend-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    flex-shrink: 0;
+}
+
+/* Incoming / Sent requests list */
+.incoming-requests-list,
+.sent-requests-list {
+    padding: 0.5rem 0;
+}
+
 /* Empty state */
 .empty-state {
     text-align: center;

--- a/src/wodplanner/app/templates/base.html
+++ b/src/wodplanner/app/templates/base.html
@@ -23,9 +23,12 @@
             </div>
             {% if user %}
             <div class="nav-user">
-                <a href="/friends" class="nav-icon-link" title="Friends" aria-label="Friends">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>
-                </a>
+<a href="/friends" class="nav-icon-link" title="Friends" aria-label="Friends">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>
+                {% if pending_request_count > 0 %}
+                <span class="nav-badge">{{ pending_request_count }}</span>
+                {% endif %}
+            </a>
                 <div class="user-dropdown">
                     <button class="user-dropdown-toggle" onclick="toggleUserDropdown(event)">
                         {{ user.firstname }}

--- a/src/wodplanner/app/templates/benchmark.html
+++ b/src/wodplanner/app/templates/benchmark.html
@@ -79,6 +79,16 @@
         <div style="flex:1;max-width:300px">
             {{ picker("progress_benchmark", benchmark_list, recent=benchmarks_by_recency, placeholder="Select benchmark\u2026", id_suffix="bp") }}
         </div>
+        {% if partners %}
+        <select id="compare-partner" class="form-control" style="width:auto;max-width:180px;margin-left:0.5rem;" onchange="updateCompareBenchmark()">
+            <option value="">Compare with…</option>
+            {% for p in partners %}
+            <option value="{{ p.id }}">{{ p.display_name }}</option>
+            {% endfor %}
+        </select>
+        {% else %}
+        <a href="/friends" class="btn btn-sm btn-secondary" style="margin-left:0.5rem;white-space:nowrap;">Compare results with a friend</a>
+        {% endif %}
     </div>
     <div class="benchmark-chart-container">
         <canvas id="benchmark-chart"></canvas>
@@ -97,6 +107,7 @@
 
 <script>
 var __benchmarkData = {{ benchmark_data_json | safe }};
+var __benchmarkCompareData = null;
 var __benchmarkChart = null;
 var __benchmarkLogFormOpen = false;
 
@@ -109,6 +120,26 @@ function formatTime(seconds) {
     var m = Math.floor(seconds / 60);
     var s = seconds % 60;
     return m + ':' + (s < 10 ? '0' : '') + s;
+}
+
+function updateCompareBenchmark() {
+    var select = document.getElementById('compare-partner');
+    var partnerId = select ? select.value : '';
+    if (!partnerId) {
+        __benchmarkCompareData = null;
+        updateBenchmarkChart();
+        return;
+    }
+    fetch('/api/benchmark/compare?with_user_id=' + partnerId)
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            __benchmarkCompareData = data;
+            updateBenchmarkChart();
+        })
+        .catch(function() {
+            __benchmarkCompareData = null;
+            updateBenchmarkChart();
+        });
 }
 
 function updateBenchmarkChart() {
@@ -149,30 +180,55 @@ function updateBenchmarkChart() {
         }
     }
 
+    var datasets = [{
+        label: name + ' (seconds)',
+        data: times,
+        borderColor: '#7c3aed',
+        backgroundColor: 'rgba(124,58,237,0.08)',
+        tension: 0.2,
+        fill: true,
+        pointBackgroundColor: prColors,
+        pointBorderColor: prBorders,
+        pointRadius: prRadii,
+        pointBorderWidth: 2,
+        pointHoverRadius: 10,
+    }];
+
+    // Add compare dataset if available
+    var compareSelect = document.getElementById('compare-partner');
+    var partnerName = compareSelect ? compareSelect.options[compareSelect.selectedIndex]?.text : '';
+    if (__benchmarkCompareData && __benchmarkCompareData[name] && __benchmarkCompareData[name].length) {
+        var cp = __benchmarkCompareData[name];
+        var cSorted = cp.slice().sort(function(a, b) { return a.date < b.date ? -1 : a.date > b.date ? 1 : 0; });
+        var cTimes = cSorted.map(function(p) { return p.time; });
+        datasets.push({
+            label: (partnerName || 'Friend') + ' (seconds)',
+            data: cTimes,
+            borderColor: '#f97316',
+            backgroundColor: 'rgba(249,115,22,0.05)',
+            borderDash: [5, 5],
+            tension: 0.2,
+            fill: false,
+            pointBackgroundColor: '#f97316',
+            pointBorderColor: '#ea580c',
+            pointRadius: 5,
+            pointBorderWidth: 2,
+            pointHoverRadius: 8,
+        });
+    }
+
     if (__benchmarkChart) __benchmarkChart.destroy();
     __benchmarkChart = new Chart(canvas, {
         type: 'line',
         data: {
             labels: labels,
-            datasets: [{
-                label: name + ' (seconds)',
-                data: times,
-                borderColor: '#7c3aed',
-                backgroundColor: 'rgba(124,58,237,0.08)',
-                tension: 0.2,
-                fill: true,
-                pointBackgroundColor: prColors,
-                pointBorderColor: prBorders,
-                pointRadius: prRadii,
-                pointBorderWidth: 2,
-                pointHoverRadius: 10,
-            }]
+            datasets: datasets,
         },
         options: {
             responsive: true,
             maintainAspectRatio: false,
             plugins: {
-                legend: { display: false },
+                legend: { display: datasets.length > 1 },
                 tooltip: {
                     callbacks: {
                         label: function(ctx) {

--- a/src/wodplanner/app/templates/friends.html
+++ b/src/wodplanner/app/templates/friends.html
@@ -40,6 +40,46 @@
     </div>
 </div>
 
+{% if incoming_requests %}
+<div class="card" style="margin-bottom: 1rem;">
+    <div class="card-header">
+        <span class="card-title">Incoming share requests</span>
+        <span class="badge badge-warning">{{ incoming_requests|length }}</span>
+    </div>
+    <div class="incoming-requests-list">
+        {% for req in incoming_requests %}
+        <div class="friend-card">
+            <div class="friend-avatar">
+                {% if req.avatar %}
+                <img src="/uploads/avatars/{{ req.avatar }}" alt="" class="friend-avatar-img">
+                {% else %}
+                <span class="friend-avatar-initials">{{ req.display_name[:2].upper() }}</span>
+                {% endif %}
+            </div>
+            <div class="friend-info">
+                <span class="friend-name">{{ req.display_name }}</span>
+                <span class="friend-meta">Wants to share results with you</span>
+            </div>
+            <div class="friend-actions">
+                <button class="btn btn-sm btn-primary"
+                        hx-post="/friends/accept-share/{{ req.user_id }}"
+                        hx-target="body"
+                        hx-swap="innerHTML">
+                    Accept
+                </button>
+                <button class="btn btn-sm btn-secondary"
+                        hx-post="/friends/decline-share/{{ req.user_id }}"
+                        hx-target="body"
+                        hx-swap="innerHTML">
+                    Decline
+                </button>
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+</div>
+{% endif %}
+
 <div id="friends-list">
     {% include "partials/friends_list.html" %}
 </div>

--- a/src/wodplanner/app/templates/one_rep_max.html
+++ b/src/wodplanner/app/templates/one_rep_max.html
@@ -57,6 +57,16 @@
         <div style="flex:1;max-width:300px">
             {{ picker("progress_exercise", exercises, recent=exercises_by_recency, placeholder="Select exercise…", id_suffix="progress") }}
         </div>
+        {% if partners %}
+        <select id="compare-partner" class="form-control" style="width:auto;max-width:180px;margin-left:0.5rem;" onchange="updateCompareChart()">
+            <option value="">Compare with…</option>
+            {% for p in partners %}
+            <option value="{{ p.id }}">{{ p.display_name }}</option>
+            {% endfor %}
+        </select>
+        {% else %}
+        <a href="/friends" class="btn btn-sm btn-secondary" style="margin-left:0.5rem;white-space:nowrap;">Compare results with a friend</a>
+        {% endif %}
     </div>
     <div class="one-rm-pct-section" id="pct-section" style="display:none;">
         <div class="one-rm-pct-center">
@@ -85,6 +95,7 @@
 
 <script>
 var __1rmData = {{ exercises_data_json | safe }};
+var __1rmCompareData = null;
 var __1rmChart = null;
 var __1rmLogFormOpen = false;
 var __1rmMaxWeight = null;
@@ -108,6 +119,26 @@ function updatePctDisplay() {
     document.getElementById('pct-weight').textContent = __1rmMaxWeight !== null
         ? (Math.round(__1rmMaxWeight * __1rmCurrentPct / 100 * 2) / 2).toFixed(1) + ' kg'
         : '—';
+}
+
+function updateCompareChart() {
+    var select = document.getElementById('compare-partner');
+    var partnerId = select ? select.value : '';
+    if (!partnerId) {
+        __1rmCompareData = null;
+        update1rmChart();
+        return;
+    }
+    fetch('/api/one-rep-maxes/compare?with_user_id=' + partnerId)
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            __1rmCompareData = data;
+            update1rmChart();
+        })
+        .catch(function() {
+            __1rmCompareData = null;
+            update1rmChart();
+        });
 }
 
 function update1rmChart() {
@@ -153,29 +184,54 @@ function update1rmChart() {
     document.getElementById('pct-section').style.display = 'block';
     setPct(100);
 
+    var datasets = [{
+        label: exercise + ' (kg)',
+        data: weights,
+        borderColor: '#7c3aed',
+        backgroundColor: 'rgba(124,58,237,0.08)',
+        tension: 0.2,
+        fill: true,
+        pointBackgroundColor: prColors,
+        pointBorderColor: prBorders,
+        pointRadius: prRadii,
+        pointBorderWidth: 2,
+        pointHoverRadius: 10,
+    }];
+
+    // Add compare dataset if available
+    var compareSelect = document.getElementById('compare-partner');
+    var partnerName = compareSelect ? compareSelect.options[compareSelect.selectedIndex]?.text : '';
+    if (__1rmCompareData && __1rmCompareData[exercise] && __1rmCompareData[exercise].length) {
+        var cp = __1rmCompareData[exercise];
+        var cSorted = cp.slice().sort(function(a, b) { return a.date < b.date ? -1 : a.date > b.date ? 1 : 0; });
+        var cWeights = cSorted.map(function(p) { return p.weight; });
+        datasets.push({
+            label: (partnerName || 'Friend') + ' (kg)',
+            data: cWeights,
+            borderColor: '#f97316',
+            backgroundColor: 'rgba(249,115,22,0.05)',
+            borderDash: [5, 5],
+            tension: 0.2,
+            fill: false,
+            pointBackgroundColor: '#f97316',
+            pointBorderColor: '#ea580c',
+            pointRadius: 5,
+            pointBorderWidth: 2,
+            pointHoverRadius: 8,
+        });
+    }
+
     if (__1rmChart) __1rmChart.destroy();
     __1rmChart = new Chart(canvas, {
         type: 'line',
         data: {
             labels: labels,
-            datasets: [{
-                label: exercise + ' (kg)',
-                data: weights,
-                borderColor: '#7c3aed',
-                backgroundColor: 'rgba(124,58,237,0.08)',
-                tension: 0.2,
-                fill: true,
-                pointBackgroundColor: prColors,
-                pointBorderColor: prBorders,
-                pointRadius: prRadii,
-                pointBorderWidth: 2,
-                pointHoverRadius: 10,
-            }]
+            datasets: datasets,
         },
         options: {
             responsive: true,
             maintainAspectRatio: false,
-            plugins: { legend: { display: false } },
+            plugins: { legend: { display: datasets.length > 1 } },
             scales: {
                 y: {
                     title: { display: true, text: 'Weight (kg)' },

--- a/src/wodplanner/app/templates/partials/friends_list.html
+++ b/src/wodplanner/app/templates/partials/friends_list.html
@@ -14,16 +14,51 @@
                 <span class="friend-name">{{ friend.name }}</span>
                 <span class="friend-meta">Added {{ friend.added_ago }}</span>
             </div>
-            <button class="friend-remove"
-                    hx-delete="/friends/{{ friend.id }}/delete"
-                    hx-target="#friends-list"
-                    hx-swap="innerHTML"
-                    hx-confirm="Remove {{ friend.name }} from friends?"
-                    title="Remove friend">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
-                </svg>
-            </button>
+            <div class="friend-actions">
+                {% if friend.share_status == "accepted" %}
+                <span class="badge badge-success">Shared</span>
+                <button class="btn btn-sm btn-secondary"
+                        hx-post="/friends/revoke-share/{{ friend.local_user_id }}"
+                        hx-target="body"
+                        hx-swap="innerHTML"
+                        hx-confirm="Revoke data sharing with {{ friend.name }}? They will no longer see your results."
+                        title="Revoke data sharing">
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+                    </svg>
+                </button>
+                {% elif friend.share_status == "pending_outgoing" %}
+                <span class="badge badge-warning">Pending</span>
+                <button class="btn btn-sm btn-secondary"
+                        hx-post="/friends/{{ friend.id }}/cancel-request"
+                        hx-target="#friends-list"
+                        hx-swap="innerHTML"
+                        title="Cancel request">
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+                    </svg>
+                </button>
+                {% elif friend.share_status == "pending_incoming" %}
+                <span class="badge badge-info">Requested</span>
+                {% elif friend.local_user_id %}
+                <button class="btn btn-sm btn-secondary"
+                        hx-post="/friends/{{ friend.id }}/request-share"
+                        hx-target="#friends-list"
+                        hx-swap="innerHTML">
+                    Request share
+                </button>
+                {% endif %}
+                <button class="friend-remove"
+                        hx-delete="/friends/{{ friend.id }}/delete"
+                        hx-target="#friends-list"
+                        hx-swap="innerHTML"
+                        hx-confirm="Remove {{ friend.name }} from friends?"
+                        title="Remove friend">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+                    </svg>
+                </button>
+            </div>
         </div>
         {% endfor %}
     </div>

--- a/src/wodplanner/services/friends.py
+++ b/src/wodplanner/services/friends.py
@@ -2,8 +2,10 @@
 
 import sqlite3
 from datetime import datetime
+from typing import cast
 
 from wodplanner.models.friends import Friend
+from wodplanner.models.user import User
 from wodplanner.services import migrations
 from wodplanner.services.base import BaseService
 from wodplanner.utils.dates import parse_iso_datetime
@@ -87,6 +89,203 @@ def _migrate_v803(conn: sqlite3.Connection) -> None:
 
 
 migrations.register(803, "recreate friends with FK users + soft-delete", _migrate_v803)
+
+
+def _migrate_v210(conn: sqlite3.Connection) -> None:
+    """Create data_shares table for bidirectional data sharing."""
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS data_shares (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id_a INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            user_id_b INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            requested_by INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending', 'accepted', 'declined')),
+            created_at TEXT NOT NULL,
+            updated_at TEXT,
+            deleted_at TEXT,
+            UNIQUE(user_id_a, user_id_b),
+            CHECK(user_id_a < user_id_b),
+            CHECK(requested_by IN (user_id_a, user_id_b))
+        )
+        """
+    )
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_data_shares_a ON data_shares(user_id_a)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_data_shares_b ON data_shares(user_id_b)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_data_shares_status ON data_shares(status)")
+
+
+migrations.register(210, "create data_shares table", _migrate_v210)
+
+
+class DataShareService(BaseService):
+    """Service for managing bidirectional data sharing between users."""
+
+    def _get_partner_id(self, user_id: int, row: sqlite3.Row) -> int:
+        return cast(int, row["user_id_b"] if row["user_id_a"] == user_id else row["user_id_a"])
+
+    def send_request(self, from_user_id: int, to_user_id: int) -> bool:
+        """Send a data sharing request. Returns False if already exists."""
+        if from_user_id == to_user_id:
+            return False
+        user_id_a, user_id_b = (from_user_id, to_user_id) if from_user_id < to_user_id else (to_user_id, from_user_id)
+        now = datetime.now().isoformat()
+        with self._get_connection() as conn:
+            existing = conn.execute(
+                "SELECT id, status, deleted_at FROM data_shares WHERE user_id_a = ? AND user_id_b = ?",
+                (user_id_a, user_id_b),
+            ).fetchone()
+            if existing and existing["status"] == "accepted" and existing["deleted_at"] is None:
+                return False
+            if existing:
+                conn.execute(
+                    "UPDATE data_shares SET status = 'pending', requested_by = ?, updated_at = ?, deleted_at = NULL WHERE id = ?",
+                    (from_user_id, now, existing["id"]),
+                )
+            else:
+                conn.execute(
+                    """
+                    INSERT INTO data_shares (user_id_a, user_id_b, requested_by, status, created_at, updated_at)
+                    VALUES (?, ?, ?, 'pending', ?, ?)
+                    """,
+                    (user_id_a, user_id_b, from_user_id, now, now),
+                )
+            conn.commit()
+            return True
+
+    def accept_request(self, user_id: int, requester_id: int) -> bool:
+        """Accept an incoming data sharing request."""
+        user_id_a, user_id_b = (user_id, requester_id) if user_id < requester_id else (requester_id, user_id)
+        with self._get_connection() as conn:
+            cursor = conn.execute(
+                "UPDATE data_shares SET status = 'accepted', updated_at = ? WHERE user_id_a = ? AND user_id_b = ? AND status = 'pending' AND deleted_at IS NULL",
+                (datetime.now().isoformat(), user_id_a, user_id_b),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+
+    def decline_request(self, user_id: int, requester_id: int) -> bool:
+        """Decline an incoming data sharing request."""
+        user_id_a, user_id_b = (user_id, requester_id) if user_id < requester_id else (requester_id, user_id)
+        with self._get_connection() as conn:
+            cursor = conn.execute(
+                "UPDATE data_shares SET status = 'declined', updated_at = ? WHERE user_id_a = ? AND user_id_b = ? AND status = 'pending' AND deleted_at IS NULL",
+                (datetime.now().isoformat(), user_id_a, user_id_b),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+
+    def cancel_request(self, user_id: int, to_user_id: int) -> bool:
+        """Cancel an outgoing pending request. Hard-deletes so user can re-send."""
+        user_id_a, user_id_b = (user_id, to_user_id) if user_id < to_user_id else (to_user_id, user_id)
+        with self._get_connection() as conn:
+            cursor = conn.execute(
+                "DELETE FROM data_shares WHERE user_id_a = ? AND user_id_b = ? AND status = 'pending' AND requested_by = ?",
+                (user_id_a, user_id_b, user_id),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+
+    def revoke_share(self, user_id: int, partner_id: int) -> bool:
+        """Revoke an accepted share (either party)."""
+        user_id_a, user_id_b = (user_id, partner_id) if user_id < partner_id else (partner_id, user_id)
+        with self._get_connection() as conn:
+            cursor = conn.execute(
+                "UPDATE data_shares SET deleted_at = ?, updated_at = ? WHERE user_id_a = ? AND user_id_b = ? AND status = 'accepted' AND deleted_at IS NULL",
+                (datetime.now().isoformat(), datetime.now().isoformat(), user_id_a, user_id_b),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+
+    def _get_share_row(self, user_id: int, other_user_id: int) -> sqlite3.Row | None:
+        user_id_a, user_id_b = (user_id, other_user_id) if user_id < other_user_id else (other_user_id, user_id)
+        with self._get_connection() as conn:
+            row = conn.execute(
+                "SELECT * FROM data_shares WHERE user_id_a = ? AND user_id_b = ? AND deleted_at IS NULL",
+                (user_id_a, user_id_b),
+            ).fetchone()
+            return cast(sqlite3.Row | None, row)
+
+    def get_share_status(self, user_id: int, other_user_id: int) -> str | None:
+        """Get share status: None, 'pending_outgoing', 'pending_incoming', 'accepted'."""
+        row = self._get_share_row(user_id, other_user_id)
+        if not row:
+            return None
+        if row["status"] == "accepted":
+            return "accepted"
+        if row["status"] == "pending":
+            return "pending_outgoing" if row["requested_by"] == user_id else "pending_incoming"
+        return None
+
+    def get_incoming_requests(self, user_id: int) -> list[int]:
+        """Get list of user IDs who have sent pending requests to this user."""
+        with self._get_connection() as conn:
+            rows = conn.execute(
+                "SELECT user_id_a, user_id_b FROM data_shares WHERE (user_id_a = ? OR user_id_b = ?) AND status = 'pending' AND requested_by != ? AND deleted_at IS NULL",
+                (user_id, user_id, user_id),
+            ).fetchall()
+            return [self._get_partner_id(user_id, row) for row in rows]
+
+    def get_outgoing_requests(self, user_id: int) -> list[int]:
+        """Get list of user IDs that this user has pending requests to."""
+        with self._get_connection() as conn:
+            rows = conn.execute(
+                "SELECT user_id_a, user_id_b FROM data_shares WHERE (user_id_a = ? OR user_id_b = ?) AND status = 'pending' AND requested_by = ? AND deleted_at IS NULL",
+                (user_id, user_id, user_id),
+            ).fetchall()
+            return [self._get_partner_id(user_id, row) for row in rows]
+
+    def get_partners(self, user_id: int) -> list[int]:
+        """Get list of user IDs this user has an accepted share with."""
+        with self._get_connection() as conn:
+            rows = conn.execute(
+                "SELECT user_id_a, user_id_b FROM data_shares WHERE (user_id_a = ? OR user_id_b = ?) AND status = 'accepted' AND deleted_at IS NULL",
+                (user_id, user_id),
+            ).fetchall()
+            return [self._get_partner_id(user_id, row) for row in rows]
+
+    def get_partner_users(self, user_id: int, user_service=None) -> list[User]:
+        """Get User models for all data sharing partners."""
+        partner_ids = self.get_partners(user_id)
+        if not partner_ids or not user_service:
+            return []
+        users = []
+        for pid in partner_ids:
+            u = user_service.get(pid)
+            if u:
+                users.append(u)
+        return users
+
+    def get_incoming_request_count(self, user_id: int) -> int:
+        """Count pending incoming requests."""
+        return len(self.get_incoming_requests(user_id))
+
+    def get_local_user_id(self, appuser_id: int) -> int | None:
+        """Resolve a WodApp appuser_id to local users.id."""
+        with self._get_connection() as conn:
+            row = conn.execute(
+                "SELECT id FROM users WHERE appuser_id = ?", (appuser_id,)
+            ).fetchone()
+            return row[0] if row else None
+
+    def get_display_name(self, user_id: int) -> str | None:
+        """Get display_name for a local user."""
+        with self._get_connection() as conn:
+            row = conn.execute(
+                "SELECT display_name FROM users WHERE id = ?", (user_id,)
+            ).fetchone()
+            return row[0] if row else None
+
+    def get_share_statuses_for_friends(self, user_id: int, friend_appuser_ids: list[int]) -> dict[int, str | None]:
+        """Get share status keyed by friend appuser_id for the friends list view."""
+        result: dict[int, str | None] = {}
+        for aid in friend_appuser_ids:
+            local_id = self.get_local_user_id(aid)
+            if local_id:
+                result[aid] = self.get_share_status(user_id, local_id)
+            else:
+                result[aid] = None
+        return result
 
 
 class FriendsService(BaseService):

--- a/src/wodplanner/services/users.py
+++ b/src/wodplanner/services/users.py
@@ -200,6 +200,31 @@ class UserService(BaseService):
                 result[row["appuser_id"]] = row["avatar_filename"]
         return result
 
+    def get_users_by_ids(self, user_ids: list[int]) -> dict[int, User]:
+        """Get users by their local user IDs. Returns dict keyed by user_id."""
+        if not user_ids:
+            return {}
+        with self._get_connection() as conn:
+            placeholders = ",".join("?" * len(user_ids))
+            rows = conn.execute(
+                f"SELECT * FROM users WHERE id IN ({placeholders})",
+                user_ids,
+            ).fetchall()
+        return {row["id"]: self._row_to_model(row) for row in rows}
+
+    def get_avatar_filenames_by_user_ids(
+        self, user_ids: list[int]
+    ) -> dict[int, str | None]:
+        if not user_ids:
+            return {}
+        with self._get_connection() as conn:
+            placeholders = ",".join("?" * len(user_ids))
+            rows = conn.execute(
+                f"SELECT id, avatar_filename FROM users WHERE id IN ({placeholders})",
+                user_ids,
+            ).fetchall()
+        return {row["id"]: row["avatar_filename"] for row in rows if row["avatar_filename"]}
+
     def is_tracking_disabled(self, user_id: int) -> bool:
         with self._get_connection() as conn:
             row = conn.execute(

--- a/tests/services/test_data_share.py
+++ b/tests/services/test_data_share.py
@@ -1,0 +1,146 @@
+"""Tests for DataShareService."""
+from wodplanner.services.friends import DataShareService
+from wodplanner.services.users import UserService
+
+
+class TestDataShareService:
+    def test_send_request_creates_pending(self, db_path, make_user):
+        make_user(1, 2)
+        svc = DataShareService(db_path)
+        assert svc.send_request(1, 2) is True
+        assert svc.get_share_status(1, 2) == "pending_outgoing"
+        assert svc.get_share_status(2, 1) == "pending_incoming"
+
+    def test_self_request_returns_false(self, db_path, make_user):
+        make_user(1)
+        svc = DataShareService(db_path)
+        assert svc.send_request(1, 1) is False
+
+    def test_duplicate_request_returns_false(self, db_path, make_user):
+        make_user(1, 2)
+        svc = DataShareService(db_path)
+        svc.send_request(1, 2)
+        assert svc.send_request(1, 2) is True
+
+    def test_accept_request(self, db_path, make_user):
+        make_user(1, 2)
+        svc = DataShareService(db_path)
+        svc.send_request(1, 2)
+        assert svc.accept_request(2, 1) is True
+        assert svc.get_share_status(1, 2) == "accepted"
+        assert svc.get_share_status(2, 1) == "accepted"
+
+    def test_accept_nonexistent_returns_false(self, db_path, make_user):
+        make_user(1, 2)
+        svc = DataShareService(db_path)
+        assert svc.accept_request(2, 1) is False
+
+    def test_decline_request(self, db_path, make_user):
+        make_user(1, 2)
+        svc = DataShareService(db_path)
+        svc.send_request(1, 2)
+        assert svc.decline_request(2, 1) is True
+        assert svc.get_share_status(1, 2) is None
+
+    def test_cancel_request_and_resend(self, db_path, make_user):
+        make_user(1, 2)
+        svc = DataShareService(db_path)
+        svc.send_request(1, 2)
+        assert svc.get_share_status(1, 2) == "pending_outgoing"
+        assert svc.cancel_request(1, 2) is True
+        assert svc.get_share_status(1, 2) is None
+        assert svc.send_request(1, 2) is True
+        assert svc.get_share_status(1, 2) == "pending_outgoing"
+
+    def test_revoke_share(self, db_path, make_user):
+        make_user(1, 2)
+        svc = DataShareService(db_path)
+        svc.send_request(1, 2)
+        svc.accept_request(2, 1)
+        assert svc.revoke_share(1, 2) is True
+        assert svc.get_share_status(1, 2) is None
+
+    def test_get_incoming_requests(self, db_path, make_user):
+        make_user(1, 2, 3)
+        svc = DataShareService(db_path)
+        svc.send_request(2, 1)
+        svc.send_request(3, 1)
+        incoming = svc.get_incoming_requests(1)
+        assert sorted(incoming) == [2, 3]
+
+    def test_get_outgoing_requests(self, db_path, make_user):
+        make_user(1, 2, 3)
+        svc = DataShareService(db_path)
+        svc.send_request(1, 2)
+        svc.send_request(1, 3)
+        outgoing = svc.get_outgoing_requests(1)
+        assert sorted(outgoing) == [2, 3]
+
+    def test_get_partners(self, db_path, make_user):
+        make_user(1, 2, 3)
+        svc = DataShareService(db_path)
+        svc.send_request(1, 2)
+        svc.accept_request(2, 1)
+        svc.send_request(3, 1)
+        svc.accept_request(1, 3)
+        partners = svc.get_partners(1)
+        assert sorted(partners) == [2, 3]
+
+    def test_get_partner_users(self, db_path, make_user):
+        user_svc = make_user(1, 2)
+        svc = DataShareService(db_path)
+        svc.send_request(1, 2)
+        svc.accept_request(2, 1)
+        partners = svc.get_partner_users(1, user_svc)
+        assert [u.id for u in partners] == [2]
+
+    def test_get_incoming_request_count(self, db_path, make_user):
+        make_user(1, 2, 3)
+        svc = DataShareService(db_path)
+        assert svc.get_incoming_request_count(1) == 0
+        svc.send_request(2, 1)
+        svc.send_request(3, 1)
+        assert svc.get_incoming_request_count(1) == 2
+
+    def test_get_local_user_id(self, db_path, make_user):
+        user_svc = make_user(1)
+        user_svc.upsert(user_id=1, appuser_id=4242, gym_id=1, display_name="One")
+        svc = DataShareService(db_path)
+        assert svc.get_local_user_id(4242) == 1
+        assert svc.get_local_user_id(9999) is None
+
+    def test_get_share_statuses_for_friends(self, db_path, make_user):
+        user_svc = make_user(1, 2)
+        user_svc.upsert(user_id=2, appuser_id=202, gym_id=2, display_name="Two")
+        svc = DataShareService(db_path)
+        svc.send_request(1, 2)
+        statuses = svc.get_share_statuses_for_friends(1, [202])
+        assert statuses[202] == "pending_outgoing"
+
+    def test_send_request_reverse_direction(self, db_path, make_user):
+        make_user(1, 2)
+        svc = DataShareService(db_path)
+        svc.send_request(2, 1)
+        assert svc.get_share_status(1, 2) == "pending_incoming"
+        assert svc.get_share_status(2, 1) == "pending_outgoing"
+
+    def test_revoked_share_can_be_re_requested(self, db_path, make_user):
+        make_user(1, 2)
+        svc = DataShareService(db_path)
+        svc.send_request(1, 2)
+        svc.accept_request(2, 1)
+        svc.revoke_share(1, 2)
+        assert svc.send_request(1, 2) is True
+        assert svc.get_share_status(1, 2) == "pending_outgoing"
+
+    def test_non_partner_cannot_send_request_to_self(self, db_path, make_user):
+        make_user(1)
+        svc = DataShareService(db_path)
+        assert svc.send_request(1, 1) is False
+
+    def test_get_display_name(self, db_path, make_user):
+        make_user(1)
+        UserService(db_path).upsert(user_id=1, appuser_id=None, gym_id=1, display_name="Alice")
+        svc = DataShareService(db_path)
+        assert svc.get_display_name(1) == "Alice"
+        assert svc.get_display_name(999) is None

--- a/tests/services/test_users_migration.py
+++ b/tests/services/test_users_migration.py
@@ -153,7 +153,7 @@ def migrated_db(tmp_path):
     path = tmp_path / "old.db"
     _build_old_schema(path)
     ran = migrations.ensure_migrations(path)
-    assert set(ran) == set(range(800, 811))
+    assert set(ran) == {210, 800, 801, 802, 803, 804, 805, 806, 807, 808, 809, 810}
     return path
 
 


### PR DESCRIPTION
## Summary

Introduces a bidirectional data sharing system that lets friends share 1RM and Benchmark results. Users send a request to a friend, who can accept or decline. Once accepted, both see each other's data on the 1RM and Benchmark pages via a compare overlay.

## Changes

### Data layer
- **Migration v210**: New `data_shares` table with symmetric `(user_id_a, user_id_b)`, status (pending/accepted/declined), soft-delete, indexes
- **`DataShareService`**: Full CRUD — send, accept, decline, cancel, revoke requests. Query methods for partners, incoming/outgoing requests, share status per friend

### UI — Friends page
- **Incoming requests section** at top with Accept/Decline buttons
- **Share status badges** on each friend card: "Request share" button, "Pending" badge + cancel, "Shared" badge + revoke
- **Nav bar badge** on friends icon showing pending incoming request count

### UI — Compare views
- **1RM and Benchmark pages**: "Compare with…" dropdown populated with sharing partners
- Selecting a partner fetches their data via API and overlays it as a dashed orange line on the chart with legend
- Empty state links to /friends when no partners exist

### API
- `POST /friends/{id}/request-share`, `cancel-request`, `accept-share/{id}`, `decline-share/{id}`, `revoke-share/{id}`
- `GET /api/one-rep-maxes/compare?with_user_id=X`
- `GET /api/benchmark/compare?with_user_id=X`

### Tests
- 19 unit tests for `DataShareService` covering all operations and edge cases

## Notes
- Existing friendships are unchanged — sharing is opt-in only
- Revoke/cancel allows re-requesting (hard-delete on cancel, soft-delete re-activation on revoke -> re-send)
- Sharing is bidirectional: either party can revoke at any time