### PR TITLE
feat: highlight RX results with gold border on chart points

### DIFF
--- a/src/wodplanner/app/static/css/style.css
+++ b/src/wodplanner/app/static/css/style.css
@@ -933,6 +933,15 @@ body {
         min-width: 0;
         width: 100%;
     }
+    .benchmark-form--modal .form-row {
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
+    .benchmark-form--modal .form-group-narrow {
+        flex: 1 1 auto;
+        min-width: 0;
+        width: auto;
+    }
 }
 
 .one-rm-chart-container {

--- a/src/wodplanner/app/templates/benchmark.html
+++ b/src/wodplanner/app/templates/benchmark.html
@@ -211,7 +211,7 @@ function updateBenchmarkChart() {
         var sorted = points.slice().sort(function(a, b) { return a.date < b.date ? -1 : a.date > b.date ? 1 : 0; });
         var times = alignDataToLabels(sorted, allLabels, 'time');
 
-        var prColors = [], prRadii = [], prBorders = [];
+        var prColors = [], prRadii = [], prBorders = [], prBorderWidths = [];
         var runningMin = Infinity;
         var idxMap = {};
         for (var i = 0; i < sorted.length; i++) {
@@ -231,6 +231,7 @@ function updateBenchmarkChart() {
                     prRadii.push(4);
                     prBorders.push('#f59e0b');
                 }
+                prBorderWidths.push(sorted[si].is_rx ? 3 : 1);
             }
         }
 
@@ -247,7 +248,7 @@ function updateBenchmarkChart() {
             pointBackgroundColor: prColors,
             pointBorderColor: prBorders,
             pointRadius: prRadii,
-            pointBorderWidth: 2,
+            pointBorderWidth: prBorderWidths,
             pointHoverRadius: 10,
         });
     }
@@ -260,6 +261,10 @@ function updateBenchmarkChart() {
             var cSorted = cp.slice().sort(function(a, b) { return a.date < b.date ? -1 : a.date > b.date ? 1 : 0; });
             var cTimes = alignDataToLabels(cSorted, allLabels, 'time');
             var cIsRx = alignDataToLabels(cSorted, allLabels, 'is_rx');
+            var cBorderWidths = [];
+            for (var i = 0; i < allLabels.length; i++) {
+                cBorderWidths.push(cIsRx[i] ? 3 : 1);
+            }
             var color = PARTNER_COLORS[colorIndex % PARTNER_COLORS.length];
             colorIndex++;
             datasets.push({
@@ -274,7 +279,7 @@ function updateBenchmarkChart() {
                 pointBackgroundColor: color.point,
                 pointBorderColor: color.pointBorder,
                 pointRadius: 5,
-                pointBorderWidth: 2,
+                pointBorderWidth: cBorderWidths,
                 pointHoverRadius: 8,
             });
         }

--- a/src/wodplanner/app/templates/partials/benchmark_modal.html
+++ b/src/wodplanner/app/templates/partials/benchmark_modal.html
@@ -159,7 +159,7 @@ function modalUpdateBenchmarkChart() {
         var sorted = points.slice().sort(function(a, b) { return a.date < b.date ? -1 : a.date > b.date ? 1 : 0; });
         var times = alignDataToLabels(sorted, allLabels, 'time');
 
-        var prColors = [], prRadii = [], prBorders = [];
+        var prColors = [], prRadii = [], prBorders = [], prBorderWidths = [];
         var runningMin = Infinity;
         var idxMap = {};
         for (var i = 0; i < sorted.length; i++) {
@@ -179,6 +179,7 @@ function modalUpdateBenchmarkChart() {
                     prRadii.push(4);
                     prBorders.push('#f59e0b');
                 }
+                prBorderWidths.push(sorted[si].is_rx ? 3 : 1);
             }
         }
 
@@ -195,7 +196,7 @@ function modalUpdateBenchmarkChart() {
             pointBackgroundColor: prColors,
             pointBorderColor: prBorders,
             pointRadius: prRadii,
-            pointBorderWidth: 2,
+            pointBorderWidth: prBorderWidths,
             pointHoverRadius: 10,
         });
     }
@@ -208,6 +209,10 @@ function modalUpdateBenchmarkChart() {
             var cSorted = cp.slice().sort(function(a, b) { return a.date < b.date ? -1 : a.date > b.date ? 1 : 0; });
             var cTimes = alignDataToLabels(cSorted, allLabels, 'time');
             var cIsRx = alignDataToLabels(cSorted, allLabels, 'is_rx');
+            var cBorderWidths = [];
+            for (var i = 0; i < allLabels.length; i++) {
+                cBorderWidths.push(cIsRx[i] ? 3 : 1);
+            }
             var color = PARTNER_COLORS[colorIndex % PARTNER_COLORS.length];
             colorIndex++;
             datasets.push({
@@ -222,7 +227,7 @@ function modalUpdateBenchmarkChart() {
                 pointBackgroundColor: color.point,
                 pointBorderColor: color.pointBorder,
                 pointRadius: 5,
-                pointBorderWidth: 2,
+                pointBorderWidth: cBorderWidths,
                 pointHoverRadius: 8,
             });
         }


### PR DESCRIPTION
RX points now draw with `pointBorderWidth: 3` (gold/`#f59e0b` border) vs scaled points with `pointBorderWidth: 1` (thin subtle border).\n\nAlso fixed mobile modal form layout to keep inputs in a row.