### PR TITLE
fix: apply gold border to partner RX points too

### DIFF
--- a/src/wodplanner/app/templates/benchmark.html
+++ b/src/wodplanner/app/templates/benchmark.html
@@ -261,8 +261,10 @@ pointRadius: 8,
             var cTimes = alignDataToLabels(cSorted, allLabels, 'time');
             var cIsRx = alignDataToLabels(cSorted, allLabels, 'is_rx');
             var cBorderWidths = [];
+            var cPointBorders = [];
             for (var i = 0; i < allLabels.length; i++) {
-cBorderWidths.push(cIsRx[i] ? 2 : 1);
+                cBorderWidths.push(cIsRx[i] ? 2 : 1);
+                cPointBorders.push(cIsRx[i] ? '#f59e0b' : color.pointBorder);
             }
             var color = PARTNER_COLORS[colorIndex % PARTNER_COLORS.length];
             colorIndex++;
@@ -276,7 +278,7 @@ cBorderWidths.push(cIsRx[i] ? 2 : 1);
                 tension: 0.2,
                 fill: false,
                 pointBackgroundColor: color.point,
-                pointBorderColor: color.pointBorder,
+                pointBorderColor: cPointBorders,
                 pointRadius: 5,
                 pointBorderWidth: cBorderWidths,
                 pointHoverRadius: 8,

--- a/src/wodplanner/app/templates/partials/benchmark_modal.html
+++ b/src/wodplanner/app/templates/partials/benchmark_modal.html
@@ -209,8 +209,10 @@ pointRadius: 8,
             var cTimes = alignDataToLabels(cSorted, allLabels, 'time');
             var cIsRx = alignDataToLabels(cSorted, allLabels, 'is_rx');
             var cBorderWidths = [];
+            var cPointBorders = [];
             for (var i = 0; i < allLabels.length; i++) {
 cBorderWidths.push(cIsRx[i] ? 2 : 1);
+                cPointBorders.push(cIsRx[i] ? '#f59e0b' : color.pointBorder);
             }
             var color = PARTNER_COLORS[colorIndex % PARTNER_COLORS.length];
             colorIndex++;
@@ -224,7 +226,7 @@ cBorderWidths.push(cIsRx[i] ? 2 : 1);
                 tension: 0.2,
                 fill: false,
                 pointBackgroundColor: color.point,
-                pointBorderColor: color.pointBorder,
+                pointBorderColor: cPointBorders,
                 pointRadius: 5,
                 pointBorderWidth: cBorderWidths,
                 pointHoverRadius: 8,


### PR DESCRIPTION
Partner data points now use gold (#f59e0b) border for RX results, matching the user's own RX points.