### PR TITLE
fix: legend marker inheriting gold border from first RX data point

### DIFF
--- a/src/wodplanner/app/templates/benchmark.html
+++ b/src/wodplanner/app/templates/benchmark.html
@@ -297,7 +297,7 @@ pointRadius: 8,
             responsive: true,
             maintainAspectRatio: false,
             plugins: {
-                legend: { display: datasets.length > 0, labels: { usePointStyle: true, generateLabels: function(chart) { var orig = Chart.defaults.plugins.legend.labels.generateLabels(chart); orig.push({ text: 'RX', fillStyle: 'transparent', strokeStyle: '#f59e0b', borderWidth: 7, pointStyle: 'circle', hidden: false, datasetIndex: -1 }); return orig; } } },
+                legend: { display: datasets.length > 0, labels: { usePointStyle: true, generateLabels: function(chart) { var orig = Chart.defaults.plugins.legend.labels.generateLabels(chart); for (var i = 0; i < orig.length; i++) { var item = orig[i]; if (item.datasetIndex >= 0) { item.strokeStyle = chart.data.datasets[item.datasetIndex].borderColor; item.borderWidth = 3; } } orig.push({ text: 'RX', fillStyle: 'transparent', strokeStyle: '#f59e0b', borderWidth: 7, pointStyle: 'circle', hidden: false, datasetIndex: -1 }); return orig; } } },
                 tooltip: {
                     callbacks: {
                         label: function(ctx) {

--- a/src/wodplanner/app/templates/partials/benchmark_modal.html
+++ b/src/wodplanner/app/templates/partials/benchmark_modal.html
@@ -245,7 +245,7 @@ pointRadius: 8,
             responsive: true,
             maintainAspectRatio: false,
             plugins: {
-                legend: { display: datasets.length > 0, labels: { usePointStyle: true, generateLabels: function(chart) { var orig = Chart.defaults.plugins.legend.labels.generateLabels(chart); orig.push({ text: 'RX', fillStyle: 'transparent', strokeStyle: '#f59e0b', borderWidth: 7, pointStyle: 'circle', hidden: false, datasetIndex: -1 }); return orig; } } },
+                legend: { display: datasets.length > 0, labels: { usePointStyle: true, generateLabels: function(chart) { var orig = Chart.defaults.plugins.legend.labels.generateLabels(chart); for (var i = 0; i < orig.length; i++) { var item = orig[i]; if (item.datasetIndex >= 0) { item.strokeStyle = chart.data.datasets[item.datasetIndex].borderColor; item.borderWidth = 3; } } orig.push({ text: 'RX', fillStyle: 'transparent', strokeStyle: '#f59e0b', borderWidth: 7, pointStyle: 'circle', hidden: false, datasetIndex: -1 }); return orig; } } },
                 tooltip: {
                     callbacks: {
                         label: function(ctx) {


### PR DESCRIPTION
When a user's first charted data point is RX, the legend marker inherited the gold border from `pointBorderColor[0]`. Fixed by overriding legend item `strokeStyle` to use the dataset's `borderColor` (the line color) instead.