### PR TITLE
feat: improve benchmark chart legends, modal form layout, and RX/Scaled tooltip

### DIFF
--- a/src/wodplanner/app/static/css/style.css
+++ b/src/wodplanner/app/static/css/style.css
@@ -838,14 +838,10 @@ body {
 }
 
 .benchmark-form--modal .form-row {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    align-items: end;
+    display: flex;
     gap: 0.5rem;
-}
-
-.benchmark-form--modal .form-row > :nth-child(1) {
-    grid-column: 1 / -1;
+    align-items: end;
+    flex-wrap: wrap;
 }
 
 .benchmark-form--modal .form-group-submit .btn {

--- a/src/wodplanner/app/templates/benchmark.html
+++ b/src/wodplanner/app/templates/benchmark.html
@@ -234,9 +234,12 @@ function updateBenchmarkChart() {
             }
         }
 
+        var isRxData = alignDataToLabels(sorted, allLabels, 'is_rx');
+
         datasets.push({
-            label: '{{ user.firstname }}' + ' (seconds)',
+            label: '{{ user.firstname }}',
             data: times,
+            isRxData: isRxData,
             borderColor: '#f59e0b',
             backgroundColor: 'rgba(245,158,11,0.08)',
             tension: 0.2,
@@ -256,11 +259,13 @@ function updateBenchmarkChart() {
             var cp = __benchmarkCompareAllData[pid][name];
             var cSorted = cp.slice().sort(function(a, b) { return a.date < b.date ? -1 : a.date > b.date ? 1 : 0; });
             var cTimes = alignDataToLabels(cSorted, allLabels, 'time');
+            var cIsRx = alignDataToLabels(cSorted, allLabels, 'is_rx');
             var color = PARTNER_COLORS[colorIndex % PARTNER_COLORS.length];
             colorIndex++;
             datasets.push({
-                label: (__benchmarkPartnerInfo[pid] || 'Friend') + ' (seconds)',
+                label: (__benchmarkPartnerInfo[pid] || 'Friend'),
                 data: cTimes,
+                isRxData: cIsRx,
                 borderColor: color.border,
                 backgroundColor: color.bg,
                 borderDash: [5, 5],
@@ -286,11 +291,16 @@ function updateBenchmarkChart() {
             responsive: true,
             maintainAspectRatio: false,
             plugins: {
-                legend: { display: datasets.length > 0 },
+                legend: { display: datasets.length > 0, labels: { usePointStyle: true } },
                 tooltip: {
                     callbacks: {
                         label: function(ctx) {
-                            return formatTime(ctx.parsed.y);
+                            var label = formatTime(ctx.parsed.y);
+                            var isRx = ctx.dataset.isRxData ? ctx.dataset.isRxData[ctx.dataIndex] : null;
+                            if (isRx !== null) {
+                                label += isRx ? ' (RX)' : ' (Scaled)';
+                            }
+                            return label;
                         }
                     }
                 }

--- a/src/wodplanner/app/templates/one_rep_max.html
+++ b/src/wodplanner/app/templates/one_rep_max.html
@@ -240,7 +240,7 @@ function update1rmChart() {
         setPct(100);
 
         datasets.push({
-            label: '{{ user.firstname }}' + ' (kg)',
+            label: '{{ user.firstname }}',
             data: weights,
             borderColor: '#f59e0b',
             backgroundColor: 'rgba(245,158,11,0.08)',
@@ -266,7 +266,7 @@ function update1rmChart() {
             var color = PARTNER_COLORS[colorIndex % PARTNER_COLORS.length];
             colorIndex++;
             datasets.push({
-                label: (__1rmPartnerInfo[pid] || 'Friend') + ' (kg)',
+                label: (__1rmPartnerInfo[pid] || 'Friend'),
                 data: cWeights,
                 borderColor: color.border,
                 backgroundColor: color.bg,
@@ -292,7 +292,7 @@ function update1rmChart() {
         options: {
             responsive: true,
             maintainAspectRatio: false,
-            plugins: { legend: { display: datasets.length > 0 } },
+            plugins: { legend: { display: datasets.length > 0, labels: { usePointStyle: true } } },
             scales: {
                 y: {
                     title: { display: true, text: 'Weight (kg)' },

--- a/src/wodplanner/app/templates/partials/benchmark_modal.html
+++ b/src/wodplanner/app/templates/partials/benchmark_modal.html
@@ -182,9 +182,12 @@ function modalUpdateBenchmarkChart() {
             }
         }
 
+        var isRxData = alignDataToLabels(sorted, allLabels, 'is_rx');
+
         datasets.push({
-            label: '{{ user_firstname }}' + ' (seconds)',
+            label: '{{ user_firstname }}',
             data: times,
+            isRxData: isRxData,
             borderColor: '#f59e0b',
             backgroundColor: 'rgba(245,158,11,0.08)',
             tension: 0.2,
@@ -204,11 +207,13 @@ function modalUpdateBenchmarkChart() {
             var cp = __modalBenchmarkCompareAllData[pid][name];
             var cSorted = cp.slice().sort(function(a, b) { return a.date < b.date ? -1 : a.date > b.date ? 1 : 0; });
             var cTimes = alignDataToLabels(cSorted, allLabels, 'time');
+            var cIsRx = alignDataToLabels(cSorted, allLabels, 'is_rx');
             var color = PARTNER_COLORS[colorIndex % PARTNER_COLORS.length];
             colorIndex++;
             datasets.push({
-                label: (__modalBenchmarkPartnerInfo[pid] || 'Friend') + ' (seconds)',
+                label: (__modalBenchmarkPartnerInfo[pid] || 'Friend'),
                 data: cTimes,
+                isRxData: cIsRx,
                 borderColor: color.border,
                 backgroundColor: color.bg,
                 borderDash: [5, 5],
@@ -234,11 +239,16 @@ function modalUpdateBenchmarkChart() {
             responsive: true,
             maintainAspectRatio: false,
             plugins: {
-                legend: { display: datasets.length > 0 },
+                legend: { display: datasets.length > 0, labels: { usePointStyle: true } },
                 tooltip: {
                     callbacks: {
                         label: function(ctx) {
-                            return formatTime(ctx.parsed.y);
+                            var label = formatTime(ctx.parsed.y);
+                            var isRx = ctx.dataset.isRxData ? ctx.dataset.isRxData[ctx.dataIndex] : null;
+                            if (isRx !== null) {
+                                label += isRx ? ' (RX)' : ' (Scaled)';
+                            }
+                            return label;
                         }
                     }
                 }

--- a/src/wodplanner/app/templates/partials/one_rep_max_modal.html
+++ b/src/wodplanner/app/templates/partials/one_rep_max_modal.html
@@ -215,7 +215,7 @@ function modalUpdate1rmChart() {
         modalSetPct(100);
 
         datasets.push({
-            label: '{{ user_firstname }}' + ' (kg)',
+            label: '{{ user_firstname }}',
             data: weights,
             borderColor: '#f59e0b',
             backgroundColor: 'rgba(245,158,11,0.08)',
@@ -241,7 +241,7 @@ function modalUpdate1rmChart() {
             var color = PARTNER_COLORS[colorIndex % PARTNER_COLORS.length];
             colorIndex++;
             datasets.push({
-                label: (__modal1rmPartnerInfo[pid] || 'Friend') + ' (kg)',
+                label: (__modal1rmPartnerInfo[pid] || 'Friend'),
                 data: cWeights,
                 borderColor: color.border,
                 backgroundColor: color.bg,
@@ -267,7 +267,7 @@ function modalUpdate1rmChart() {
         options: {
             responsive: true,
             maintainAspectRatio: false,
-            plugins: { legend: { display: datasets.length > 0 } },
+            plugins: { legend: { display: datasets.length > 0, labels: { usePointStyle: true } } },
             scales: {
                 y: {
                     title: { display: true, text: 'Weight (kg)' },


### PR DESCRIPTION
### Changes

- **Legend**: Uses point markers instead of dashed lines via `usePointStyle: true`
- **Modal form**: Minutes, seconds, RX/Scaled inputs now on a single line (flexbox instead of grid)
- **Tooltip**: Shows `(RX)` or `(Scaled)` when hovering over data points
- **Labels**: Removed redundant `(kg)` and `(seconds)` suffixes from legend