### PR TITLE
fix: partner gold border hoisting bug and mobile modal layout

### DIFF
--- a/src/wodplanner/app/static/css/style.css
+++ b/src/wodplanner/app/static/css/style.css
@@ -936,11 +936,29 @@ body {
     .benchmark-form--modal .form-row {
         flex-direction: row;
         flex-wrap: wrap;
+        gap: 0.25rem;
     }
     .benchmark-form--modal .form-group-narrow {
         flex: 1 1 auto;
         min-width: 0;
         width: auto;
+    }
+    .benchmark-form--modal .form-group-narrow .form-control {
+        padding: 0.35rem 0.5rem;
+        font-size: 0.8125rem;
+    }
+    .benchmark-form--modal .radio-group {
+        gap: 0.25rem;
+        padding-top: 0;
+    }
+    .benchmark-form--modal .radio-inline {
+        font-size: 0.8125rem;
+    }
+    .benchmark-form--modal .form-group-submit {
+        flex: 1 1 100%;
+    }
+    .benchmark-form--modal .form-group-submit .btn {
+        width: 100%;
     }
 }
 

--- a/src/wodplanner/app/templates/benchmark.html
+++ b/src/wodplanner/app/templates/benchmark.html
@@ -261,12 +261,12 @@ pointRadius: 8,
             var cTimes = alignDataToLabels(cSorted, allLabels, 'time');
             var cIsRx = alignDataToLabels(cSorted, allLabels, 'is_rx');
             var cBorderWidths = [];
+            var color = PARTNER_COLORS[colorIndex % PARTNER_COLORS.length];
             var cPointBorders = [];
             for (var i = 0; i < allLabels.length; i++) {
                 cBorderWidths.push(cIsRx[i] ? 2 : 1);
                 cPointBorders.push(cIsRx[i] ? '#f59e0b' : color.pointBorder);
             }
-            var color = PARTNER_COLORS[colorIndex % PARTNER_COLORS.length];
             colorIndex++;
             datasets.push({
                 label: (__benchmarkPartnerInfo[pid] || 'Friend'),

--- a/src/wodplanner/app/templates/partials/benchmark_modal.html
+++ b/src/wodplanner/app/templates/partials/benchmark_modal.html
@@ -209,12 +209,12 @@ pointRadius: 8,
             var cTimes = alignDataToLabels(cSorted, allLabels, 'time');
             var cIsRx = alignDataToLabels(cSorted, allLabels, 'is_rx');
             var cBorderWidths = [];
+            var color = PARTNER_COLORS[colorIndex % PARTNER_COLORS.length];
             var cPointBorders = [];
             for (var i = 0; i < allLabels.length; i++) {
-cBorderWidths.push(cIsRx[i] ? 2 : 1);
+                cBorderWidths.push(cIsRx[i] ? 2 : 1);
                 cPointBorders.push(cIsRx[i] ? '#f59e0b' : color.pointBorder);
             }
-            var color = PARTNER_COLORS[colorIndex % PARTNER_COLORS.length];
             colorIndex++;
             datasets.push({
                 label: (__modalBenchmarkPartnerInfo[pid] || 'Friend'),


### PR DESCRIPTION
- Fixed JS hoisting bug: `color` used before `var color` declaration caused TypeError, breaking partner chart rendering entirely\n- Compacted modal form on mobile: smaller inputs, tighter radio gaps, save button on its own line