### PR TITLE
fix: mobile responsive controls, rename partners to friends, show user name in legend

### DIFF
--- a/src/wodplanner/app/routers/views.py
+++ b/src/wodplanner/app/routers/views.py
@@ -1408,6 +1408,7 @@ def one_rep_max_modal_view(
             "show_date": False,
             "preset_date": schedule_date.isoformat(),
             "exercises_data_json": _build_exercises_chart_data(formatted),
+            "user_firstname": session.firstname,
         },
     )
 
@@ -1593,6 +1594,7 @@ def benchmark_modal_view(
             "entries": entries,
             "preset_date": schedule_date.isoformat(),
             "benchmark_data_json": benchmark_data_json,
+            "user_firstname": session.firstname,
         },
     )
 

--- a/src/wodplanner/app/static/css/style.css
+++ b/src/wodplanner/app/static/css/style.css
@@ -570,6 +570,43 @@ body {
     min-width: 0;
 }
 
+.card-header .compare-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+}
+
+.card-header .compare-controls .checkbox-label {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    white-space: nowrap;
+    font-size: 0.875rem;
+}
+
+.card-header .compare-controls .form-control {
+    width: 130px;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.875rem;
+}
+
+@media (max-width: 640px) {
+    .card-header {
+        flex-wrap: wrap;
+    }
+
+    .card-header .compare-controls {
+        width: 100%;
+        margin-top: 0.4rem;
+    }
+
+    .card-header .compare-controls .form-control {
+        flex: 1;
+        min-width: 100px;
+    }
+}
+
 .card-title {
     font-size: 1.125rem;
     font-weight: 600;

--- a/src/wodplanner/app/templates/benchmark.html
+++ b/src/wodplanner/app/templates/benchmark.html
@@ -80,11 +80,13 @@
             {{ picker("progress_benchmark", benchmark_list, recent=benchmarks_by_recency, placeholder="Select benchmark\u2026", id_suffix="bp") }}
         </div>
         {% if partners %}
-        <label class="checkbox-label" style="margin-left:0.5rem;white-space:nowrap;display:flex;align-items:center;gap:0.3rem;">
-            <input type="checkbox" id="show-compare" checked onchange="toggleCompare()">
-            Show partners
-        </label>
-        <input type="text" id="filter-partner" placeholder="Filter partner..." class="form-control" style="width:auto;max-width:120px;margin-left:0.3rem;" oninput="updateCompareFilter()">
+        <div class="compare-controls">
+            <label class="checkbox-label">
+                <input type="checkbox" id="show-compare" checked onchange="toggleCompare()">
+                Show friends
+            </label>
+            <input type="text" id="filter-partner" placeholder="Filter friends..." class="form-control" oninput="updateCompareFilter()">
+        </div>
         {% else %}
         <a href="/friends" class="btn btn-sm btn-secondary" style="margin-left:0.5rem;white-space:nowrap;">Compare results with a friend</a>
         {% endif %}
@@ -256,7 +258,7 @@ function updateBenchmarkChart() {
         }
 
         datasets.push({
-            label: name + ' (seconds)',
+            label: '{{ user.firstname }}' + ' (seconds)',
             data: times,
             borderColor: '#f59e0b',
             backgroundColor: 'rgba(245,158,11,0.08)',

--- a/src/wodplanner/app/templates/one_rep_max.html
+++ b/src/wodplanner/app/templates/one_rep_max.html
@@ -58,11 +58,13 @@
             {{ picker("progress_exercise", exercises, recent=exercises_by_recency, placeholder="Select exercise…", id_suffix="progress") }}
         </div>
         {% if partners %}
-        <label class="checkbox-label" style="margin-left:0.5rem;white-space:nowrap;display:flex;align-items:center;gap:0.3rem;">
-            <input type="checkbox" id="show-compare" checked onchange="toggleCompare()">
-            Show partners
-        </label>
-        <input type="text" id="filter-partner" placeholder="Filter partner..." class="form-control" style="width:auto;max-width:120px;margin-left:0.3rem;" oninput="updateCompareFilter()">
+        <div class="compare-controls">
+            <label class="checkbox-label">
+                <input type="checkbox" id="show-compare" checked onchange="toggleCompare()">
+                Show friends
+            </label>
+            <input type="text" id="filter-partner" placeholder="Filter friends..." class="form-control" oninput="updateCompareFilter()">
+        </div>
         {% else %}
         <a href="/friends" class="btn btn-sm btn-secondary" style="margin-left:0.5rem;white-space:nowrap;">Compare results with a friend</a>
         {% endif %}
@@ -261,7 +263,7 @@ function update1rmChart() {
         setPct(100);
 
         datasets.push({
-            label: exercise + ' (kg)',
+            label: '{{ user.firstname }}' + ' (kg)',
             data: weights,
             borderColor: '#f59e0b',
             backgroundColor: 'rgba(245,158,11,0.08)',

--- a/src/wodplanner/app/templates/partials/benchmark_modal.html
+++ b/src/wodplanner/app/templates/partials/benchmark_modal.html
@@ -183,7 +183,7 @@ function modalUpdateBenchmarkChart() {
         }
 
         datasets.push({
-            label: name + ' (seconds)',
+            label: '{{ user_firstname }}' + ' (seconds)',
             data: times,
             borderColor: '#f59e0b',
             backgroundColor: 'rgba(245,158,11,0.08)',

--- a/src/wodplanner/app/templates/partials/one_rep_max_modal.html
+++ b/src/wodplanner/app/templates/partials/one_rep_max_modal.html
@@ -215,7 +215,7 @@ function modalUpdate1rmChart() {
         modalSetPct(100);
 
         datasets.push({
-            label: exercise + ' (kg)',
+            label: '{{ user_firstname }}' + ' (kg)',
             data: weights,
             borderColor: '#f59e0b',
             backgroundColor: 'rgba(245,158,11,0.08)',


### PR DESCRIPTION
## Fixes

1. **Mobile responsiveness** — add `.compare-controls` CSS with `flex-wrap` so the checkbox and filter input don't overflow the window on small screens
2. **Rename** — "Show partners" → "Show friends", "Filter partner..." → "Filter friends..."
3. **Legend label** — show the user's firstname instead of the exercise/benchmark name for the user's dataset line