### PR TITLE
refactor: always show all friends' data, remove checkbox and filter

### DIFF
--- a/src/wodplanner/app/static/css/style.css
+++ b/src/wodplanner/app/static/css/style.css
@@ -570,43 +570,6 @@ body {
     min-width: 0;
 }
 
-.card-header .compare-controls {
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-    flex-wrap: wrap;
-}
-
-.card-header .compare-controls .checkbox-label {
-    display: flex;
-    align-items: center;
-    gap: 0.3rem;
-    white-space: nowrap;
-    font-size: 0.875rem;
-}
-
-.card-header .compare-controls .form-control {
-    width: 130px;
-    padding: 0.25rem 0.5rem;
-    font-size: 0.875rem;
-}
-
-@media (max-width: 640px) {
-    .card-header {
-        flex-wrap: wrap;
-    }
-
-    .card-header .compare-controls {
-        width: 100%;
-        margin-top: 0.4rem;
-    }
-
-    .card-header .compare-controls .form-control {
-        flex: 1;
-        min-width: 100px;
-    }
-}
-
 .card-title {
     font-size: 1.125rem;
     font-weight: 600;

--- a/src/wodplanner/app/templates/benchmark.html
+++ b/src/wodplanner/app/templates/benchmark.html
@@ -79,15 +79,7 @@
         <div style="flex:1;max-width:300px">
             {{ picker("progress_benchmark", benchmark_list, recent=benchmarks_by_recency, placeholder="Select benchmark\u2026", id_suffix="bp") }}
         </div>
-        {% if partners %}
-        <div class="compare-controls">
-            <label class="checkbox-label">
-                <input type="checkbox" id="show-compare" checked onchange="toggleCompare()">
-                Show friends
-            </label>
-            <input type="text" id="filter-partner" placeholder="Filter friends..." class="form-control" oninput="updateCompareFilter()">
-        </div>
-        {% else %}
+        {% if not partners %}
         <a href="/friends" class="btn btn-sm btn-secondary" style="margin-left:0.5rem;white-space:nowrap;">Compare results with a friend</a>
         {% endif %}
     </div>
@@ -149,8 +141,6 @@ function alignDataToLabels(sortedPoints, labels, valueKey) {
 }
 
 function fetchAllCompareData() {
-    var el = document.getElementById('show-compare');
-    if (!el) return;
     fetch('/api/benchmark/compare-all')
         .then(function(r) { return r.json(); })
         .then(function(response) {
@@ -164,14 +154,6 @@ function fetchAllCompareData() {
         });
 }
 
-function toggleCompare() {
-    updateBenchmarkChart();
-}
-
-function updateCompareFilter() {
-    updateBenchmarkChart();
-}
-
 function updateBenchmarkChart() {
     var hidden = document.getElementById('picker-hidden-bp');
     var canvas = document.getElementById('benchmark-chart');
@@ -179,19 +161,14 @@ function updateBenchmarkChart() {
     if (!hidden || !canvas) return;
     var name = hidden.value;
 
-    var showCompare = document.getElementById('show-compare') ? document.getElementById('show-compare').checked : false;
-    var filterText = (document.getElementById('filter-partner') ? document.getElementById('filter-partner').value : '').toLowerCase();
-
     var hasUserData = __benchmarkData && __benchmarkData[name] && __benchmarkData[name].length;
     var allLabels = [];
     var labelToDate = {};
 
     var hasPartnerData = false;
-    if (showCompare && __benchmarkCompareAllData && __benchmarkPartnerInfo) {
+    if (__benchmarkCompareAllData && __benchmarkPartnerInfo) {
         for (var pid in __benchmarkCompareAllData) {
             if (!__benchmarkCompareAllData[pid][name] || !__benchmarkCompareAllData[pid][name].length) continue;
-            var pname = (__benchmarkPartnerInfo[pid] || '').toLowerCase();
-            if (filterText && pname.indexOf(filterText) === -1) continue;
             hasPartnerData = true;
             var cp = __benchmarkCompareAllData[pid][name];
             for (var i = 0; i < cp.length; i++) {
@@ -272,12 +249,10 @@ function updateBenchmarkChart() {
         });
     }
 
-    if (showCompare && __benchmarkCompareAllData && __benchmarkPartnerInfo) {
+    if (__benchmarkCompareAllData && __benchmarkPartnerInfo) {
         var colorIndex = 0;
         for (var pid in __benchmarkCompareAllData) {
             if (!__benchmarkCompareAllData[pid][name] || !__benchmarkCompareAllData[pid][name].length) continue;
-            var pname = (__benchmarkPartnerInfo[pid] || '').toLowerCase();
-            if (filterText && pname.indexOf(filterText) === -1) continue;
             var cp = __benchmarkCompareAllData[pid][name];
             var cSorted = cp.slice().sort(function(a, b) { return a.date < b.date ? -1 : a.date > b.date ? 1 : 0; });
             var cTimes = alignDataToLabels(cSorted, allLabels, 'time');

--- a/src/wodplanner/app/templates/one_rep_max.html
+++ b/src/wodplanner/app/templates/one_rep_max.html
@@ -57,15 +57,7 @@
         <div style="flex:1;max-width:300px">
             {{ picker("progress_exercise", exercises, recent=exercises_by_recency, placeholder="Select exercise…", id_suffix="progress") }}
         </div>
-        {% if partners %}
-        <div class="compare-controls">
-            <label class="checkbox-label">
-                <input type="checkbox" id="show-compare" checked onchange="toggleCompare()">
-                Show friends
-            </label>
-            <input type="text" id="filter-partner" placeholder="Filter friends..." class="form-control" oninput="updateCompareFilter()">
-        </div>
-        {% else %}
+        {% if not partners %}
         <a href="/friends" class="btn btn-sm btn-secondary" style="margin-left:0.5rem;white-space:nowrap;">Compare results with a friend</a>
         {% endif %}
     </div>
@@ -149,8 +141,6 @@ function alignDataToLabels(sortedPoints, labels, valueKey) {
 }
 
 function fetchAllCompareData() {
-    var el = document.getElementById('show-compare');
-    if (!el) return;
     fetch('/api/one-rep-maxes/compare-all')
         .then(function(r) { return r.json(); })
         .then(function(response) {
@@ -164,14 +154,6 @@ function fetchAllCompareData() {
         });
 }
 
-function toggleCompare() {
-    update1rmChart();
-}
-
-function updateCompareFilter() {
-    update1rmChart();
-}
-
 function update1rmChart() {
     var hidden = document.getElementById('picker-hidden-progress');
     var canvas = document.getElementById('1rm-chart');
@@ -179,19 +161,14 @@ function update1rmChart() {
     if (!hidden || !canvas) return;
     var exercise = hidden.value;
 
-    var showCompare = document.getElementById('show-compare') ? document.getElementById('show-compare').checked : false;
-    var filterText = (document.getElementById('filter-partner') ? document.getElementById('filter-partner').value : '').toLowerCase();
-
     var hasUserData = __1rmData && __1rmData[exercise] && __1rmData[exercise].length;
     var allLabels = [];
     var labelToDate = {};
 
     var hasPartnerData = false;
-    if (showCompare && __1rmCompareAllData && __1rmPartnerInfo) {
+    if (__1rmCompareAllData && __1rmPartnerInfo) {
         for (var pid in __1rmCompareAllData) {
             if (!__1rmCompareAllData[pid][exercise] || !__1rmCompareAllData[pid][exercise].length) continue;
-            var name = (__1rmPartnerInfo[pid] || '').toLowerCase();
-            if (filterText && name.indexOf(filterText) === -1) continue;
             hasPartnerData = true;
             var cp = __1rmCompareAllData[pid][exercise];
             for (var i = 0; i < cp.length; i++) {
@@ -279,12 +256,10 @@ function update1rmChart() {
         document.getElementById('pct-section').style.display = 'none';
     }
 
-    if (showCompare && __1rmCompareAllData && __1rmPartnerInfo) {
+    if (__1rmCompareAllData && __1rmPartnerInfo) {
         var colorIndex = 0;
         for (var pid in __1rmCompareAllData) {
             if (!__1rmCompareAllData[pid][exercise] || !__1rmCompareAllData[pid][exercise].length) continue;
-            var name = (__1rmPartnerInfo[pid] || '').toLowerCase();
-            if (filterText && name.indexOf(filterText) === -1) continue;
             var cp = __1rmCompareAllData[pid][exercise];
             var cSorted = cp.slice().sort(function(a, b) { return a.date < b.date ? -1 : a.date > b.date ? 1 : 0; });
             var cWeights = alignDataToLabels(cSorted, allLabels, 'weight');


### PR DESCRIPTION
Remove the 'Show friends' checkbox and filter dropdown. Friends' data now always shows on the chart when available. The 'Compare results with a friend' button still appears when there are no sharing partners.