### PR TITLE
feat: show all partners' compare data by default with filter and checkbox

### DIFF
--- a/src/wodplanner/app/routers/views.py
+++ b/src/wodplanner/app/routers/views.py
@@ -1272,6 +1272,27 @@ def compare_one_rep_max(
     return JSONResponse(json.loads(data))
 
 
+@router.get("/api/one-rep-maxes/compare-all")
+def compare_all_one_rep_max(
+    session: Annotated[AuthSession, Depends(require_session)],
+    one_rep_max_service: OneRepMaxService = Depends(get_one_rep_max_service),
+    data_share_service: DataShareService = Depends(get_data_share_service),
+    user_service: UserService = Depends(get_user_service),
+):
+    """Get all partners' 1RM data for compare overlay. Returns JSON."""
+    partners = data_share_service.get_partners(session.user_id)
+    result = {}
+    partner_info = {}
+    for pid in partners:
+        u = user_service.get(pid)
+        partner_info[str(pid)] = u.display_name if u else "Unknown"
+        raw = one_rep_max_service.get_all(pid)
+        formatted = _format_1rm_entries(raw)
+        data = _build_exercises_chart_data(formatted)
+        result[str(pid)] = json.loads(data)
+    return JSONResponse({"data": result, "partners": partner_info})
+
+
 @router.get("/api/benchmark/compare")
 def compare_benchmark(
     session: Annotated[AuthSession, Depends(require_session)],
@@ -1290,6 +1311,27 @@ def compare_benchmark(
     entries = _format_benchmark_entries(raw)
     data = _build_benchmark_chart_data(entries)
     return JSONResponse(json.loads(data))
+
+
+@router.get("/api/benchmark/compare-all")
+def compare_all_benchmark(
+    session: Annotated[AuthSession, Depends(require_session)],
+    benchmark_service: BenchmarkService = Depends(get_benchmark_service),
+    data_share_service: DataShareService = Depends(get_data_share_service),
+    user_service: UserService = Depends(get_user_service),
+):
+    """Get all partners' benchmark data for compare overlay. Returns JSON."""
+    partners = data_share_service.get_partners(session.user_id)
+    result = {}
+    partner_info = {}
+    for pid in partners:
+        u = user_service.get(pid)
+        partner_info[str(pid)] = u.display_name if u else "Unknown"
+        raw = benchmark_service.get_all_results(pid)
+        formatted = _format_benchmark_entries(raw)
+        data = _build_benchmark_chart_data(formatted)
+        result[str(pid)] = json.loads(data)
+    return JSONResponse({"data": result, "partners": partner_info})
 
 
 @router.get("/appointments/{appointment_id}/schedule", response_class=HTMLResponse)
@@ -1541,6 +1583,7 @@ def benchmark_modal_view(
 
     raw = benchmark_service.get_results_for_benchmark(session.user_id, benchmark_name)
     entries = _format_benchmark_entries(raw)
+    benchmark_data_json = _build_benchmark_chart_data(entries)
 
     return render(
         request,
@@ -1549,6 +1592,7 @@ def benchmark_modal_view(
             "benchmark_name": benchmark_name,
             "entries": entries,
             "preset_date": schedule_date.isoformat(),
+            "benchmark_data_json": benchmark_data_json,
         },
     )
 

--- a/src/wodplanner/app/templates/benchmark.html
+++ b/src/wodplanner/app/templates/benchmark.html
@@ -80,12 +80,11 @@
             {{ picker("progress_benchmark", benchmark_list, recent=benchmarks_by_recency, placeholder="Select benchmark\u2026", id_suffix="bp") }}
         </div>
         {% if partners %}
-        <select id="compare-partner" class="form-control" style="width:auto;max-width:180px;margin-left:0.5rem;" onchange="updateCompareBenchmark()">
-            <option value="">Compare with…</option>
-            {% for p in partners %}
-            <option value="{{ p.id }}">{{ p.display_name }}</option>
-            {% endfor %}
-        </select>
+        <label class="checkbox-label" style="margin-left:0.5rem;white-space:nowrap;display:flex;align-items:center;gap:0.3rem;">
+            <input type="checkbox" id="show-compare" checked onchange="toggleCompare()">
+            Show partners
+        </label>
+        <input type="text" id="filter-partner" placeholder="Filter partner..." class="form-control" style="width:auto;max-width:120px;margin-left:0.3rem;" oninput="updateCompareFilter()">
         {% else %}
         <a href="/friends" class="btn btn-sm btn-secondary" style="margin-left:0.5rem;white-space:nowrap;">Compare results with a friend</a>
         {% endif %}
@@ -107,9 +106,23 @@
 
 <script>
 var __benchmarkData = {{ benchmark_data_json | safe }};
-var __benchmarkCompareData = null;
+var __benchmarkCompareAllData = null;
+var __benchmarkPartnerInfo = null;
 var __benchmarkChart = null;
 var __benchmarkLogFormOpen = false;
+
+var PARTNER_COLORS = [
+    { border: '#f97316', bg: 'rgba(249,115,22,0.05)', point: '#f97316', pointBorder: '#ea580c' },
+    { border: '#3b82f6', bg: 'rgba(59,130,246,0.05)', point: '#3b82f6', pointBorder: '#2563eb' },
+    { border: '#10b981', bg: 'rgba(16,185,129,0.05)', point: '#10b981', pointBorder: '#059669' },
+    { border: '#ef4444', bg: 'rgba(239,68,68,0.05)', point: '#ef4444', pointBorder: '#dc2626' },
+    { border: '#8b5cf6', bg: 'rgba(139,92,246,0.05)', point: '#8b5cf6', pointBorder: '#7c3aed' },
+    { border: '#06b6d4', bg: 'rgba(6,182,212,0.05)', point: '#06b6d4', pointBorder: '#0891b2' },
+    { border: '#ec4899', bg: 'rgba(236,72,153,0.05)', point: '#ec4899', pointBorder: '#db2777' },
+    { border: '#84cc16', bg: 'rgba(132,204,22,0.05)', point: '#84cc16', pointBorder: '#65a30d' },
+    { border: '#6366f1', bg: 'rgba(99,102,241,0.05)', point: '#6366f1', pointBorder: '#4f46e5' },
+    { border: '#14b8a6', bg: 'rgba(20,184,166,0.05)', point: '#14b8a6', pointBorder: '#0d9488' },
+];
 
 function toggleBenchmarkLogForm() {
     __benchmarkLogFormOpen = !__benchmarkLogFormOpen;
@@ -122,24 +135,39 @@ function formatTime(seconds) {
     return m + ':' + (s < 10 ? '0' : '') + s;
 }
 
-function updateCompareBenchmark() {
-    var select = document.getElementById('compare-partner');
-    var partnerId = select ? select.value : '';
-    if (!partnerId) {
-        __benchmarkCompareData = null;
-        updateBenchmarkChart();
-        return;
+function alignDataToLabels(sortedPoints, labels, valueKey) {
+    var map = {};
+    for (var i = 0; i < sortedPoints.length; i++) {
+        map[sortedPoints[i].date] = sortedPoints[i];
     }
-    fetch('/api/benchmark/compare?with_user_id=' + partnerId)
+    return labels.map(function(l) {
+        var p = map[l];
+        return p ? p[valueKey] : null;
+    });
+}
+
+function fetchAllCompareData() {
+    var el = document.getElementById('show-compare');
+    if (!el) return;
+    fetch('/api/benchmark/compare-all')
         .then(function(r) { return r.json(); })
-        .then(function(data) {
-            __benchmarkCompareData = data;
+        .then(function(response) {
+            __benchmarkCompareAllData = response.data;
+            __benchmarkPartnerInfo = response.partners;
             updateBenchmarkChart();
         })
         .catch(function() {
-            __benchmarkCompareData = null;
-            updateBenchmarkChart();
+            __benchmarkCompareAllData = null;
+            __benchmarkPartnerInfo = null;
         });
+}
+
+function toggleCompare() {
+    updateBenchmarkChart();
+}
+
+function updateCompareFilter() {
+    updateBenchmarkChart();
 }
 
 function updateBenchmarkChart() {
@@ -149,7 +177,45 @@ function updateBenchmarkChart() {
     if (!hidden || !canvas) return;
     var name = hidden.value;
 
-    if (!name || !__benchmarkData[name] || !__benchmarkData[name].length) {
+    var showCompare = document.getElementById('show-compare') ? document.getElementById('show-compare').checked : false;
+    var filterText = (document.getElementById('filter-partner') ? document.getElementById('filter-partner').value : '').toLowerCase();
+
+    var hasUserData = __benchmarkData && __benchmarkData[name] && __benchmarkData[name].length;
+    var allLabels = [];
+    var labelToDate = {};
+
+    var hasPartnerData = false;
+    if (showCompare && __benchmarkCompareAllData && __benchmarkPartnerInfo) {
+        for (var pid in __benchmarkCompareAllData) {
+            if (!__benchmarkCompareAllData[pid][name] || !__benchmarkCompareAllData[pid][name].length) continue;
+            var pname = (__benchmarkPartnerInfo[pid] || '').toLowerCase();
+            if (filterText && pname.indexOf(filterText) === -1) continue;
+            hasPartnerData = true;
+            var cp = __benchmarkCompareAllData[pid][name];
+            for (var i = 0; i < cp.length; i++) {
+                var l = cp[i].date;
+                if (allLabels.indexOf(l) === -1) {
+                    allLabels.push(l);
+                    labelToDate[l] = cp[i].date;
+                }
+            }
+        }
+    }
+
+    if (hasUserData) {
+        var points = __benchmarkData[name];
+        for (var i = 0; i < points.length; i++) {
+            var l = points[i].date;
+            if (allLabels.indexOf(l) === -1) {
+                allLabels.push(l);
+                labelToDate[l] = points[i].date;
+            }
+        }
+    }
+
+    allLabels.sort();
+
+    if (!hasUserData && !hasPartnerData) {
         canvas.style.display = 'none';
         noData.style.display = 'block';
         if (__benchmarkChart) { __benchmarkChart.destroy(); __benchmarkChart = null; }
@@ -159,69 +225,84 @@ function updateBenchmarkChart() {
     canvas.style.display = 'block';
     noData.style.display = 'none';
 
-    var points = __benchmarkData[name];
-    var sorted = points.slice().sort(function(a, b) { return a.date < b.date ? -1 : a.date > b.date ? 1 : 0; });
-    var labels = sorted.map(function(p) { return p.label; });
-    var times = sorted.map(function(p) { return p.time; });
+    var datasets = [];
 
-    var prColors = [], prRadii = [], prBorders = [];
-    var runningMin = Infinity;
-    for (var i = 0; i < sorted.length; i++) {
-        var t = sorted[i].time;
-        if (t < runningMin) {
-            runningMin = t;
-            prColors.push('#f59e0b');
-            prRadii.push(8);
-            prBorders.push('#d97706');
-        } else {
-            prColors.push('#f59e0b');
-            prRadii.push(4);
-            prBorders.push('#f59e0b');
+    if (hasUserData) {
+        var points = __benchmarkData[name];
+        var sorted = points.slice().sort(function(a, b) { return a.date < b.date ? -1 : a.date > b.date ? 1 : 0; });
+        var times = alignDataToLabels(sorted, allLabels, 'time');
+
+        var prColors = [], prRadii = [], prBorders = [];
+        var runningMin = Infinity;
+        var idxMap = {};
+        for (var i = 0; i < sorted.length; i++) {
+            idxMap[sorted[i].date] = i;
         }
+        for (var i = 0; i < allLabels.length; i++) {
+            var si = idxMap[allLabels[i]];
+            if (si !== undefined) {
+                var t = sorted[si].time;
+                if (t < runningMin) {
+                    runningMin = t;
+                    prColors.push('#f59e0b');
+                    prRadii.push(8);
+                    prBorders.push('#d97706');
+                } else {
+                    prColors.push('#f59e0b');
+                    prRadii.push(4);
+                    prBorders.push('#f59e0b');
+                }
+            }
+        }
+
+        datasets.push({
+            label: name + ' (seconds)',
+            data: times,
+            borderColor: '#f59e0b',
+            backgroundColor: 'rgba(245,158,11,0.08)',
+            tension: 0.2,
+            fill: true,
+            pointBackgroundColor: prColors,
+            pointBorderColor: prBorders,
+            pointRadius: prRadii,
+            pointBorderWidth: 2,
+            pointHoverRadius: 10,
+        });
     }
 
-    var datasets = [{
-        label: name + ' (seconds)',
-        data: times,
-        borderColor: '#f59e0b',
-        backgroundColor: 'rgba(245,158,11,0.08)',
-        tension: 0.2,
-        fill: true,
-        pointBackgroundColor: prColors,
-        pointBorderColor: prBorders,
-        pointRadius: prRadii,
-        pointBorderWidth: 2,
-        pointHoverRadius: 10,
-    }];
-
-    // Add compare dataset if available
-    var compareSelect = document.getElementById('compare-partner');
-    var partnerName = compareSelect ? compareSelect.options[compareSelect.selectedIndex]?.text : '';
-    if (__benchmarkCompareData && __benchmarkCompareData[name] && __benchmarkCompareData[name].length) {
-        var cp = __benchmarkCompareData[name];
-        var cSorted = cp.slice().sort(function(a, b) { return a.date < b.date ? -1 : a.date > b.date ? 1 : 0; });
-        var cTimes = cSorted.map(function(p) { return p.time; });
-        datasets.push({
-            label: (partnerName || 'Friend') + ' (seconds)',
-            data: cTimes,
-            borderColor: '#f97316',
-            backgroundColor: 'rgba(249,115,22,0.05)',
-            borderDash: [5, 5],
-            tension: 0.2,
-            fill: false,
-            pointBackgroundColor: '#f97316',
-            pointBorderColor: '#ea580c',
-            pointRadius: 5,
-            pointBorderWidth: 2,
-            pointHoverRadius: 8,
-        });
+    if (showCompare && __benchmarkCompareAllData && __benchmarkPartnerInfo) {
+        var colorIndex = 0;
+        for (var pid in __benchmarkCompareAllData) {
+            if (!__benchmarkCompareAllData[pid][name] || !__benchmarkCompareAllData[pid][name].length) continue;
+            var pname = (__benchmarkPartnerInfo[pid] || '').toLowerCase();
+            if (filterText && pname.indexOf(filterText) === -1) continue;
+            var cp = __benchmarkCompareAllData[pid][name];
+            var cSorted = cp.slice().sort(function(a, b) { return a.date < b.date ? -1 : a.date > b.date ? 1 : 0; });
+            var cTimes = alignDataToLabels(cSorted, allLabels, 'time');
+            var color = PARTNER_COLORS[colorIndex % PARTNER_COLORS.length];
+            colorIndex++;
+            datasets.push({
+                label: (__benchmarkPartnerInfo[pid] || 'Friend') + ' (seconds)',
+                data: cTimes,
+                borderColor: color.border,
+                backgroundColor: color.bg,
+                borderDash: [5, 5],
+                tension: 0.2,
+                fill: false,
+                pointBackgroundColor: color.point,
+                pointBorderColor: color.pointBorder,
+                pointRadius: 5,
+                pointBorderWidth: 2,
+                pointHoverRadius: 8,
+            });
+        }
     }
 
     if (__benchmarkChart) __benchmarkChart.destroy();
     __benchmarkChart = new Chart(canvas, {
         type: 'line',
         data: {
-            labels: labels,
+            labels: allLabels,
             datasets: datasets,
         },
         options: {
@@ -271,6 +352,7 @@ document.addEventListener('DOMContentLoaded', function() {
     } else {
         document.getElementById('benchmark-chart').style.display = 'none';
     }
+    fetchAllCompareData();
 });
 
 document.addEventListener('htmx:afterSwap', function(e) {

--- a/src/wodplanner/app/templates/one_rep_max.html
+++ b/src/wodplanner/app/templates/one_rep_max.html
@@ -58,12 +58,11 @@
             {{ picker("progress_exercise", exercises, recent=exercises_by_recency, placeholder="Select exercise…", id_suffix="progress") }}
         </div>
         {% if partners %}
-        <select id="compare-partner" class="form-control" style="width:auto;max-width:180px;margin-left:0.5rem;" onchange="updateCompareChart()">
-            <option value="">Compare with…</option>
-            {% for p in partners %}
-            <option value="{{ p.id }}">{{ p.display_name }}</option>
-            {% endfor %}
-        </select>
+        <label class="checkbox-label" style="margin-left:0.5rem;white-space:nowrap;display:flex;align-items:center;gap:0.3rem;">
+            <input type="checkbox" id="show-compare" checked onchange="toggleCompare()">
+            Show partners
+        </label>
+        <input type="text" id="filter-partner" placeholder="Filter partner..." class="form-control" style="width:auto;max-width:120px;margin-left:0.3rem;" oninput="updateCompareFilter()">
         {% else %}
         <a href="/friends" class="btn btn-sm btn-secondary" style="margin-left:0.5rem;white-space:nowrap;">Compare results with a friend</a>
         {% endif %}
@@ -95,11 +94,26 @@
 
 <script>
 var __1rmData = {{ exercises_data_json | safe }};
-var __1rmCompareData = null;
+var __1rmCompareAllData = null;
+var __1rmPartnerInfo = null;
 var __1rmChart = null;
 var __1rmLogFormOpen = false;
 var __1rmMaxWeight = null;
 var __1rmCurrentPct = 100;
+
+var PARTNER_COLORS = [
+    { border: '#f97316', bg: 'rgba(249,115,22,0.05)', point: '#f97316', pointBorder: '#ea580c' },
+    { border: '#3b82f6', bg: 'rgba(59,130,246,0.05)', point: '#3b82f6', pointBorder: '#2563eb' },
+    { border: '#10b981', bg: 'rgba(16,185,129,0.05)', point: '#10b981', pointBorder: '#059669' },
+    { border: '#ef4444', bg: 'rgba(239,68,68,0.05)', point: '#ef4444', pointBorder: '#dc2626' },
+    { border: '#8b5cf6', bg: 'rgba(139,92,246,0.05)', point: '#8b5cf6', pointBorder: '#7c3aed' },
+    { border: '#06b6d4', bg: 'rgba(6,182,212,0.05)', point: '#06b6d4', pointBorder: '#0891b2' },
+    { border: '#ec4899', bg: 'rgba(236,72,153,0.05)', point: '#ec4899', pointBorder: '#db2777' },
+    { border: '#84cc16', bg: 'rgba(132,204,22,0.05)', point: '#84cc16', pointBorder: '#65a30d' },
+    { border: '#6366f1', bg: 'rgba(99,102,241,0.05)', point: '#6366f1', pointBorder: '#4f46e5' },
+    { border: '#14b8a6', bg: 'rgba(20,184,166,0.05)', point: '#14b8a6', pointBorder: '#0d9488' },
+];
+
 function stepPct(delta) {
     setPct(Math.min(100, Math.max(0, __1rmCurrentPct + delta)));
 }
@@ -121,24 +135,39 @@ function updatePctDisplay() {
         : '—';
 }
 
-function updateCompareChart() {
-    var select = document.getElementById('compare-partner');
-    var partnerId = select ? select.value : '';
-    if (!partnerId) {
-        __1rmCompareData = null;
-        update1rmChart();
-        return;
+function alignDataToLabels(sortedPoints, labels, valueKey) {
+    var map = {};
+    for (var i = 0; i < sortedPoints.length; i++) {
+        map[sortedPoints[i].label] = sortedPoints[i];
     }
-    fetch('/api/one-rep-maxes/compare?with_user_id=' + partnerId)
+    return labels.map(function(l) {
+        var p = map[l];
+        return p ? p[valueKey] : null;
+    });
+}
+
+function fetchAllCompareData() {
+    var el = document.getElementById('show-compare');
+    if (!el) return;
+    fetch('/api/one-rep-maxes/compare-all')
         .then(function(r) { return r.json(); })
-        .then(function(data) {
-            __1rmCompareData = data;
+        .then(function(response) {
+            __1rmCompareAllData = response.data;
+            __1rmPartnerInfo = response.partners;
             update1rmChart();
         })
         .catch(function() {
-            __1rmCompareData = null;
-            update1rmChart();
+            __1rmCompareAllData = null;
+            __1rmPartnerInfo = null;
         });
+}
+
+function toggleCompare() {
+    update1rmChart();
+}
+
+function updateCompareFilter() {
+    update1rmChart();
 }
 
 function update1rmChart() {
@@ -148,7 +177,45 @@ function update1rmChart() {
     if (!hidden || !canvas) return;
     var exercise = hidden.value;
 
-    if (!exercise || !__1rmData[exercise] || !__1rmData[exercise].length) {
+    var showCompare = document.getElementById('show-compare') ? document.getElementById('show-compare').checked : false;
+    var filterText = (document.getElementById('filter-partner') ? document.getElementById('filter-partner').value : '').toLowerCase();
+
+    var hasUserData = __1rmData && __1rmData[exercise] && __1rmData[exercise].length;
+    var allLabels = [];
+    var labelToDate = {};
+
+    var hasPartnerData = false;
+    if (showCompare && __1rmCompareAllData && __1rmPartnerInfo) {
+        for (var pid in __1rmCompareAllData) {
+            if (!__1rmCompareAllData[pid][exercise] || !__1rmCompareAllData[pid][exercise].length) continue;
+            var name = (__1rmPartnerInfo[pid] || '').toLowerCase();
+            if (filterText && name.indexOf(filterText) === -1) continue;
+            hasPartnerData = true;
+            var cp = __1rmCompareAllData[pid][exercise];
+            for (var i = 0; i < cp.length; i++) {
+                var l = cp[i].label;
+                if (allLabels.indexOf(l) === -1) {
+                    allLabels.push(l);
+                    labelToDate[l] = cp[i].date;
+                }
+            }
+        }
+    }
+
+    if (hasUserData) {
+        var points = __1rmData[exercise];
+        for (var i = 0; i < points.length; i++) {
+            var l = points[i].label;
+            if (allLabels.indexOf(l) === -1) {
+                allLabels.push(l);
+                labelToDate[l] = points[i].date;
+            }
+        }
+    }
+
+    allLabels.sort(function(a, b) { return labelToDate[a] < labelToDate[b] ? -1 : labelToDate[a] > labelToDate[b] ? 1 : 0; });
+
+    if (!hasUserData && !hasPartnerData) {
         canvas.style.display = 'none';
         noData.style.display = 'block';
         document.getElementById('pct-section').style.display = 'none';
@@ -159,73 +226,90 @@ function update1rmChart() {
     canvas.style.display = 'block';
     noData.style.display = 'none';
 
-    var points = __1rmData[exercise];
-    var sorted = points.slice().sort(function(a, b) { return a.date < b.date ? -1 : a.date > b.date ? 1 : 0; });
-    var labels = sorted.map(function(p) { return p.label; });
-    var weights = sorted.map(function(p) { return p.weight; });
+    var datasets = [];
 
-    var prColors = [], prRadii = [], prBorders = [];
-    var runningMax = 0;
-    for (var i = 0; i < sorted.length; i++) {
-        var w = sorted[i].weight;
-        if (w > runningMax) {
-            runningMax = w;
-            prColors.push('#f59e0b');
-            prRadii.push(8);
-            prBorders.push('#d97706');
-        } else {
-            prColors.push('#f59e0b');
-            prRadii.push(4);
-            prBorders.push('#f59e0b');
+    if (hasUserData) {
+        var points = __1rmData[exercise];
+        var sorted = points.slice().sort(function(a, b) { return a.date < b.date ? -1 : a.date > b.date ? 1 : 0; });
+        var weights = alignDataToLabels(sorted, allLabels, 'weight');
+
+        var prColors = [], prRadii = [], prBorders = [];
+        var runningMax = 0;
+        var idxMap = {};
+        for (var i = 0; i < sorted.length; i++) {
+            idxMap[sorted[i].label] = i;
         }
+        for (var i = 0; i < allLabels.length; i++) {
+            var si = idxMap[allLabels[i]];
+            if (si !== undefined) {
+                var w = sorted[si].weight;
+                if (w > runningMax) {
+                    runningMax = w;
+                    prColors.push('#f59e0b');
+                    prRadii.push(8);
+                    prBorders.push('#d97706');
+                } else {
+                    prColors.push('#f59e0b');
+                    prRadii.push(4);
+                    prBorders.push('#f59e0b');
+                }
+            }
+        }
+
+        __1rmMaxWeight = runningMax;
+        document.getElementById('pct-section').style.display = 'block';
+        setPct(100);
+
+        datasets.push({
+            label: exercise + ' (kg)',
+            data: weights,
+            borderColor: '#f59e0b',
+            backgroundColor: 'rgba(245,158,11,0.08)',
+            tension: 0.2,
+            fill: true,
+            pointBackgroundColor: prColors,
+            pointBorderColor: prBorders,
+            pointRadius: prRadii,
+            pointBorderWidth: 2,
+            pointHoverRadius: 10,
+        });
+    } else {
+        document.getElementById('pct-section').style.display = 'none';
     }
 
-    __1rmMaxWeight = runningMax;
-    document.getElementById('pct-section').style.display = 'block';
-    setPct(100);
-
-    var datasets = [{
-        label: exercise + ' (kg)',
-        data: weights,
-        borderColor: '#f59e0b',
-        backgroundColor: 'rgba(245,158,11,0.08)',
-        tension: 0.2,
-        fill: true,
-        pointBackgroundColor: prColors,
-        pointBorderColor: prBorders,
-        pointRadius: prRadii,
-        pointBorderWidth: 2,
-        pointHoverRadius: 10,
-    }];
-
-    // Add compare dataset if available
-    var compareSelect = document.getElementById('compare-partner');
-    var partnerName = compareSelect ? compareSelect.options[compareSelect.selectedIndex]?.text : '';
-    if (__1rmCompareData && __1rmCompareData[exercise] && __1rmCompareData[exercise].length) {
-        var cp = __1rmCompareData[exercise];
-        var cSorted = cp.slice().sort(function(a, b) { return a.date < b.date ? -1 : a.date > b.date ? 1 : 0; });
-        var cWeights = cSorted.map(function(p) { return p.weight; });
-        datasets.push({
-            label: (partnerName || 'Friend') + ' (kg)',
-            data: cWeights,
-            borderColor: '#f97316',
-            backgroundColor: 'rgba(249,115,22,0.05)',
-            borderDash: [5, 5],
-            tension: 0.2,
-            fill: false,
-            pointBackgroundColor: '#f97316',
-            pointBorderColor: '#ea580c',
-            pointRadius: 5,
-            pointBorderWidth: 2,
-            pointHoverRadius: 8,
-        });
+    if (showCompare && __1rmCompareAllData && __1rmPartnerInfo) {
+        var colorIndex = 0;
+        for (var pid in __1rmCompareAllData) {
+            if (!__1rmCompareAllData[pid][exercise] || !__1rmCompareAllData[pid][exercise].length) continue;
+            var name = (__1rmPartnerInfo[pid] || '').toLowerCase();
+            if (filterText && name.indexOf(filterText) === -1) continue;
+            var cp = __1rmCompareAllData[pid][exercise];
+            var cSorted = cp.slice().sort(function(a, b) { return a.date < b.date ? -1 : a.date > b.date ? 1 : 0; });
+            var cWeights = alignDataToLabels(cSorted, allLabels, 'weight');
+            var color = PARTNER_COLORS[colorIndex % PARTNER_COLORS.length];
+            colorIndex++;
+            datasets.push({
+                label: (__1rmPartnerInfo[pid] || 'Friend') + ' (kg)',
+                data: cWeights,
+                borderColor: color.border,
+                backgroundColor: color.bg,
+                borderDash: [5, 5],
+                tension: 0.2,
+                fill: false,
+                pointBackgroundColor: color.point,
+                pointBorderColor: color.pointBorder,
+                pointRadius: 5,
+                pointBorderWidth: 2,
+                pointHoverRadius: 8,
+            });
+        }
     }
 
     if (__1rmChart) __1rmChart.destroy();
     __1rmChart = new Chart(canvas, {
         type: 'line',
         data: {
-            labels: labels,
+            labels: allLabels,
             datasets: datasets,
         },
         options: {
@@ -262,6 +346,7 @@ document.addEventListener('DOMContentLoaded', function() {
     } else {
         document.getElementById('1rm-chart').style.display = 'none';
     }
+    fetchAllCompareData();
 });
 
 document.addEventListener('htmx:afterSwap', function(e) {

--- a/src/wodplanner/app/templates/partials/benchmark_modal.html
+++ b/src/wodplanner/app/templates/partials/benchmark_modal.html
@@ -51,6 +51,221 @@
             </div>
         </form>
 
+        <div class="benchmark-chart-container" style="margin-top:1rem;">
+            <canvas id="modal-benchmark-chart" style="display:none;height:200px;"></canvas>
+            <p id="modal-benchmark-no-data" class="text-muted benchmark-empty">No results yet for this benchmark.</p>
+        </div>
+
         {% include "partials/benchmark_history.html" %}
     </div>
 </div>
+<script>
+var __modalBenchmarkData = {{ benchmark_data_json | safe }};
+var __modalBenchmarkCompareAllData = null;
+var __modalBenchmarkPartnerInfo = null;
+var __modalBenchmarkChart = null;
+var __modalBenchmarkName = '{{ benchmark_name }}';
+
+var PARTNER_COLORS = [
+    { border: '#f97316', bg: 'rgba(249,115,22,0.05)', point: '#f97316', pointBorder: '#ea580c' },
+    { border: '#3b82f6', bg: 'rgba(59,130,246,0.05)', point: '#3b82f6', pointBorder: '#2563eb' },
+    { border: '#10b981', bg: 'rgba(16,185,129,0.05)', point: '#10b981', pointBorder: '#059669' },
+    { border: '#ef4444', bg: 'rgba(239,68,68,0.05)', point: '#ef4444', pointBorder: '#dc2626' },
+    { border: '#8b5cf6', bg: 'rgba(139,92,246,0.05)', point: '#8b5cf6', pointBorder: '#7c3aed' },
+    { border: '#06b6d4', bg: 'rgba(6,182,212,0.05)', point: '#06b6d4', pointBorder: '#0891b2' },
+    { border: '#ec4899', bg: 'rgba(236,72,153,0.05)', point: '#ec4899', pointBorder: '#db2777' },
+    { border: '#84cc16', bg: 'rgba(132,204,22,0.05)', point: '#84cc16', pointBorder: '#65a30d' },
+    { border: '#6366f1', bg: 'rgba(99,102,241,0.05)', point: '#6366f1', pointBorder: '#4f46e5' },
+    { border: '#14b8a6', bg: 'rgba(20,184,166,0.05)', point: '#14b8a6', pointBorder: '#0d9488' },
+];
+
+function formatTime(seconds) {
+    var m = Math.floor(seconds / 60);
+    var s = seconds % 60;
+    return m + ':' + (s < 10 ? '0' : '') + s;
+}
+
+function alignDataToLabels(sortedPoints, labels, valueKey) {
+    var map = {};
+    for (var i = 0; i < sortedPoints.length; i++) {
+        map[sortedPoints[i].date] = sortedPoints[i];
+    }
+    return labels.map(function(l) {
+        var p = map[l];
+        return p ? p[valueKey] : null;
+    });
+}
+
+function modalBenchmarkFetchCompare() {
+    fetch('/api/benchmark/compare-all')
+        .then(function(r) { return r.json(); })
+        .then(function(response) {
+            __modalBenchmarkCompareAllData = response.data;
+            __modalBenchmarkPartnerInfo = response.partners;
+            modalUpdateBenchmarkChart();
+        })
+        .catch(function() {
+            __modalBenchmarkCompareAllData = null;
+            __modalBenchmarkPartnerInfo = null;
+        });
+}
+
+function modalUpdateBenchmarkChart() {
+    var canvas = document.getElementById('modal-benchmark-chart');
+    var noData = document.getElementById('modal-benchmark-no-data');
+    if (!canvas || !noData) return;
+    var name = __modalBenchmarkName;
+
+    var hasUserData = __modalBenchmarkData && __modalBenchmarkData[name] && __modalBenchmarkData[name].length;
+    var allLabels = [];
+
+    var hasPartnerData = false;
+    if (__modalBenchmarkCompareAllData && __modalBenchmarkPartnerInfo) {
+        for (var pid in __modalBenchmarkCompareAllData) {
+            if (!__modalBenchmarkCompareAllData[pid][name] || !__modalBenchmarkCompareAllData[pid][name].length) continue;
+            hasPartnerData = true;
+            var cp = __modalBenchmarkCompareAllData[pid][name];
+            for (var i = 0; i < cp.length; i++) {
+                var l = cp[i].date;
+                if (allLabels.indexOf(l) === -1) allLabels.push(l);
+            }
+        }
+    }
+
+    if (hasUserData) {
+        var points = __modalBenchmarkData[name];
+        for (var i = 0; i < points.length; i++) {
+            var l = points[i].date;
+            if (allLabels.indexOf(l) === -1) allLabels.push(l);
+        }
+    }
+
+    allLabels.sort();
+
+    if (!hasUserData && !hasPartnerData) {
+        canvas.style.display = 'none';
+        noData.style.display = 'block';
+        if (__modalBenchmarkChart) { __modalBenchmarkChart.destroy(); __modalBenchmarkChart = null; }
+        return;
+    }
+
+    canvas.style.display = 'block';
+    noData.style.display = 'none';
+
+    var datasets = [];
+
+    if (hasUserData) {
+        var points = __modalBenchmarkData[name];
+        var sorted = points.slice().sort(function(a, b) { return a.date < b.date ? -1 : a.date > b.date ? 1 : 0; });
+        var times = alignDataToLabels(sorted, allLabels, 'time');
+
+        var prColors = [], prRadii = [], prBorders = [];
+        var runningMin = Infinity;
+        var idxMap = {};
+        for (var i = 0; i < sorted.length; i++) {
+            idxMap[sorted[i].date] = i;
+        }
+        for (var i = 0; i < allLabels.length; i++) {
+            var si = idxMap[allLabels[i]];
+            if (si !== undefined) {
+                var t = sorted[si].time;
+                if (t < runningMin) {
+                    runningMin = t;
+                    prColors.push('#f59e0b');
+                    prRadii.push(8);
+                    prBorders.push('#d97706');
+                } else {
+                    prColors.push('#f59e0b');
+                    prRadii.push(4);
+                    prBorders.push('#f59e0b');
+                }
+            }
+        }
+
+        datasets.push({
+            label: name + ' (seconds)',
+            data: times,
+            borderColor: '#f59e0b',
+            backgroundColor: 'rgba(245,158,11,0.08)',
+            tension: 0.2,
+            fill: true,
+            pointBackgroundColor: prColors,
+            pointBorderColor: prBorders,
+            pointRadius: prRadii,
+            pointBorderWidth: 2,
+            pointHoverRadius: 10,
+        });
+    }
+
+    if (__modalBenchmarkCompareAllData && __modalBenchmarkPartnerInfo) {
+        var colorIndex = 0;
+        for (var pid in __modalBenchmarkCompareAllData) {
+            if (!__modalBenchmarkCompareAllData[pid][name] || !__modalBenchmarkCompareAllData[pid][name].length) continue;
+            var cp = __modalBenchmarkCompareAllData[pid][name];
+            var cSorted = cp.slice().sort(function(a, b) { return a.date < b.date ? -1 : a.date > b.date ? 1 : 0; });
+            var cTimes = alignDataToLabels(cSorted, allLabels, 'time');
+            var color = PARTNER_COLORS[colorIndex % PARTNER_COLORS.length];
+            colorIndex++;
+            datasets.push({
+                label: (__modalBenchmarkPartnerInfo[pid] || 'Friend') + ' (seconds)',
+                data: cTimes,
+                borderColor: color.border,
+                backgroundColor: color.bg,
+                borderDash: [5, 5],
+                tension: 0.2,
+                fill: false,
+                pointBackgroundColor: color.point,
+                pointBorderColor: color.pointBorder,
+                pointRadius: 5,
+                pointBorderWidth: 2,
+                pointHoverRadius: 8,
+            });
+        }
+    }
+
+    if (__modalBenchmarkChart) __modalBenchmarkChart.destroy();
+    __modalBenchmarkChart = new Chart(canvas, {
+        type: 'line',
+        data: {
+            labels: allLabels,
+            datasets: datasets,
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+                legend: { display: datasets.length > 1 },
+                tooltip: {
+                    callbacks: {
+                        label: function(ctx) {
+                            return formatTime(ctx.parsed.y);
+                        }
+                    }
+                }
+            },
+            scales: {
+                y: {
+                    title: { display: true, text: 'Time (mm:ss)' },
+                    ticks: {
+                        callback: function(value) {
+                            return formatTime(value);
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+
+document.addEventListener('htmx:afterSwap', function(e) {
+    if (e.detail.target && e.detail.target.id === 'benchmark-history') {
+        var raw = document.getElementById('benchmark-history').dataset.benchmark;
+        if (!raw) return;
+        __modalBenchmarkData = JSON.parse(raw);
+        modalUpdateBenchmarkChart();
+    }
+});
+
+modalBenchmarkFetchCompare();
+modalUpdateBenchmarkChart();
+</script>

--- a/src/wodplanner/app/templates/partials/one_rep_max_modal.html
+++ b/src/wodplanner/app/templates/partials/one_rep_max_modal.html
@@ -70,9 +70,24 @@
 </style>
 <script>
 var __modal1rmData = {{ exercises_data_json | safe }};
+var __modal1rmCompareAllData = null;
+var __modal1rmPartnerInfo = null;
 var __modal1rmChart = null;
 var __modal1rmMaxWeight = null;
 var __modal1rmCurrentPct = 100;
+
+var PARTNER_COLORS = [
+    { border: '#f97316', bg: 'rgba(249,115,22,0.05)', point: '#f97316', pointBorder: '#ea580c' },
+    { border: '#3b82f6', bg: 'rgba(59,130,246,0.05)', point: '#3b82f6', pointBorder: '#2563eb' },
+    { border: '#10b981', bg: 'rgba(16,185,129,0.05)', point: '#10b981', pointBorder: '#059669' },
+    { border: '#ef4444', bg: 'rgba(239,68,68,0.05)', point: '#ef4444', pointBorder: '#dc2626' },
+    { border: '#8b5cf6', bg: 'rgba(139,92,246,0.05)', point: '#8b5cf6', pointBorder: '#7c3aed' },
+    { border: '#06b6d4', bg: 'rgba(6,182,212,0.05)', point: '#06b6d4', pointBorder: '#0891b2' },
+    { border: '#ec4899', bg: 'rgba(236,72,153,0.05)', point: '#ec4899', pointBorder: '#db2777' },
+    { border: '#84cc16', bg: 'rgba(132,204,22,0.05)', point: '#84cc16', pointBorder: '#65a30d' },
+    { border: '#6366f1', bg: 'rgba(99,102,241,0.05)', point: '#6366f1', pointBorder: '#4f46e5' },
+    { border: '#14b8a6', bg: 'rgba(20,184,166,0.05)', point: '#14b8a6', pointBorder: '#0d9488' },
+];
 
 function modalStepPct(delta) {
     modalSetPct(Math.min(100, Math.max(0, __modal1rmCurrentPct + delta)));
@@ -90,13 +105,71 @@ function modalUpdatePctDisplay() {
         : '—';
 }
 
+function alignDataToLabels(sortedPoints, labels, valueKey) {
+    var map = {};
+    for (var i = 0; i < sortedPoints.length; i++) {
+        map[sortedPoints[i].label] = sortedPoints[i];
+    }
+    return labels.map(function(l) {
+        var p = map[l];
+        return p ? p[valueKey] : null;
+    });
+}
+
+function modalFetchAllCompareData() {
+    fetch('/api/one-rep-maxes/compare-all')
+        .then(function(r) { return r.json(); })
+        .then(function(response) {
+            __modal1rmCompareAllData = response.data;
+            __modal1rmPartnerInfo = response.partners;
+            modalUpdate1rmChart();
+        })
+        .catch(function() {
+            __modal1rmCompareAllData = null;
+            __modal1rmPartnerInfo = null;
+        });
+}
+
 function modalUpdate1rmChart() {
     var hidden = document.getElementById('picker-hidden-modal');
     var canvas = document.getElementById('modal-1rm-chart');
     if (!hidden || !canvas) return;
     var exercise = hidden.value;
 
-    if (!exercise || !__modal1rmData[exercise] || !__modal1rmData[exercise].length) {
+    var hasUserData = __modal1rmData && __modal1rmData[exercise] && __modal1rmData[exercise].length;
+    var allLabels = [];
+    var labelToDate = {};
+
+    var hasPartnerData = false;
+    if (__modal1rmCompareAllData && __modal1rmPartnerInfo) {
+        for (var pid in __modal1rmCompareAllData) {
+            if (!__modal1rmCompareAllData[pid][exercise] || !__modal1rmCompareAllData[pid][exercise].length) continue;
+            hasPartnerData = true;
+            var cp = __modal1rmCompareAllData[pid][exercise];
+            for (var i = 0; i < cp.length; i++) {
+                var l = cp[i].label;
+                if (allLabels.indexOf(l) === -1) {
+                    allLabels.push(l);
+                    labelToDate[l] = cp[i].date;
+                }
+            }
+        }
+    }
+
+    if (hasUserData) {
+        var points = __modal1rmData[exercise];
+        for (var i = 0; i < points.length; i++) {
+            var l = points[i].label;
+            if (allLabels.indexOf(l) === -1) {
+                allLabels.push(l);
+                labelToDate[l] = points[i].date;
+            }
+        }
+    }
+
+    allLabels.sort(function(a, b) { return labelToDate[a] < labelToDate[b] ? -1 : labelToDate[a] > labelToDate[b] ? 1 : 0; });
+
+    if (!hasUserData && !hasPartnerData) {
         canvas.style.display = 'none';
         document.getElementById('modal-1rm-no-data').style.display = 'block';
         document.getElementById('modal-pct-section').style.display = 'none';
@@ -107,54 +180,94 @@ function modalUpdate1rmChart() {
     canvas.style.display = 'block';
     document.getElementById('modal-1rm-no-data').style.display = 'none';
 
-    var points = __modal1rmData[exercise];
-    var sorted = points.slice().sort(function(a, b) { return a.date < b.date ? -1 : a.date > b.date ? 1 : 0; });
-    var labels = sorted.map(function(p) { return p.label; });
-    var weights = sorted.map(function(p) { return p.weight; });
+    var datasets = [];
 
-    var prColors = [], prRadii = [], prBorders = [];
-    var runningMax = 0;
-    for (var i = 0; i < sorted.length; i++) {
-        var w = sorted[i].weight;
-        if (w > runningMax) {
-            runningMax = w;
-            prColors.push('#f59e0b');
-            prRadii.push(7);
-            prBorders.push('#d97706');
-        } else {
-            prColors.push('#f59e0b');
-            prRadii.push(4);
-            prBorders.push('#f59e0b');
+    if (hasUserData) {
+        var points = __modal1rmData[exercise];
+        var sorted = points.slice().sort(function(a, b) { return a.date < b.date ? -1 : a.date > b.date ? 1 : 0; });
+        var weights = alignDataToLabels(sorted, allLabels, 'weight');
+
+        var prColors = [], prRadii = [], prBorders = [];
+        var runningMax = 0;
+        var idxMap = {};
+        for (var i = 0; i < sorted.length; i++) {
+            idxMap[sorted[i].label] = i;
         }
+        for (var i = 0; i < allLabels.length; i++) {
+            var si = idxMap[allLabels[i]];
+            if (si !== undefined) {
+                var w = sorted[si].weight;
+                if (w > runningMax) {
+                    runningMax = w;
+                    prColors.push('#f59e0b');
+                    prRadii.push(7);
+                    prBorders.push('#d97706');
+                } else {
+                    prColors.push('#f59e0b');
+                    prRadii.push(4);
+                    prBorders.push('#f59e0b');
+                }
+            }
+        }
+
+        __modal1rmMaxWeight = runningMax;
+        document.getElementById('modal-pct-section').style.display = 'block';
+        modalSetPct(100);
+
+        datasets.push({
+            label: exercise + ' (kg)',
+            data: weights,
+            borderColor: '#f59e0b',
+            backgroundColor: 'rgba(245,158,11,0.08)',
+            tension: 0.2,
+            fill: true,
+            pointBackgroundColor: prColors,
+            pointBorderColor: prBorders,
+            pointRadius: prRadii,
+            pointBorderWidth: 2,
+            pointHoverRadius: 10,
+        });
+    } else {
+        document.getElementById('modal-pct-section').style.display = 'none';
     }
 
-    __modal1rmMaxWeight = runningMax;
-    document.getElementById('modal-pct-section').style.display = 'block';
-    modalSetPct(100);
+    if (__modal1rmCompareAllData && __modal1rmPartnerInfo) {
+        var colorIndex = 0;
+        for (var pid in __modal1rmCompareAllData) {
+            if (!__modal1rmCompareAllData[pid][exercise] || !__modal1rmCompareAllData[pid][exercise].length) continue;
+            var cp = __modal1rmCompareAllData[pid][exercise];
+            var cSorted = cp.slice().sort(function(a, b) { return a.date < b.date ? -1 : a.date > b.date ? 1 : 0; });
+            var cWeights = alignDataToLabels(cSorted, allLabels, 'weight');
+            var color = PARTNER_COLORS[colorIndex % PARTNER_COLORS.length];
+            colorIndex++;
+            datasets.push({
+                label: (__modal1rmPartnerInfo[pid] || 'Friend') + ' (kg)',
+                data: cWeights,
+                borderColor: color.border,
+                backgroundColor: color.bg,
+                borderDash: [5, 5],
+                tension: 0.2,
+                fill: false,
+                pointBackgroundColor: color.point,
+                pointBorderColor: color.pointBorder,
+                pointRadius: 5,
+                pointBorderWidth: 2,
+                pointHoverRadius: 8,
+            });
+        }
+    }
 
     if (__modal1rmChart) __modal1rmChart.destroy();
     __modal1rmChart = new Chart(canvas, {
         type: 'line',
         data: {
-            labels: labels,
-            datasets: [{
-                label: exercise + ' (kg)',
-                data: weights,
-                borderColor: '#f59e0b',
-                backgroundColor: 'rgba(245,158,11,0.08)',
-                tension: 0.2,
-                fill: true,
-                pointBackgroundColor: prColors,
-                pointBorderColor: prBorders,
-                pointRadius: prRadii,
-                pointBorderWidth: 2,
-                pointHoverRadius: 10,
-            }]
+            labels: allLabels,
+            datasets: datasets,
         },
         options: {
             responsive: true,
             maintainAspectRatio: false,
-            plugins: { legend: { display: false } },
+            plugins: { legend: { display: datasets.length > 1 } },
             scales: {
                 y: {
                     title: { display: true, text: 'Weight (kg)' },
@@ -179,5 +292,6 @@ if (modalHiddenInput) {
     modalHiddenInput.addEventListener('change', modalUpdate1rmChart);
 }
 
+modalFetchAllCompareData();
 modalUpdate1rmChart();
 </script>


### PR DESCRIPTION
## Summary

Three improvements to the compare feature:

### 1. 1RM / Benchmark modal — show all partners' data
The 1RM modal now fetches and displays all sharing partners' data on the chart. The benchmark modal now includes a chart (previously none) showing the specific benchmark results for all partners.

### 2. 1RM / Benchmark page — compare by default with filter
- **Checkbox "Show partners"** (checked by default) to toggle compare data on/off
- **Filter input** to filter partners by name
- All partners' data shown simultaneously with distinct colors (10-color palette)
- Legend only shown when 2+ datasets are present

### 3. Show data even when user has no entries
Charts now render even when the user has no data for the selected exercise/benchmark, as long as any partner has data. The "no data" message only shows when neither the user nor any partner has data.

## Backend
- Added `/api/one-rep-maxes/compare-all` and `/api/benchmark/compare-all` endpoints returning all partners' data in one call (reduces N fetches to 1)