### PR TITLE
fix: show chart legend when only one person has data

### DIFF
--- a/src/wodplanner/app/templates/benchmark.html
+++ b/src/wodplanner/app/templates/benchmark.html
@@ -286,7 +286,7 @@ function updateBenchmarkChart() {
             responsive: true,
             maintainAspectRatio: false,
             plugins: {
-                legend: { display: datasets.length > 1 },
+                legend: { display: datasets.length > 0 },
                 tooltip: {
                     callbacks: {
                         label: function(ctx) {

--- a/src/wodplanner/app/templates/one_rep_max.html
+++ b/src/wodplanner/app/templates/one_rep_max.html
@@ -292,7 +292,7 @@ function update1rmChart() {
         options: {
             responsive: true,
             maintainAspectRatio: false,
-            plugins: { legend: { display: datasets.length > 1 } },
+            plugins: { legend: { display: datasets.length > 0 } },
             scales: {
                 y: {
                     title: { display: true, text: 'Weight (kg)' },

--- a/src/wodplanner/app/templates/partials/benchmark_modal.html
+++ b/src/wodplanner/app/templates/partials/benchmark_modal.html
@@ -234,7 +234,7 @@ function modalUpdateBenchmarkChart() {
             responsive: true,
             maintainAspectRatio: false,
             plugins: {
-                legend: { display: datasets.length > 1 },
+                legend: { display: datasets.length > 0 },
                 tooltip: {
                     callbacks: {
                         label: function(ctx) {

--- a/src/wodplanner/app/templates/partials/one_rep_max_modal.html
+++ b/src/wodplanner/app/templates/partials/one_rep_max_modal.html
@@ -267,7 +267,7 @@ function modalUpdate1rmChart() {
         options: {
             responsive: true,
             maintainAspectRatio: false,
-            plugins: { legend: { display: datasets.length > 1 } },
+            plugins: { legend: { display: datasets.length > 0 } },
             scales: {
                 y: {
                     title: { display: true, text: 'Weight (kg)' },


### PR DESCRIPTION
Changes `datasets.length > 1` to `datasets.length > 0` in chart config so the legend is displayed even when only one person's data is present.