### PR TITLE
feat: add Daniel and Kelly to benchmark seed list

### DIFF
--- a/src/wodplanner/services/benchmark.py
+++ b/src/wodplanner/services/benchmark.py
@@ -37,11 +37,11 @@ _SEED_BENCHMARKS: dict[str, list[str]] = {
     "The Girls": [
         "Fran", "Helen", "Cindy", "Annie", "Isabel", "Jackie", "Karen",
         "Angie", "Barbara", "Chelsea", "Diane", "Elizabeth", "Grace",
-        "Linda", "Mary", "Nancy", "Amanda", "Eva",
+        "Linda", "Mary", "Nancy", "Amanda", "Eva", "Kelly",
     ],
     "Hero": [
         "Murph", "Kalsu", "JT", "Loredo", "Randy", "Danny", "Michael",
-        "Nate", "Joshie", "Badger",
+        "Nate", "Joshie", "Badger", "Daniel",
     ],
 }
 


### PR DESCRIPTION
Adds missing benchmark WODs to the seed list:\n- Kelly (The Girls)\n- Daniel (Hero)\n\nCloses the issue where Daniel's benchmark icon didn't render on the calendar for Sept 5. Kelly already existed in the production DB but was missing from the seed list for fresh installs.