### PR TITLE
fix: clarify bidirectional sharing text and fix chart colors

### DIFF
--- a/src/wodplanner/app/templates/benchmark.html
+++ b/src/wodplanner/app/templates/benchmark.html
@@ -174,17 +174,17 @@ function updateBenchmarkChart() {
             prRadii.push(8);
             prBorders.push('#d97706');
         } else {
-            prColors.push('#7c3aed');
+            prColors.push('#f59e0b');
             prRadii.push(4);
-            prBorders.push('#7c3aed');
+            prBorders.push('#f59e0b');
         }
     }
 
     var datasets = [{
         label: name + ' (seconds)',
         data: times,
-        borderColor: '#7c3aed',
-        backgroundColor: 'rgba(124,58,237,0.08)',
+        borderColor: '#f59e0b',
+        backgroundColor: 'rgba(245,158,11,0.08)',
         tension: 0.2,
         fill: true,
         pointBackgroundColor: prColors,

--- a/src/wodplanner/app/templates/friends.html
+++ b/src/wodplanner/app/templates/friends.html
@@ -58,7 +58,7 @@
             </div>
             <div class="friend-info">
                 <span class="friend-name">{{ req.display_name }}</span>
-                <span class="friend-meta">Wants to share results with you</span>
+                <span class="friend-meta">Wants to share results with you (you'll both see each other's data)</span>
             </div>
             <div class="friend-actions">
                 <button class="btn btn-sm btn-primary"

--- a/src/wodplanner/app/templates/one_rep_max.html
+++ b/src/wodplanner/app/templates/one_rep_max.html
@@ -174,9 +174,9 @@ function update1rmChart() {
             prRadii.push(8);
             prBorders.push('#d97706');
         } else {
-            prColors.push('#7c3aed');
+            prColors.push('#f59e0b');
             prRadii.push(4);
-            prBorders.push('#7c3aed');
+            prBorders.push('#f59e0b');
         }
     }
 
@@ -187,8 +187,8 @@ function update1rmChart() {
     var datasets = [{
         label: exercise + ' (kg)',
         data: weights,
-        borderColor: '#7c3aed',
-        backgroundColor: 'rgba(124,58,237,0.08)',
+        borderColor: '#f59e0b',
+        backgroundColor: 'rgba(245,158,11,0.08)',
         tension: 0.2,
         fill: true,
         pointBackgroundColor: prColors,

--- a/src/wodplanner/app/templates/partials/one_rep_max_modal.html
+++ b/src/wodplanner/app/templates/partials/one_rep_max_modal.html
@@ -122,9 +122,9 @@ function modalUpdate1rmChart() {
             prRadii.push(7);
             prBorders.push('#d97706');
         } else {
-            prColors.push('#7c3aed');
+            prColors.push('#f59e0b');
             prRadii.push(4);
-            prBorders.push('#7c3aed');
+            prBorders.push('#f59e0b');
         }
     }
 
@@ -140,8 +140,8 @@ function modalUpdate1rmChart() {
             datasets: [{
                 label: exercise + ' (kg)',
                 data: weights,
-                borderColor: '#7c3aed',
-                backgroundColor: 'rgba(124,58,237,0.08)',
+                borderColor: '#f59e0b',
+                backgroundColor: 'rgba(245,158,11,0.08)',
                 tension: 0.2,
                 fill: true,
                 pointBackgroundColor: prColors,


### PR DESCRIPTION
## Summary

Polish fixes for the data sharing feature (follow-up to #246).

## Changes

1. **Clearer sharing explanation** — Incoming share request text now reads: "Wants to share results with you (you'll both see each other's data)" so it's obvious the relationship is bidirectional.

2. **Fixed chart colors** — The user's own line was purple while their PR dots were yellow, causing a confusing legend (purple vs orange). The user's line is now yellow to match the PR dots, so the legend consistently shows:
   - **Yellow** = you
   - **Orange** = compared friend

Applied consistently across 1RM, Benchmark, and the 1RM modal charts.